### PR TITLE
Revert "Bump embedded-hal to rc3 (#184)"

### DIFF
--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -13,5 +13,5 @@ defmt = { version = "0.3" }
 lora-modulation = { version = ">=0.1.2" }
 num-traits = { version = "0.2", default-features = false }
 
-embedded-hal = { version = "=1.0.0-rc.3"}
-embedded-hal-async = { version = "=1.0.0-rc.3"}
+embedded-hal = { version = "=1.0.0-rc.2"}
+embedded-hal-async = { version = "=1.0.0-rc.2"}


### PR DESCRIPTION
This reverts commit d9388d050a0976be1a774cf8192e104e2d328237. I was unable to resolve the embassy-time dependency. I think it's best to wait for rust 1.76 and work from release after that.