### PR TITLE
Use mut ref device ref to save stack space

### DIFF
--- a/device/src/state_machines/mod.rs
+++ b/device/src/state_machines/mod.rs
@@ -82,7 +82,3 @@ impl<'a, R: radio::PhyRxTx + Timings> Shared<'a, R> {
         }
     }
 }
-
-trait CommonState<'a, R: radio::PhyRxTx + Timings> {
-    fn get_mut_shared(&mut self) -> &mut Shared<'a, R>;
-}

--- a/device/src/state_machines/no_session.rs
+++ b/device/src/state_machines/no_session.rs
@@ -3,7 +3,7 @@ use super::super::State as SuperState;
 use super::super::*;
 use super::{
     region::{Frame, Window},
-    CommonState, Shared,
+    Shared,
 };
 use lorawan_encoding::{
     self,
@@ -13,14 +13,11 @@ use lorawan_encoding::{
     parser::{parse_with_factory as lorawan_parse, *},
 };
 
-pub enum NoSession<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    Idle(Idle<'a, R>),
-    SendingJoin(SendingJoin<'a, R>),
-    WaitingForRxWindow(WaitingForRxWindow<'a, R>),
-    WaitingForJoinResponse(WaitingForJoinResponse<'a, R>),
+pub enum NoSession {
+    Idle(Idle),
+    SendingJoin(SendingJoin),
+    WaitingForRxWindow(WaitingForRxWindow),
+    WaitingForJoinResponse(WaitingForJoinResponse),
 }
 
 enum JoinRxWindow {
@@ -31,22 +28,10 @@ enum JoinRxWindow {
 macro_rules! into_state {
     ($($from:tt),*) => {
     $(
-        impl<'a, R, C> From<$from<'a, R>> for Device<'a, R,C>
-        where
-            R: radio::PhyRxTx + Timings,
-            C: CryptoFactory + Default
+        impl From<$from> for SuperState
         {
-            fn from(state: $from<'a, R>) -> Device<'a, R, C> {
-                Device {
-                    crypto: PhantomData::default(),
-                    state: SuperState::NoSession(NoSession::$from(state))
-                }
-            }
-        }
-
-        impl<'a, R: radio::PhyRxTx + Timings> CommonState<'a, R> for $from<'a, R> {
-            fn get_mut_shared(&mut self) -> &mut Shared<'a, R> {
-                &mut self.shared
+            fn from(state: $from) -> SuperState {
+                SuperState::NoSession(NoSession::$from(state))
             }
         }
     )*};
@@ -59,44 +44,27 @@ into_state![
     WaitingForJoinResponse
 ];
 
-impl<'a, R> From<NoSession<'a, R>> for SuperState<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    fn from(no_session: NoSession<'a, R>) -> SuperState<'a, R> {
+impl From<NoSession> for SuperState {
+    fn from(no_session: NoSession) -> SuperState {
         SuperState::NoSession(no_session)
     }
 }
 
-impl<'a, R> NoSession<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    pub fn new(shared: Shared<'a, R>) -> NoSession<'a, R> {
-        NoSession::Idle(Idle {
-            shared,
-            join_attempts: 0,
-        })
+impl NoSession {
+    pub fn new() -> NoSession {
+        NoSession::Idle(Idle { join_attempts: 0 })
     }
 
-    pub fn get_mut_shared(&mut self) -> &mut Shared<'a, R> {
-        match self {
-            NoSession::Idle(state) => state.get_mut_shared(),
-            NoSession::SendingJoin(state) => state.get_mut_shared(),
-            NoSession::WaitingForRxWindow(state) => state.get_mut_shared(),
-            NoSession::WaitingForJoinResponse(state) => state.get_mut_shared(),
-        }
-    }
-
-    pub fn handle_event<C: CryptoFactory + Default>(
+    pub fn handle_event<'a, R: radio::PhyRxTx + Timings, C: CryptoFactory + Default>(
         self,
         event: Event<R>,
-    ) -> (Device<'a, R, C>, Result<Response, super::super::Error<R>>) {
+        shared: &mut Shared<'a, R>,
+    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
         match self {
-            NoSession::Idle(state) => state.handle_event(event),
-            NoSession::SendingJoin(state) => state.handle_event(event),
-            NoSession::WaitingForRxWindow(state) => state.handle_event(event),
-            NoSession::WaitingForJoinResponse(state) => state.handle_event(event),
+            NoSession::Idle(state) => state.handle_event::<R, C>(event, shared),
+            NoSession::SendingJoin(state) => state.handle_event::<R, C>(event, shared),
+            NoSession::WaitingForRxWindow(state) => state.handle_event::<R, C>(event, shared),
+            NoSession::WaitingForJoinResponse(state) => state.handle_event::<R, C>(event, shared),
         }
     }
 }
@@ -122,32 +90,26 @@ where
 }
 type DevNonce = lorawan_encoding::parser::DevNonce<[u8; 2]>;
 
-pub struct Idle<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    shared: Shared<'a, R>,
+pub struct Idle {
     join_attempts: usize,
 }
 
-impl<'a, R> Idle<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    pub fn handle_event<C: CryptoFactory + Default>(
+impl Idle {
+    pub fn handle_event<'a, R: radio::PhyRxTx + Timings, C: CryptoFactory + Default>(
         mut self,
         event: Event<R>,
-    ) -> (Device<'a, R, C>, Result<Response, super::super::Error<R>>) {
+        shared: &mut Shared<'a, R>,
+    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
         match event {
             // NewSession Request or a Timeout from previously failed Join attempt
             Event::NewSessionRequest | Event::TimeoutFired => {
-                match self.create_join_request::<C>() {
+                match self.create_join_request::<R, C>(shared) {
                     Ok((devnonce, tx_config)) => {
                         let radio_event: radio::Event<R> =
-                            radio::Event::TxRequest(tx_config, &self.shared.tx_buffer.as_ref());
+                            radio::Event::TxRequest(tx_config, &shared.tx_buffer.as_ref());
 
                         // send the transmit request to the radio
-                        match self.shared.radio.handle_event(radio_event) {
+                        match shared.radio.handle_event(radio_event) {
                             Ok(response) => {
                                 match response {
                                     // intermediate state where we wait for Join to complete sending
@@ -159,11 +121,9 @@ where
                                     // directly jump to waiting for RxWindow
                                     // allows for synchronous sending
                                     radio::Response::TxDone(ms) => {
-                                        let first_window = self
-                                            .shared
-                                            .region
-                                            .get_rx_delay(&Frame::Join, &Window::_1)
-                                            + ms;
+                                        let first_window =
+                                            shared.region.get_rx_delay(&Frame::Join, &Window::_1)
+                                                + ms;
                                         (
                                             self.into_waiting_for_rxwindow(devnonce, first_window)
                                                 .into(),
@@ -188,18 +148,19 @@ where
         }
     }
 
-    fn create_join_request<C: CryptoFactory + Default>(
+    fn create_join_request<R: radio::PhyRxTx + Timings, C: CryptoFactory + Default>(
         &mut self,
+        shared: &mut Shared<R>,
     ) -> Result<(DevNonce, radio::TxConfig), Error> {
-        let mut random = (self.shared.get_random)();
+        let mut random = (shared.get_random)();
         // use lowest 16 bits for devnonce
         let devnonce_bytes = random as u16;
 
-        self.shared.tx_buffer.clear();
+        shared.tx_buffer.clear();
 
         let mut phy: JoinRequestCreator<[u8; 23], C> = JoinRequestCreator::default();
 
-        if let Some(creds) = &self.shared.credentials {
+        if let Some(creds) = &shared.credentials {
             let devnonce = [devnonce_bytes as u8, (devnonce_bytes >> 8) as u8];
 
             phy.set_app_eui(EUI64::new(creds.appeui()).unwrap())
@@ -209,34 +170,30 @@ where
 
             let devnonce_copy = DevNonce::new(devnonce).unwrap();
 
-            self.shared.tx_buffer.extend_from_slice(vec).unwrap();
+            shared.tx_buffer.extend_from_slice(vec).unwrap();
 
             // we'll use the rest for frequency and subband selection
             random >>= 16;
             Ok((
                 devnonce_copy,
-                self.shared.region.create_tx_config(
-                    random as u8,
-                    self.shared.datarate,
-                    &Frame::Join,
-                ),
+                shared
+                    .region
+                    .create_tx_config(random as u8, shared.datarate, &Frame::Join),
             ))
         } else {
             Err(Error::DeviceDoesNotHaveOtaaCredentials)
         }
     }
 
-    fn into_sending_join(self, devnonce: DevNonce) -> SendingJoin<'a, R> {
+    fn into_sending_join(self, devnonce: DevNonce) -> SendingJoin {
         SendingJoin {
-            shared: self.shared,
             join_attempts: self.join_attempts + 1,
             devnonce,
         }
     }
 
-    fn into_waiting_for_rxwindow(self, devnonce: DevNonce, time: u32) -> WaitingForRxWindow<'a, R> {
+    fn into_waiting_for_rxwindow(self, devnonce: DevNonce, time: u32) -> WaitingForRxWindow {
         WaitingForRxWindow {
-            shared: self.shared,
             join_attempts: self.join_attempts + 1,
             join_rx_window: JoinRxWindow::_1(time),
             devnonce,
@@ -244,37 +201,31 @@ where
     }
 }
 
-pub struct SendingJoin<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    shared: Shared<'a, R>,
+pub struct SendingJoin {
     join_attempts: usize,
     devnonce: DevNonce,
 }
 
-impl<'a, R> SendingJoin<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    pub fn handle_event<C: CryptoFactory + Default>(
-        mut self,
+impl SendingJoin {
+    pub fn handle_event<'a, R: radio::PhyRxTx + Timings, C: CryptoFactory + Default>(
+        self,
         event: Event<R>,
-    ) -> (Device<'a, R, C>, Result<Response, super::super::Error<R>>) {
+        shared: &mut Shared<'a, R>,
+    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
         match event {
             // we are waiting for the async tx to complete
             Event::RadioEvent(radio_event) => {
                 // send the transmit request to the radio
-                match self.shared.radio.handle_event(radio_event) {
+                match shared.radio.handle_event(radio_event) {
                     Ok(response) => {
                         match response {
                             // expect a complete transmit
                             radio::Response::TxDone(ms) => {
                                 let first_window =
-                                    (self.shared.region.get_rx_delay(&Frame::Join, &Window::_1) as i32
-                                    + ms as i32
-                                    + self.shared.radio.get_rx_window_offset_ms())
-                                    as u32;
+                                    (shared.region.get_rx_delay(&Frame::Join, &Window::_1) as i32
+                                        + ms as i32
+                                        + shared.radio.get_rx_window_offset_ms())
+                                        as u32;
                                 (
                                     self.into_waiting_for_rxwindow(first_window).into(),
                                     Ok(Response::TimeoutRequest(first_window)),
@@ -299,9 +250,8 @@ where
         }
     }
 
-    fn into_waiting_for_rxwindow(self, time: u32) -> WaitingForRxWindow<'a, R> {
+    fn into_waiting_for_rxwindow(self, time: u32) -> WaitingForRxWindow {
         WaitingForRxWindow {
-            shared: self.shared,
             join_attempts: self.join_attempts + 1,
             join_rx_window: JoinRxWindow::_1(time),
             devnonce: self.devnonce,
@@ -309,24 +259,18 @@ where
     }
 }
 
-pub struct WaitingForRxWindow<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    shared: Shared<'a, R>,
+pub struct WaitingForRxWindow {
     join_attempts: usize,
     devnonce: DevNonce,
     join_rx_window: JoinRxWindow,
 }
 
-impl<'a, R> WaitingForRxWindow<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    pub fn handle_event<C: CryptoFactory + Default>(
-        mut self,
+impl WaitingForRxWindow {
+    pub fn handle_event<'a, R: radio::PhyRxTx + Timings, C: CryptoFactory + Default>(
+        self,
         event: Event<R>,
-    ) -> (Device<'a, R, C>, Result<Response, super::super::Error<R>>) {
+        shared: &mut Shared<'a, R>,
+    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
         match event {
             // we are waiting for a Timeout
             Event::TimeoutFired => {
@@ -334,13 +278,11 @@ where
                     JoinRxWindow::_1(_) => Window::_1,
                     JoinRxWindow::_2(_) => Window::_2,
                 };
-                let rx_config =
-                    self.shared
-                        .region
-                        .get_rx_config(self.shared.datarate, &Frame::Join, &window);
+                let rx_config = shared
+                    .region
+                    .get_rx_config(shared.datarate, &Frame::Join, &window);
                 // configure the radio for the RX
-                match self
-                    .shared
+                match shared
                     .radio
                     .handle_event(radio::Event::RxRequest(rx_config))
                 {
@@ -348,22 +290,18 @@ where
                         let window_close: u32 = match self.join_rx_window {
                             // RxWindow1 one must timeout before RxWindow2
                             JoinRxWindow::_1(time) => {
-                                let time_between_windows = self
-                                    .shared
-                                    .region
-                                    .get_rx_delay(&Frame::Join, &Window::_2)
-                                    - self.shared.region.get_rx_delay(&Frame::Join, &Window::_1);
-                                if time_between_windows
-                                    > self.shared.radio.get_rx_window_duration_ms()
-                                {
-                                    time + self.shared.radio.get_rx_window_duration_ms()
+                                let time_between_windows =
+                                    shared.region.get_rx_delay(&Frame::Join, &Window::_2)
+                                        - shared.region.get_rx_delay(&Frame::Join, &Window::_1);
+                                if time_between_windows > shared.radio.get_rx_window_duration_ms() {
+                                    time + shared.radio.get_rx_window_duration_ms()
                                 } else {
                                     time + time_between_windows
                                 }
                             }
                             // RxWindow2 can last however long
                             JoinRxWindow::_2(time) => {
-                                time + self.shared.radio.get_rx_window_duration_ms()
+                                time + shared.radio.get_rx_window_duration_ms()
                             }
                         };
                         (
@@ -387,55 +325,44 @@ where
     }
 }
 
-impl<'a, R> From<WaitingForRxWindow<'a, R>> for WaitingForJoinResponse<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    fn from(val: WaitingForRxWindow<'a, R>) -> WaitingForJoinResponse<'a, R> {
+impl From<WaitingForRxWindow> for WaitingForJoinResponse {
+    fn from(val: WaitingForRxWindow) -> WaitingForJoinResponse {
         WaitingForJoinResponse {
             join_rx_window: val.join_rx_window,
-            shared: val.shared,
             join_attempts: val.join_attempts,
             devnonce: val.devnonce,
         }
     }
 }
 
-pub struct WaitingForJoinResponse<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    shared: Shared<'a, R>,
+pub struct WaitingForJoinResponse {
     join_attempts: usize,
     devnonce: DevNonce,
     join_rx_window: JoinRxWindow,
 }
 
-impl<'a, R> WaitingForJoinResponse<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    pub fn handle_event<C: CryptoFactory + Default>(
-        mut self,
+impl WaitingForJoinResponse {
+    pub fn handle_event<'a, R: radio::PhyRxTx + Timings, C: CryptoFactory + Default>(
+        self,
         event: Event<R>,
-    ) -> (Device<'a, R, C>, Result<Response, super::super::Error<R>>) {
+        shared: &mut Shared<'a, R>,
+    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
         match event {
             // we are waiting for the async tx to complete
             Event::RadioEvent(radio_event) => {
                 // send the transmit request to the radio
-                match self.shared.radio.handle_event(radio_event) {
+                match shared.radio.handle_event(radio_event) {
                     Ok(response) => match response {
                         radio::Response::RxDone(_quality) => {
                             if let Ok(PhyPayload::JoinAccept(JoinAcceptPayload::Encrypted(
                                 encrypted,
-                            ))) =
-                                lorawan_parse(self.shared.radio.get_received_packet(), C::default())
+                            ))) = lorawan_parse(shared.radio.get_received_packet(), C::default())
                             {
-                                match &self.shared.credentials {
+                                match &shared.credentials {
                                     Some(credentials) => {
                                         let decrypt = encrypted.decrypt(credentials.appkey());
-                                        self.shared.downlink = Some(super::Downlink::Join(
-                                            self.shared.region.process_join_accept(&decrypt),
+                                        shared.downlink = Some(super::Downlink::Join(
+                                            shared.region.process_join_accept(&decrypt),
                                         ));
                                         if decrypt.validate_mic(credentials.appkey()) {
                                             let session = SessionData::derive_new(
@@ -444,7 +371,7 @@ where
                                                 credentials,
                                             );
                                             return (
-                                                Session::new(self.shared, session).into(),
+                                                Session::new(session).into(),
                                                 Ok(Response::JoinSuccess),
                                             );
                                         }
@@ -466,20 +393,19 @@ where
             }
             Event::TimeoutFired => {
                 // send the transmit request to the radio
-                if let Err(_e) = self.shared.radio.handle_event(radio::Event::CancelRx) {
+                if let Err(_e) = shared.radio.handle_event(radio::Event::CancelRx) {
                     panic!("Error cancelling Rx");
                 }
 
                 match self.join_rx_window {
                     JoinRxWindow::_1(t1) => {
                         let time_between_windows =
-                            self.shared.region.get_rx_delay(&Frame::Join, &Window::_2)
-                                - self.shared.region.get_rx_delay(&Frame::Join, &Window::_1);
+                            shared.region.get_rx_delay(&Frame::Join, &Window::_2)
+                                - shared.region.get_rx_delay(&Frame::Join, &Window::_1);
                         let t2 = t1 + time_between_windows;
                         // TODO: jump to RxWindow2 if t2 == now
                         (
                             WaitingForRxWindow {
-                                shared: self.shared,
                                 devnonce: self.devnonce,
                                 join_attempts: self.join_attempts,
                                 join_rx_window: JoinRxWindow::_2(t2),
@@ -491,7 +417,6 @@ where
                     // Timeout during second RxWindow leads to giving up
                     JoinRxWindow::_2(_) => (
                         Idle {
-                            shared: self.shared,
                             join_attempts: self.join_attempts,
                         }
                         .into(),
@@ -508,13 +433,9 @@ where
     }
 }
 
-impl<'a, R> From<WaitingForJoinResponse<'a, R>> for Idle<'a, R>
-where
-    R: radio::PhyRxTx + Timings,
-{
-    fn from(val: WaitingForJoinResponse<'a, R>) -> Idle<'a, R> {
+impl From<WaitingForJoinResponse> for Idle {
+    fn from(val: WaitingForJoinResponse) -> Idle {
         Idle {
-            shared: val.shared,
             join_attempts: val.join_attempts,
         }
     }


### PR DESCRIPTION
* Remove type annotations no longer needed on states
* Session state no longer depends on Device type
* Shared state is stored in Device rather than on stack instead of as
part of session state


The advantages with this change is:

* Device no longer need to be moved when processing events, while session state is replaced correctly. I find this more ergonomic, and it still allows user to move the type if desirable
* Stack usage on a simple join example is reduced from 7.34kB to 4.69kB, static usage remains the same
* Flash usage reduced by 3kB
* This is a prereq for async support, where the size of the futures will include all owned state like Shared, which is avoided with this change.