### PR TITLE
set use_dio2_as_rfswitch for examples

### DIFF
--- a/examples/nrf52840/src/bin/lora_cad.rs
+++ b/examples/nrf52840/src/bin/lora_cad.rs
@@ -42,6 +42,7 @@ async fn main(_spawner: Spawner) {
         chip: Sx126xVariant::Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
     let mut lora = LoRa::new(SX1261_2::new(spi, iv, config), false, Delay).await.unwrap();

--- a/examples/nrf52840/src/bin/lora_lorawan.rs
+++ b/examples/nrf52840/src/bin/lora_lorawan.rs
@@ -50,6 +50,7 @@ async fn main(_spawner: Spawner) {
         chip: Sx126xVariant::Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
     let lora = LoRa::new(SX1261_2::new(spi, iv, config), true, Delay).await.unwrap();

--- a/examples/nrf52840/src/bin/lora_p2p_receive.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive.rs
@@ -42,6 +42,7 @@ async fn main(_spawner: Spawner) {
         chip: Sx126xVariant::Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
     let mut lora = LoRa::new(SX1261_2::new(spi, iv, config), false, Delay).await.unwrap();

--- a/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
@@ -42,6 +42,7 @@ async fn main(_spawner: Spawner) {
         chip: Sx126xVariant::Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
     let mut lora = LoRa::new(SX1261_2::new(spi, iv, config), false, Delay).await.unwrap();

--- a/examples/nrf52840/src/bin/lora_p2p_send.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_send.rs
@@ -42,6 +42,7 @@ async fn main(_spawner: Spawner) {
         chip: Sx126xVariant::Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
     let mut lora = LoRa::new(SX1261_2::new(spi, iv, config), false, Delay).await.unwrap();

--- a/examples/rp/src/bin/lora_lorawan.rs
+++ b/examples/rp/src/bin/lora_lorawan.rs
@@ -48,6 +48,7 @@ async fn main(_spawner: Spawner) {
         chip: Sx126xVariant::Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, None, None).unwrap();
     let lora = LoRa::new(SX1261_2::new(spi, iv, config), true, Delay).await.unwrap();

--- a/examples/rp/src/bin/lora_p2p_receive.rs
+++ b/examples/rp/src/bin/lora_p2p_receive.rs
@@ -42,6 +42,7 @@ async fn main(_spawner: Spawner) {
         chip: Sx126xVariant::Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, None, None).unwrap();
     let mut lora = LoRa::new(SX1261_2::new(spi, iv, config), true, Delay).await.unwrap();

--- a/examples/rp/src/bin/lora_p2p_send.rs
+++ b/examples/rp/src/bin/lora_p2p_send.rs
@@ -42,6 +42,7 @@ async fn main(_spawner: Spawner) {
         chip: Sx126xVariant::Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, None, None).unwrap();
     let mut lora = LoRa::new(SX1261_2::new(spi, iv, config), true, Delay).await.unwrap();

--- a/examples/rp/src/bin/lora_p2p_send_multicore.rs
+++ b/examples/rp/src/bin/lora_p2p_send_multicore.rs
@@ -79,6 +79,7 @@ async fn core1_task(
         chip: Sx126xVariant::Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let mut lora = LoRa::new(SX1261_2::new(spi, iv, config), true, Delay).await.unwrap();
 

--- a/examples/stm32wl/src/bin/lora_lorawan.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan.rs
@@ -67,6 +67,7 @@ async fn main(_spawner: Spawner) {
         chip: Sx126xVariant::Stm32wl,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
     let lora = LoRa::new(SX1261_2::new(spi, iv, config), true, Delay).await.unwrap();

--- a/examples/stm32wl/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_receive.rs
@@ -60,6 +60,7 @@ async fn main(_spawner: Spawner) {
         chip: Sx126xVariant::Stm32wl,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
     let mut lora = LoRa::new(SX1261_2::new(spi, iv, config), false, Delay).await.unwrap();

--- a/examples/stm32wl/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_send.rs
@@ -60,6 +60,7 @@ async fn main(_spawner: Spawner) {
         chip: Sx126xVariant::Stm32wl,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
+        use_dio2_as_rfswitch: true,
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
     let mut lora = LoRa::new(SX1261_2::new(spi, iv, config), false, Delay).await.unwrap();


### PR DESCRIPTION
From [RAK documentation](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Datasheet/#hardware):

"
Important for successful SX1262 initialization:

* Setup DIO2 to control the antenna switch
* Setup DIO3 to control the TCXO power supply
* Setup the SX1262 to use it's DCDC regulator and not the LDO
* RAK4630 schematics show GPIO P1.07 connected to the antenna switch, but it should not be initialized, as DIO2 will do the control of the antenna switch

"