### PR TITLE
Support for preamble detection during RX1-RX2 windows

### DIFF
--- a/lorawan-device/src/async_device/radio.rs
+++ b/lorawan-device/src/async_device/radio.rs
@@ -22,7 +22,6 @@ pub trait Timer {
 }
 
 /// Expected state for PhyRxTx after initiating RX
-#[derive(Debug)]
 pub enum TargetRxState {
     PreambleReceived,
     PacketReceived,

--- a/lorawan-device/src/async_device/test/mod.rs
+++ b/lorawan-device/src/async_device/test/mod.rs
@@ -20,7 +20,6 @@ use util::{setup, setup_with_session, setup_with_session_class_c};
 type Device =
     crate::async_device::Device<TestRadio, DefaultFactory, TestTimer, rand_core::OsRng, 512, 4>;
 
-#[ignore]
 #[tokio::test]
 async fn test_join_rx1() {
     let (radio, timer, mut async_device) = setup();
@@ -35,17 +34,15 @@ async fn test_join_rx1() {
 
     // Await the device to return and verify state
     if let Ok(JoinResponse::JoinSuccess) = async_device.await.unwrap() {
-        // NB: timer is armed three times (even if not fired)
+        // NB: timer is armed two times (even if not fired)
         // 1. start of rx1
         // 2. timeout after preamble (not firing)
-        // 3. end of rx1
-        assert_eq!(3, timer.get_armed_count().await);
+        assert_eq!(2, timer.get_armed_count().await);
     } else {
         panic!();
     }
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_join_long_rx1() {
     let (radio, timer, mut async_device) = setup();
@@ -62,17 +59,15 @@ async fn test_join_long_rx1() {
     radio.handle_rxtx_no_preamble(handle_join_request::<4>).await;
     // Verify state
     if let Ok(JoinResponse::JoinSuccess) = async_device.await.unwrap() {
-        // NB: timer is armed thrice
+        // NB: timer is armed twice
         // 1. start of rx1
         // 2. end of rx1
-        // 3. timeout after preamble
-        assert_eq!(3, timer.get_armed_count().await);
+        assert_eq!(2, timer.get_armed_count().await);
     } else {
         panic!();
     }
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_join_rx2() {
     let (radio, timer, mut async_device) = setup();
@@ -91,8 +86,7 @@ async fn test_join_rx2() {
 
     // Await the device to return and verify state
     if async_device.await.unwrap().is_ok() {
-        // NB: the 5th time arming is from the preamble timeout
-        assert_eq!(5, timer.get_armed_count().await);
+        assert_eq!(4, timer.get_armed_count().await);
     } else {
         panic!();
     }
@@ -210,7 +204,6 @@ async fn test_confirmed_uplink_no_ack() {
     assert!(*send_await_complete.lock().await);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_confirmed_uplink_with_ack_rx1() {
     let (radio, timer, mut async_device) = setup_with_session();
@@ -239,7 +232,6 @@ async fn test_confirmed_uplink_with_ack_rx1() {
     }
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_confirmed_uplink_with_ack_rx2() {
     let (radio, timer, mut async_device) = setup_with_session();
@@ -274,7 +266,6 @@ async fn test_confirmed_uplink_with_ack_rx2() {
     }
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_link_adr_ans() {
     let (radio, timer, mut async_device) = setup_with_session();

--- a/lorawan-device/src/async_device/test/mod.rs
+++ b/lorawan-device/src/async_device/test/mod.rs
@@ -35,9 +35,10 @@ async fn test_join_rx1() {
     // Await the device to return and verify state
     if let Ok(JoinResponse::JoinSuccess) = async_device.await.unwrap() {
         // NB: timer is armed two times (even if not fired)
-        // 1. start of rx1
+        // 1. start of rx1 preamble detect
         // 2. timeout after preamble (not firing)
-        assert_eq!(2, timer.get_armed_count().await);
+        // 3. start of rx1 payload rx
+        assert_eq!(3, timer.get_armed_count().await);
     } else {
         panic!();
     }
@@ -60,9 +61,10 @@ async fn test_join_long_rx1() {
     // Verify state
     if let Ok(JoinResponse::JoinSuccess) = async_device.await.unwrap() {
         // NB: timer is armed twice
-        // 1. start of rx1
-        // 2. end of rx1
-        assert_eq!(2, timer.get_armed_count().await);
+        // 1. start of rx1 preamble detect
+        // 2. start of rx1 payload receive
+        // 3. end of rx1
+        assert_eq!(3, timer.get_armed_count().await);
     } else {
         panic!();
     }
@@ -86,7 +88,7 @@ async fn test_join_rx2() {
 
     // Await the device to return and verify state
     if async_device.await.unwrap().is_ok() {
-        assert_eq!(4, timer.get_armed_count().await);
+        assert_eq!(5, timer.get_armed_count().await);
     } else {
         panic!();
     }

--- a/lorawan-encoding/src/lib.rs
+++ b/lorawan-encoding/src/lib.rs
@@ -15,6 +15,7 @@ pub mod creator;
 pub mod keys;
 pub mod maccommandcreator;
 pub mod maccommands;
+pub mod packet_length;
 pub mod parser;
 
 #[cfg(feature = "full")]

--- a/lorawan-encoding/src/packet_length.rs
+++ b/lorawan-encoding/src/packet_length.rs
@@ -1,0 +1,30 @@
+pub mod phy {
+    pub const UPLINK_CRC: u8 = 2;
+
+    pub const UPLINK_OVERHEAD: u8 = UPLINK_CRC;
+    pub const DOWNLINK_OVERHEAD: u8 = 0;
+
+    pub mod mac {
+        pub const UPLINK_OVERHEAD: u8 = super::UPLINK_OVERHEAD + MHDR + MIC;
+        pub const DOWNLINK_OVERHEAD: u8 = super::DOWNLINK_OVERHEAD + MHDR + MIC;
+
+        pub const MHDR: u8 = 1;
+        pub const MIC: u8 = 4;
+
+        pub const JOIN_ACCEPT_MIN: u8 = DOWNLINK_OVERHEAD + 12;
+        pub const JOIN_ACCEPT_MAX: u8 = JOIN_ACCEPT_MIN + 16;
+
+        pub mod frm {
+            pub mod fhdr {
+                pub const DEV_ADDR: u8 = 4;
+                pub const FCTRL: u8 = 1;
+                pub const FCNT: u8 = 2;
+                pub const FOPTS_MIN: u8 = 0;
+                pub const FOPTS_MAX: u8 = 15;
+
+                pub const MIN: u8 = DEV_ADDR + FCTRL + FCNT + FOPTS_MIN;
+                pub const MAX: u8 = DEV_ADDR + FCTRL + FCNT + FOPTS_MAX;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a draft PR for receiving packets that take longer to receive than RX1 and RX2 windows.
Obsoletes PR #142 and once properly implemented, fixes #115.

- [x] Figure out issue with RX2 not working - Apparently RX2 packet is only pushed out if gateway runs into scheduling problems during RX1.
- [x] Test with sx127x radios
- [x] Configure timeout for both preamble and packet payload reception
- [x] Clean up window start and duration calculations
- [ ] Fix Class C tests (test runner needs to handle preamble properly)


Currently tested within EU868:
* sx1262 -RAK4631 with nrf52840
* sx1272 - custom board with nrf52832

Things left for upcoming PRs:
* ValidHeader IRQ handling to detect whether packet is actually intended for our device by checking address + MIC
* Preamble noise handling (ie currently when we detect preamble during RX1, we won't start RX2 window)
* Refactor RX path for Class A to not use continuous RX