### PR TITLE
Use absolute paths so CODEOWNERS actually works as intended

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
-lora-modulation/ @ceekdee @lthiery @lulf @ivajloip
-lorawan-encoding/ @ivajloip @lthiery @lulf
-lorawan-device/ @ivajloip @lthiery @lulf
-lora-phy/ @lucasgranberg @plaes @CBJamo @Dirbaio
-Cargo.toml @ivajloip @lthiery @lulf
-README.md @ivajloip @lthiery @lulf
+/Cargo.toml @ivajloip @lthiery @lulf
+/README.md @ivajloip @lthiery @lulf
+
+/lora-modulation/ @lthiery @lulf @ivajloip
+/lora-phy/ @lucasgranberg @plaes @CBJamo @Dirbaio
+/lorawan-device/ @ivajloip @lthiery @lulf
+/lorawan-encoding/ @ivajloip @lthiery @lulf


### PR DESCRIPTION
README.md and Cargo.toml specified without any path were overriding codeowners for packages.

Also retire @ceekdee :(