### PR TITLE
lora-phy: put lorawan-device behind lorawan-radio feature, add async

### DIFF
--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -15,11 +15,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 defmt = { version = "0.3" }
 lora-modulation = { version = ">=0.1.2" }
-lorawan-device = { path = "../lorawan-device", version = ">=0.11.0", features = ["defmt"] }
+lorawan-device = { path = "../lorawan-device", version = ">=0.11.0", features = [
+    "defmt",
+], optional = true }
 num-traits = { version = "0.2", default-features = false }
 
-embedded-hal = { version = "=1.0.0-rc.2"}
-embedded-hal-async = { version = "=1.0.0-rc.2"}
+embedded-hal = { version = "=1.0.0-rc.2" }
+embedded-hal-async = { version = "=1.0.0-rc.2" }
 
 [features]
-lorawan-radio = []
+lorawan-radio = ["dep:lorawan-device"]

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -17,6 +17,7 @@ defmt = { version = "0.3" }
 lora-modulation = { version = ">=0.1.2" }
 lorawan-device = { path = "../lorawan-device", version = ">=0.11.0", features = [
     "defmt",
+    "async",
 ], optional = true }
 num-traits = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
This removes lorawan-device dependency for people not needing it
The async feature is needed to make this compile