### PR TITLE
lora-phy: sx127x: Make sure to copy only required bytes from FIFO

### DIFF
--- a/lora-phy/src/sx1276_7_8_9/mod.rs
+++ b/lora-phy/src/sx1276_7_8_9/mod.rs
@@ -484,7 +484,7 @@ where
     async fn set_payload(&mut self, payload: &[u8]) -> Result<(), RadioError> {
         self.write_register(Register::RegFifoAddrPtr, 0x00u8).await?;
         self.write_register(Register::RegPayloadLength, 0x00u8).await?;
-        self.write_buffer(Register::RegFifo, &payload).await?;
+        self.write_buffer(Register::RegFifo, payload).await?;
         self.write_register(Register::RegPayloadLength, payload.len() as u8)
             .await
     }
@@ -547,7 +547,8 @@ where
         }
         let fifo_addr = self.read_register(Register::RegFifoRxCurrentAddr).await?;
         self.write_register(Register::RegFifoAddrPtr, fifo_addr).await?;
-        self.read_buffer(Register::RegFifo, receiving_buffer).await?;
+        self.read_buffer(Register::RegFifo, &mut receiving_buffer[0..payload_length as usize])
+            .await?;
         self.write_register(Register::RegFifoAddrPtr, 0x00u8).await?;
 
         Ok(payload_length)


### PR DESCRIPTION
Apparently we were always pulling the whole length of buffer from FIFO, instead of correctly passing packet length to the read call.

And also fix a nit from clippy in set_payload as well.

Fixes: da7ed97831