### PR TITLE
use enums instead of &str for encoding errors

### DIFF
--- a/lorawan-device/src/mac/otaa.rs
+++ b/lorawan-device/src/mac/otaa.rs
@@ -41,8 +41,7 @@ impl Otaa {
         phy.set_app_eui(self.network_credentials.appeui.0)
             .set_dev_eui(self.network_credentials.deveui.0)
             .set_dev_nonce(self.dev_nonce);
-        let result = phy.build(&self.network_credentials.appkey.0);
-        let vec = result.unwrap();
+        let vec = phy.build(&self.network_credentials.appkey.0);
         buf.extend_from_slice(vec).unwrap();
         u16::from(self.dev_nonce)
     }

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -121,7 +121,7 @@ impl Session {
                             &mut self.uplink,
                             &mut decrypted.fhdr().fopts(),
                         );
-                        if let Ok(FRMPayload::MACCommands(mac_cmds)) = decrypted.frm_payload() {
+                        if let FRMPayload::MACCommands(mac_cmds) = decrypted.frm_payload() {
                             configuration.handle_downlink_macs(
                                 region,
                                 &mut self.uplink,
@@ -140,7 +140,7 @@ impl Session {
                     } else {
                         // we can always increment fcnt_up when we receive a downlink
                         self.fcnt_up += 1;
-                        if let (Some(fport), Ok(FRMPayload::Data(data))) =
+                        if let (Some(fport), FRMPayload::Data(data)) =
                             (decrypted.f_port(), decrypted.frm_payload())
                         {
                             // heapless Vec from slice fails only if slice is too large.
@@ -212,7 +212,7 @@ impl Session {
                 tx_buffer.clear();
                 tx_buffer.extend_from_slice(packet).unwrap();
             }
-            Err(e) => panic!("Error assembling packet! {} ", e),
+            Err(e) => panic!("Error assembling packet! {:?} ", e),
         }
         fcnt
     }

--- a/lorawan-device/src/mac/uplink.rs
+++ b/lorawan-device/src/mac/uplink.rs
@@ -79,8 +79,7 @@ impl Uplink {
         self.adr_ans.clear();
 
         if self.rx_delay_ans.get() != 0 {
-            macs.push(MacCommand::RXTimingSetupAns(RXTimingSetupAnsPayload::new(&[]).unwrap()))
-                .unwrap();
+            macs.push(MacCommand::RXTimingSetupAns(RXTimingSetupAnsPayload::new(&[]))).unwrap();
         }
         self.rx_delay_ans.clear();
     }

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -1,11 +1,11 @@
 use super::*;
 use lorawan::maccommands::{ChannelMask, SerializableMacCommand};
-use lorawan::parser::DataHeader;
+use lorawan::parser::{self, DataHeader};
 use lorawan::{
     default_crypto::DefaultFactory,
     maccommandcreator::LinkADRReqCreator,
     maccommands::{LinkADRReqPayload, MacCommand},
-    parser::{parse, DataPayload, FCtrl, JoinAcceptPayload, PhyPayload},
+    parser::{parse, DataPayload, JoinAcceptPayload, PhyPayload},
 };
 use mac::Session;
 use radio::{RfConfig, TxConfig};
@@ -24,7 +24,7 @@ pub struct Uplink {
 
 impl Uplink {
     /// Creates a copy from a reference and ensures the packet is at least parseable.
-    pub fn new(data_in: &[u8], tx_config: TxConfig) -> Result<Self, &'static str> {
+    pub fn new(data_in: &[u8], tx_config: TxConfig) -> Result<Self, parser::Error> {
         let mut data: Vec<u8> = Vec::new();
         data.extend_from_slice(data_in);
         let _parse = parse(data.as_mut_slice())?;

--- a/lorawan-encoding/benches/lorawan.rs
+++ b/lorawan-encoding/benches/lorawan.rs
@@ -101,7 +101,7 @@ fn bench_complete_data_payload_decrypt(c: &mut Criterion) {
             if let PhyPayload::Data(DataPayload::Encrypted(data_payload)) = phy {
                 assert_eq!(
                     data_payload.decrypt(None, Some(&key), 1).unwrap().frm_payload(),
-                    Ok(FRMPayload::Data(&payload[..]))
+                    FRMPayload::Data(&payload[..])
                 );
             }
         })

--- a/lorawan-encoding/tests/lorawan.rs
+++ b/lorawan-encoding/tests/lorawan.rs
@@ -155,7 +155,7 @@ fn test_parse_phy_payload_with_unsupported_major_versoin() {
     let phy = parse(bytes);
 
     // this is now part of the API.
-    assert_eq!(phy.err(), Some("Unsupported major version"));
+    assert_eq!(phy.err(), Some(lorawan::parser::Error::UnsupportedMajorVersion));
 }
 
 #[test]
@@ -194,14 +194,14 @@ fn test_parse_data_payload_no_panic_when_bad_packet() {
     // This reproduces a panic from https://github.com/ivajloip/rust-lorawan/issues/94.
     let data = [0x40, 0x04, 0x03, 0x02, 0x01, 0x85, 0x01, 0x00, 0xd6, 0xc3, 0xb5, 0x82];
     let phy = parse(data);
-    assert_eq!(phy.err(), Some("can not build EncryptedDataPayload from the provided data"));
+    assert_eq!(phy.err(), Some(lorawan::parser::Error::InvalidData));
 }
 
 #[test]
 fn test_parse_data_payload_no_panic_when_too_short_packet() {
     let data = [0x40, 0x04, 0x03, 0x02, 0x01];
     let phy = EncryptedDataPayload::new(data);
-    assert_eq!(phy.err(), Some("can not build EncryptedDataPayload from the provided data"));
+    assert_eq!(phy.err(), Some(lorawan::parser::Error::InvalidData));
 }
 
 #[test]
@@ -356,7 +356,7 @@ fn test_complete_dataup_payload_frm_payload() {
     let mut payload = Vec::new();
     payload.extend_from_slice(&String::from("hello").into_bytes()[..]);
 
-    assert_eq!(decrypted.frm_payload(), Ok(FRMPayload::Data(&payload)));
+    assert_eq!(decrypted.frm_payload(), FRMPayload::Data(&payload));
 }
 
 #[test]
@@ -368,7 +368,7 @@ fn test_complete_long_dataup_payload_frm_payload() {
     let mut payload = Vec::new();
     payload.extend_from_slice(&long_data_payload().into_bytes()[..]);
 
-    assert_eq!(decrypted.frm_payload(), Ok(FRMPayload::Data(&payload)));
+    assert_eq!(decrypted.frm_payload(), FRMPayload::Data(&payload));
 }
 
 #[test]
@@ -379,7 +379,7 @@ fn test_complete_datadown_payload_frm_payload() {
     let mut payload = Vec::new();
     payload.extend_from_slice(&String::from("hello lora").into_bytes()[..]);
 
-    assert_eq!(decrypted.frm_payload(), Ok(FRMPayload::Data(&payload)));
+    assert_eq!(decrypted.frm_payload(), FRMPayload::Data(&payload));
 }
 
 #[test]
@@ -606,7 +606,7 @@ fn test_join_accept_creator() {
         .set_dl_settings(0)
         .set_rx_delay(0);
 
-    assert_eq!(phy.build(&key).unwrap(), &phy_join_accept_payload()[..]);
+    assert_eq!(phy.build(&key), &phy_join_accept_payload()[..]);
 }
 
 #[test]
@@ -617,7 +617,7 @@ fn test_join_request_creator() {
         .set_dev_eui(&[0x05, 0x04, 0x03, 0x02, 0x05, 0x04, 0x03, 0x02])
         .set_dev_nonce(&[0x2du8, 0x10]);
 
-    assert_eq!(phy.build(&key).unwrap(), &phy_join_request_payload()[..]);
+    assert_eq!(phy.build(&key), &phy_join_request_payload()[..]);
 }
 
 #[test]
@@ -630,7 +630,7 @@ fn test_join_request_creator_with_options() {
             .set_dev_eui(&[0x05, 0x04, 0x03, 0x02, 0x05, 0x04, 0x03, 0x02])
             .set_dev_nonce(&[0x2du8, 0x10]);
 
-        assert_eq!(phy.build(&key).unwrap(), &phy_join_request_payload()[..]);
+        assert_eq!(phy.build(&key), &phy_join_request_payload()[..]);
     }
     assert_eq!(&data[..], &phy_join_request_payload()[..]);
 }

--- a/lorawan-encoding/tests/maccommands.rs
+++ b/lorawan-encoding/tests/maccommands.rs
@@ -30,8 +30,7 @@ macro_rules! test_helper {
         {
             let data = [];
             let mc = $type::new_as_mac_cmd(&data[..]);
-            assert!(mc.is_ok());
-            if let (MacCommand::$name(_), size) = mc.unwrap() {
+            if let (MacCommand::$name(_), size) = mc {
                 assert_eq!(size, 0);
             } else {
                 panic!("failed to parse {}", stringify!($type));


### PR DESCRIPTION
By using enums everywhere error handling should be easier in the long run. This also allows better use of defmt.