### PR TITLE
extend join channel bias to data frames

### DIFF
--- a/lorawan-device/src/async_device/test/mod.rs
+++ b/lorawan-device/src/async_device/test/mod.rs
@@ -276,11 +276,9 @@ async fn test_link_adr_ans() {
 #[tokio::test]
 async fn test_class_c_data_before_rx1() {
     let (radio, timer, mut async_device) = setup_with_session_class_c().await;
-    println!("setup complete");
     // Run the device
     let task = tokio::spawn(async move {
         let response = async_device.send(&[1, 2, 3], 3, true).await;
-        println!("response not done?");
         (async_device, response)
     });
 

--- a/lorawan-device/src/async_device/test/timer.rs
+++ b/lorawan-device/src/async_device/test/timer.rs
@@ -57,6 +57,7 @@ impl TimerChannel {
         tx.send(()).await.unwrap();
     }
 
+    #[allow(unused)]
     pub async fn confirm_dropped_timer(&self, index: usize) {
         tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
         let mut tx_map = self.tx.lock().await;

--- a/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
@@ -328,9 +328,9 @@ mod test {
         let response = mac.handle_rx::<DefaultFactory, 255, 3>(&mut buf, &mut downlinks);
         if let Response::JoinSuccess = response {
         } else {
-            assert!(false);
+            panic!("Did not receive join success");
         }
-        let (tx_config, len) = mac
+        let (tx_config, _len) = mac
             .send::<DefaultFactory, _, 255>(
                 &mut rand::rngs::OsRng,
                 &mut buf,
@@ -389,10 +389,10 @@ mod test {
         let response = mac.handle_rx::<DefaultFactory, 255, 3>(&mut buf, &mut downlinks);
         if let Response::JoinSuccess = response {
         } else {
-            assert!(false);
+            panic!("Did not receive JoinSuccess")
         }
-        for i in 0..8 {
-            let (tx_config, len) = mac
+        for _ in 0..8 {
+            let (tx_config, _len) = mac
                 .send::<DefaultFactory, _, 255>(
                     &mut rand::rngs::OsRng,
                     &mut buf,

--- a/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
@@ -209,12 +209,14 @@ impl_join_bias!(AU915);
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        test_util::{handle_join_request, Uplink, get_key},
-        mac::{Mac, SendData}, AppEui, AppKey, DevEui, NetworkCredentials};
-    use lorawan::default_crypto::DefaultFactory;
-    use heapless::Vec;
     use crate::mac::Response;
+    use crate::{
+        mac::{Mac, SendData},
+        test_util::{get_key, handle_join_request, Uplink},
+        AppEui, AppKey, DevEui, NetworkCredentials,
+    };
+    use heapless::Vec;
+    use lorawan::default_crypto::DefaultFactory;
 
     #[test]
     fn test_join_channels_standard() {
@@ -304,35 +306,48 @@ mod test {
             &mut buf,
         );
         // Confirm that the join request occurs on our subband
-        assert!(tx_config.rf.frequency >= 903_900_000, "Unexpected frequency: {} is below 903.9 MHz!", tx_config.rf.frequency);
-        assert!(tx_config.rf.frequency <= 905_300_000, "Unexpected frequency: {} is above 905.3 MHz!", tx_config.rf.frequency);
+        assert!(
+            tx_config.rf.frequency >= 903_900_000,
+            "Unexpected frequency: {} is below 903.9 MHz!",
+            tx_config.rf.frequency
+        );
+        assert!(
+            tx_config.rf.frequency <= 905_300_000,
+            "Unexpected frequency: {} is above 905.3 MHz!",
+            tx_config.rf.frequency
+        );
         let mut downlinks: Vec<_, 3> = Vec::new();
         let mut data = std::vec::Vec::new();
         data.extend_from_slice(buf.as_ref_for_read());
-        let uplink = Uplink::new(
-            buf.as_ref_for_read(),
-            tx_config,
-        ).unwrap();
+        let uplink = Uplink::new(buf.as_ref_for_read(), tx_config).unwrap();
 
         let mut rx_buf = [0; 255];
-        let len = handle_join_request::<0>(
-            Some(uplink),
-            tx_config.rf,
-            &mut rx_buf,);
+        let len = handle_join_request::<0>(Some(uplink), tx_config.rf, &mut rx_buf);
         buf.clear();
         buf.extend_from_slice(&rx_buf[..len]).unwrap();
         let response = mac.handle_rx::<DefaultFactory, 255, 3>(&mut buf, &mut downlinks);
-        if let Response::JoinSuccess = response {} else {
+        if let Response::JoinSuccess = response {
+        } else {
             assert!(false);
         }
-        let (tx_config, len) = mac.send::<DefaultFactory, _, 255>(&mut rand::rngs::OsRng, &mut buf, &SendData {
-            fport: 1,
-            data: &[0x0; 1],
-            confirmed: false,
-        }).unwrap();
+        let (tx_config, len) = mac
+            .send::<DefaultFactory, _, 255>(
+                &mut rand::rngs::OsRng,
+                &mut buf,
+                &SendData { fport: 1, data: &[0x0; 1], confirmed: false },
+            )
+            .unwrap();
         // Confirm that the first data frame occurs on our subband
-        assert!(tx_config.rf.frequency >= 903_900_000, "Unexpected frequency: {} is below 903.9 MHz!", tx_config.rf.frequency);
-        assert!(tx_config.rf.frequency <= 905_300_000, "Unexpected frequency: {} is above 905.3 MHz!", tx_config.rf.frequency);
+        assert!(
+            tx_config.rf.frequency >= 903_900_000,
+            "Unexpected frequency: {} is below 903.9 MHz!",
+            tx_config.rf.frequency
+        );
+        assert!(
+            tx_config.rf.frequency <= 905_300_000,
+            "Unexpected frequency: {} is above 905.3 MHz!",
+            tx_config.rf.frequency
+        );
     }
 
     #[test]
@@ -352,38 +367,50 @@ mod test {
             &mut buf,
         );
         // Confirm that the join request occurs on our subband
-        assert!(tx_config.rf.frequency >= 903_900_000, "Unexpected frequency: {} is below 903.9 MHz!", tx_config.rf.frequency);
-        assert!(tx_config.rf.frequency <= 905_300_000, "Unexpected frequency: {} is above 905.3 MHz!", tx_config.rf.frequency);
+        assert!(
+            tx_config.rf.frequency >= 903_900_000,
+            "Unexpected frequency: {} is below 903.9 MHz!",
+            tx_config.rf.frequency
+        );
+        assert!(
+            tx_config.rf.frequency <= 905_300_000,
+            "Unexpected frequency: {} is above 905.3 MHz!",
+            tx_config.rf.frequency
+        );
         let mut downlinks: Vec<_, 3> = Vec::new();
         let mut data = std::vec::Vec::new();
         data.extend_from_slice(buf.as_ref_for_read());
-        let uplink = Uplink::new(
-            buf.as_ref_for_read(),
-            tx_config,
-        ).unwrap();
+        let uplink = Uplink::new(buf.as_ref_for_read(), tx_config).unwrap();
 
         let mut rx_buf = [0; 255];
-        let len = handle_join_request::<0>(
-            Some(uplink),
-            tx_config.rf,
-            &mut rx_buf,);
+        let len = handle_join_request::<0>(Some(uplink), tx_config.rf, &mut rx_buf);
         buf.clear();
         buf.extend_from_slice(&rx_buf[..len]).unwrap();
         let response = mac.handle_rx::<DefaultFactory, 255, 3>(&mut buf, &mut downlinks);
-        if let Response::JoinSuccess = response {} else {
+        if let Response::JoinSuccess = response {
+        } else {
             assert!(false);
         }
         for i in 0..8 {
-            let (tx_config, len) = mac.send::<DefaultFactory, _, 255>(&mut rand::rngs::OsRng, &mut buf, &SendData {
-                fport: 1,
-                data: &[0x0; 1],
-                confirmed: false,
-            }).unwrap();
+            let (tx_config, len) = mac
+                .send::<DefaultFactory, _, 255>(
+                    &mut rand::rngs::OsRng,
+                    &mut buf,
+                    &SendData { fport: 1, data: &[0x0; 1], confirmed: false },
+                )
+                .unwrap();
             // Confirm that the first data frame occurs on our subband
-            assert!(tx_config.rf.frequency >= 903_900_000, "Unexpected frequency: {} is below 903.9 MHz!", tx_config.rf.frequency);
-            assert!(tx_config.rf.frequency <= 905_300_000, "Unexpected frequency: {} is above 905.3 MHz!", tx_config.rf.frequency);
+            assert!(
+                tx_config.rf.frequency >= 903_900_000,
+                "Unexpected frequency: {} is below 903.9 MHz!",
+                tx_config.rf.frequency
+            );
+            assert!(
+                tx_config.rf.frequency <= 905_300_000,
+                "Unexpected frequency: {} is above 905.3 MHz!",
+                tx_config.rf.frequency
+            );
             mac.rx2_complete();
         }
-
     }
 }

--- a/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
@@ -20,12 +20,12 @@ impl JoinChannels {
     pub(crate) fn has_bias_and_not_exhausted(&self) -> bool {
         // there are remaining retries AND we have not yet been reset
         self.preferred_subband.is_some()
-            && self.num_retries <= self.max_retries
+            && self.num_retries < self.max_retries
             && self.num_retries != 0
     }
 
     pub(crate) fn first_data_channel(&mut self, rng: &mut impl RngCore) -> Option<usize> {
-        if self.preferred_subband.is_none() && self.num_retries != 0 {
+        if self.preferred_subband.is_some() && self.num_retries != 0 {
             self.clear_join_bias();
             // determine which subband the successful join was sent on
             let sb = if self.previous_channel < 64 {
@@ -34,7 +34,7 @@ impl JoinChannels {
                 self.previous_channel % 8
             };
             // pick another channel on that subband
-            Some((rng.next_u32() as usize % 8) + ((sb - 1) * 8))
+            Some((rng.next_u32() as usize % 8) + (sb * 8))
         } else {
             None
         }
@@ -209,6 +209,12 @@ impl_join_bias!(AU915);
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::{
+        test_util::{handle_join_request, Uplink, get_key},
+        mac::{Mac, SendData}, AppEui, AppKey, DevEui, NetworkCredentials};
+    use lorawan::default_crypto::DefaultFactory;
+    use heapless::Vec;
+    use crate::mac::Response;
 
     #[test]
     fn test_join_channels_standard() {
@@ -279,5 +285,105 @@ mod test {
             assert_eq!(ninth_channel / 8, first_channel / 8);
             assert_ne!(ninth_channel, first_channel);
         }
+    }
+
+    #[test]
+    fn test_full_mac_compliant_bias() {
+        let mut us915 = US915::new();
+        us915.set_join_bias(Subband::_2);
+        let mut mac = Mac::new(us915.into(), 21, 2);
+
+        let mut buf: RadioBuffer<255> = RadioBuffer::new();
+        let (tx_config, _len) = mac.join_otaa::<DefaultFactory, _, 255>(
+            &mut rand::rngs::OsRng,
+            NetworkCredentials::new(
+                AppEui::from([0x0; 8]),
+                DevEui::from([0x0; 8]),
+                AppKey::from(get_key()),
+            ),
+            &mut buf,
+        );
+        // Confirm that the join request occurs on our subband
+        assert!(tx_config.rf.frequency >= 903_900_000, "Unexpected frequency: {} is below 903.9 MHz!", tx_config.rf.frequency);
+        assert!(tx_config.rf.frequency <= 905_300_000, "Unexpected frequency: {} is above 905.3 MHz!", tx_config.rf.frequency);
+        let mut downlinks: Vec<_, 3> = Vec::new();
+        let mut data = std::vec::Vec::new();
+        data.extend_from_slice(buf.as_ref_for_read());
+        let uplink = Uplink::new(
+            buf.as_ref_for_read(),
+            tx_config,
+        ).unwrap();
+
+        let mut rx_buf = [0; 255];
+        let len = handle_join_request::<0>(
+            Some(uplink),
+            tx_config.rf,
+            &mut rx_buf,);
+        buf.clear();
+        buf.extend_from_slice(&rx_buf[..len]).unwrap();
+        let response = mac.handle_rx::<DefaultFactory, 255, 3>(&mut buf, &mut downlinks);
+        if let Response::JoinSuccess = response {} else {
+            assert!(false);
+        }
+        let (tx_config, len) = mac.send::<DefaultFactory, _, 255>(&mut rand::rngs::OsRng, &mut buf, &SendData {
+            fport: 1,
+            data: &[0x0; 1],
+            confirmed: false,
+        }).unwrap();
+        // Confirm that the first data frame occurs on our subband
+        assert!(tx_config.rf.frequency >= 903_900_000, "Unexpected frequency: {} is below 903.9 MHz!", tx_config.rf.frequency);
+        assert!(tx_config.rf.frequency <= 905_300_000, "Unexpected frequency: {} is above 905.3 MHz!", tx_config.rf.frequency);
+    }
+
+    #[test]
+    fn test_full_mac_non_compliant_bias() {
+        let mut us915 = US915::new();
+        us915.set_join_bias_and_noncompliant_retries(Subband::_2, 8);
+        let mut mac = Mac::new(us915.into(), 21, 2);
+
+        let mut buf: RadioBuffer<255> = RadioBuffer::new();
+        let (tx_config, _len) = mac.join_otaa::<DefaultFactory, _, 255>(
+            &mut rand::rngs::OsRng,
+            NetworkCredentials::new(
+                AppEui::from([0x0; 8]),
+                DevEui::from([0x0; 8]),
+                AppKey::from(get_key()),
+            ),
+            &mut buf,
+        );
+        // Confirm that the join request occurs on our subband
+        assert!(tx_config.rf.frequency >= 903_900_000, "Unexpected frequency: {} is below 903.9 MHz!", tx_config.rf.frequency);
+        assert!(tx_config.rf.frequency <= 905_300_000, "Unexpected frequency: {} is above 905.3 MHz!", tx_config.rf.frequency);
+        let mut downlinks: Vec<_, 3> = Vec::new();
+        let mut data = std::vec::Vec::new();
+        data.extend_from_slice(buf.as_ref_for_read());
+        let uplink = Uplink::new(
+            buf.as_ref_for_read(),
+            tx_config,
+        ).unwrap();
+
+        let mut rx_buf = [0; 255];
+        let len = handle_join_request::<0>(
+            Some(uplink),
+            tx_config.rf,
+            &mut rx_buf,);
+        buf.clear();
+        buf.extend_from_slice(&rx_buf[..len]).unwrap();
+        let response = mac.handle_rx::<DefaultFactory, 255, 3>(&mut buf, &mut downlinks);
+        if let Response::JoinSuccess = response {} else {
+            assert!(false);
+        }
+        for i in 0..8 {
+            let (tx_config, len) = mac.send::<DefaultFactory, _, 255>(&mut rand::rngs::OsRng, &mut buf, &SendData {
+                fport: 1,
+                data: &[0x0; 1],
+                confirmed: false,
+            }).unwrap();
+            // Confirm that the first data frame occurs on our subband
+            assert!(tx_config.rf.frequency >= 903_900_000, "Unexpected frequency: {} is below 903.9 MHz!", tx_config.rf.frequency);
+            assert!(tx_config.rf.frequency <= 905_300_000, "Unexpected frequency: {} is above 905.3 MHz!", tx_config.rf.frequency);
+            mac.rx2_complete();
+        }
+
     }
 }

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -151,7 +151,6 @@ pub fn handle_data_uplink_with_link_adr_req<const FCNT_UP: u16, const FCNT_DOWN:
             phy.set_dev_addr(&[0; 4]);
             phy.set_uplink(false);
             phy.set_fcnt(FCNT_DOWN);
-            println!("Packaged with Fcnt {}", FCNT_DOWN);
             let finished =
                 phy.build(&[3, 2, 1], &cmd, &AES128(get_key()), &AES128(get_key())).unwrap();
             finished.len()


### PR DESCRIPTION
On fixed channel plans, there remains some difficulties for single subband networks if the LNS does not implement CFList. After the successful Join, the device will start hopping on all 64 channels until the subband is randomly hit again and the subband is eventually communicated via the ChannelMask in LinkAdrReq. 

This PR extends usage of the JoinChannels module such that it can influence the dataframes. The behavior is as follows:
* if join bias was configured, `num_retries` has not been exceeded, and the struct has not been reset, we will continue using the struct for the data frames. This will only occur once if the "compliant" subband bias was used and therefore, remains compliant.
* if join bias was not configured and the struct has not been reset, we will use the successful subband from the JoinRequest for the first Data frame. We reset the struct such that this only occurs once. Similarly, this remains compliant since only the first Data frame is sent on the successful subband of the join.

TODO: would like to setup some unit tests to confirm the behavior described above

@jbeaurivage 