### PR TITLE
Fixed Join Channel Bug Fix

### DIFF
--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -134,6 +134,7 @@ impl<const D: usize, F: FixedChannelRegion<D>> RegionHandler for FixedChannelPla
                 } else {
                     DR::_4
                 };
+                self.last_tx_channel = channel as u8;
                 let data_rate = F::datarates()[dr as usize].clone().unwrap();
                 (data_rate, F::uplink_channels()[channel])
             }


### PR DESCRIPTION
I noticed a bug where we were not saving the previously used transmit channel to determine the receive channel on joins. 

