### PR TITLE
always incr fcnt-up

### DIFF
--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -158,14 +158,12 @@ impl Session {
     }
 
     pub(crate) fn rx2_complete(&mut self) -> Response {
-        // we only increment the fcnt_up if the uplink was not confirmed
-        if !self.confirmed {
-            if self.fcnt_up == 0xFFFF_FFFF {
-                // if the FCnt is used up, the session has expired
-                return Response::SessionExpired;
-            } else {
-                self.fcnt_up += 1;
-            }
+        // Until we handle NbTrans, there is no case where we should not increment FCntUp.
+        if self.fcnt_up == 0xFFFF_FFFF {
+            // if the FCnt is used up, the session has expired
+            return Response::SessionExpired;
+        } else {
+            self.fcnt_up += 1;
         }
         if self.confirmed {
             Response::NoAck


### PR DESCRIPTION
Initially, I had interpreted that we should not increment FCntUp after a failed confirmed uplink (ie: no corresponding ACK). But it seems that most LNS's don't appreciate the replay and the device simply gets stuck.

Upon more closely reading 1.0.4, I see:
```
FCntUp SHALL NOT be incremented in the case of multiple
transmissions of a confirmed or unconfirmed frame (see NbTrans parameter). Network
Servers SHALL drop the application payload of the retransmitted frames and only forward a
single instance to the appropriate Application Server.
```

We don't really handle NbTrans yet so I don't think this failure to increment FCntUp makes sense.
