### PR TITLE
Adapt to lora-phy's BoardType removal

### DIFF
--- a/lorawan-device/src/async_device/lora_radio.rs
+++ b/lorawan-device/src/async_device/lora_radio.rs
@@ -1,7 +1,7 @@
 use super::radio::{PhyRxTx, RfConfig, RxQuality, TxConfig};
 use super::Timings;
 
-use lora_phy::mod_params::{BoardType, RadioError};
+use lora_phy::mod_params::RadioError;
 use lora_phy::mod_traits::RadioKind;
 use lora_phy::{DelayUs, LoRa};
 
@@ -33,21 +33,12 @@ where
     RK: RadioKind,
     DLY: DelayUs,
 {
+    // TODO: Use a struct with Default or Option fallback?
     fn get_rx_window_offset_ms(&self) -> i32 {
-        match self.lora.get_board_type() {
-            BoardType::Rak4631Sx1262 => -15,
-            BoardType::Stm32l0Sx1276 => -15,
-            BoardType::Stm32wlSx1262 => -50,
-            _ => -50,
-        }
+        -50
     }
     fn get_rx_window_duration_ms(&self) -> u32 {
-        match self.lora.get_board_type() {
-            BoardType::Rak4631Sx1262 => 1050,
-            BoardType::Stm32l0Sx1276 => 1003,
-            BoardType::Stm32wlSx1262 => 1050,
-            _ => 1050,
-        }
+        1050
     }
 }
 


### PR DESCRIPTION
Upsteam lora-phy has dropped global BoardType enum in favor of driver-specific configuration.
In rust-lorawan BoardType was being used to specify board-specific RX1/RX2 window timing tweaks.