### PR TITLE
Clean up READMEs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 lora-modulation/ @ceekdee @lthiery @lulf @ivajloip
-encoding/ @ivajloip @lthiery @lulf
-device/ @ivajloip @lthiery @lulf
+lorawan-encoding/ @ivajloip @lthiery @lulf
+lorawan-device/ @ivajloip @lthiery @lulf
 
 Cargo.toml @ivajloip @lthiery @lulf
 README.md @ivajloip @lthiery @lulf

--- a/README.md
+++ b/README.md
@@ -1,21 +1,18 @@
-# Rust LoRaWAN
+# lora-rs
+
 [![Continuous Integration](https://github.com/ivajloip/rust-lorawan/actions/workflows/rust.yml/badge.svg)](https://github.com/ivajloip/rust-lorawan/actions/workflows/rust.yml)
 
-[![Gitter chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/rust-lorawan/lorawan)
+[![Matrix](https://img.shields.io/matrix/public-lora-wan-rs%3Amatrix.org)](https://matrix.to/#/#public-lora-wan-rs:matrix.org)
 
-This repository provides primitives for reading and writing LoRaWAN 1.0.2
-messages from and to slices of bytes in the `encoding` folder and an
-experimental device stack in the `device` folder. Please refer to those folders
-for more information, examples and benchmark results where available.
+This repository aims to provide a set of compatible crates for implementing LoRa end devices in Rust. 
+As a general rule, all crates are `nostd` and designed to be friendly for embedded projects.
+
+## Crates
+
+* **lora-modulation**: LoRa modulation characteristics and a utility for calculating time on air
+* **lorawan-encoding**: encoding and decoding LoRaWAN packets
+* **lorawan-device**: a LoRaWAN device stack with non-blocking and async implementations
 
 ## Contributing
 
-Please read [the contributing guidelines](CONTRIBUTING.md)
-
-## Used code and inspiration
-
-I would like to thank the projects [lorawan][1] by [brocaar][2] for the
-inspiration and useful examples.
-
-[1]: https://github.com/brocaar/lorawan
-[2]: https://github.com/brocaar
+Please read [the contributing guidelines](CONTRIBUTING.md).

--- a/lora-modulation/README.md
+++ b/lora-modulation/README.md
@@ -1,6 +1,27 @@
-# lora
+# lora-modulation
+
+[![Latest Version]][crates.io]
+[![Docs]][doc.rs]
 
 A minimal crate for providing LoRa modulation characteristics of:
 * Bandwidth
 * Spreading factor
 * Coding rate
+
+Provides utility for calculating time on air.
+
+## Usage
+
+```rust
+let length = 12;
+let params = BaseBandModulationParams::new(SpreadingFactor::_5, Bandwidth::_500KHz, CodingRate::_4_5);
+let time_on_air = params.time_on_air_us(
+    Some(8), // preamble
+    true,    // explicit header
+    length); // length of payload
+```
+
+[Latest Version]: https://img.shields.io/crates/v/lora-modulation.svg
+[crates.io]: https://crates.io/crates/lora-modulation
+[Docs]: https://docs.rs/lora-modulation/badge.svg
+[doc.rs]: https://docs.rs/lora-modulation

--- a/lorawan-device/README.md
+++ b/lorawan-device/README.md
@@ -1,6 +1,7 @@
 # lorawan-device
 
-[![Gitter chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/rust-lorawan/lorawan)
+[![Latest Version]][crates.io]
+[![Docs]][doc.rs]
 
 This is an experimental LoRaWAN device stack. It can be tested by using the
 example in [the sx12xx-rs repository](https://github.com/lthiery/sx12xx-rs). You
@@ -68,3 +69,8 @@ differs from the state machine implementation in the following ways:
 
 In terms of features, the async stack supports the same set of features as the state machine driven
 implementation.
+
+[Latest Version]: https://img.shields.io/crates/v/lorawan-device.svg
+[crates.io]: https://crates.io/crates/lorawan-device
+[Docs]: https://docs.rs/lorawan-device/badge.svg
+[doc.rs]: https://docs.rs/lorawan-device

--- a/lorawan-encoding/README.md
+++ b/lorawan-encoding/README.md
@@ -1,9 +1,7 @@
 # LoRaWAN
 
-[![Build Status](https://travis-ci.org/ivajloip/rust-lorawan.svg?branch=master)](https://travis-ci.org/ivajloip/rust-lorawan)
 [![Latest Version]][crates.io]
 [![Docs]][doc.rs]
-[![Gitter chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/rust-lorawan/lorawan)
 
 The lorawan library provides structures and tools for reading and writing
 LoRaWAN 1.0.2 messages from and to slices of bytes.
@@ -118,8 +116,15 @@ Found 8 outliers among 100 measurements (8.00%)
 Approximate memory usage per iteration: 57 from 8668603
 ```
 
+## Used code and inspiration
+
+I would like to thank the projects [lorawan][5] by [brocaar][6] for the
+inspiration and useful examples.
+
 [3]: https://gist.github.com/ivajloip/d63981e4caddaa68bd0b9c2390f4af90
 [4]: https://github.com/brocaar/lorawan/commit/6095d473cf605ce4da4584ae2b570bca8e1259ff
+[5]: https://github.com/brocaar/lorawan
+[6]: https://github.com/brocaar
 [Latest Version]: https://img.shields.io/crates/v/lorawan.svg
 [crates.io]: https://crates.io/crates/lorawan
 [Docs]: https://docs.rs/lorawan/badge.svg


### PR DESCRIPTION
I've made all the crate README's consistent in that they provide version and crates.io links. 

Main README presents a repo overview and it's objectives and the chat badge is replaced for the more active one. 

A quick example is provided for the `lora-modulation` crate.