### PR TITLE
lorawan-encoding: Add module with various packet length values

### DIFF
--- a/lorawan-encoding/CHANGELOG.md
+++ b/lorawan-encoding/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
-# Unreleased
+## [v0.7.5] - Unreleased
+
+- Add `packet_length` module containing constants for packet component sizes.
 
 ---
 

--- a/lorawan-encoding/Cargo.toml
+++ b/lorawan-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorawan"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 authors = ["Ivaylo Petrov <ivajloip@gmail.com>"]
 description = "Crate lorawan provides structures and tools for reading and writing LoRaWAN messages from and to a slice of bytes."

--- a/lorawan-encoding/src/lib.rs
+++ b/lorawan-encoding/src/lib.rs
@@ -15,6 +15,7 @@ pub mod creator;
 pub mod keys;
 pub mod maccommandcreator;
 pub mod maccommands;
+pub mod packet_length;
 pub mod parser;
 
 #[cfg(feature = "full")]

--- a/lorawan-encoding/src/packet_length.rs
+++ b/lorawan-encoding/src/packet_length.rs
@@ -1,0 +1,30 @@
+pub mod phy {
+    pub const UPLINK_CRC: u8 = 2;
+
+    pub const UPLINK_OVERHEAD: u8 = UPLINK_CRC;
+    pub const DOWNLINK_OVERHEAD: u8 = 0;
+
+    pub mod mac {
+        pub const UPLINK_OVERHEAD: u8 = super::UPLINK_OVERHEAD + MHDR + MIC;
+        pub const DOWNLINK_OVERHEAD: u8 = super::DOWNLINK_OVERHEAD + MHDR + MIC;
+
+        pub const MHDR: u8 = 1;
+        pub const MIC: u8 = 4;
+
+        pub const JOIN_ACCEPT_MIN: u8 = DOWNLINK_OVERHEAD + 12;
+        pub const JOIN_ACCEPT_MAX: u8 = JOIN_ACCEPT_MIN + 16;
+
+        pub mod frm {
+            pub mod fhdr {
+                pub const DEV_ADDR: u8 = 4;
+                pub const FCTRL: u8 = 1;
+                pub const FCNT: u8 = 2;
+                pub const FOPTS_MIN: u8 = 0;
+                pub const FOPTS_MAX: u8 = 15;
+
+                pub const MIN: u8 = DEV_ADDR + FCTRL + FCNT + FOPTS_MIN;
+                pub const MAX: u8 = DEV_ADDR + FCTRL + FCNT + FOPTS_MAX;
+            }
+        }
+    }
+}

--- a/lorawan-encoding/tests/packet_length.rs
+++ b/lorawan-encoding/tests/packet_length.rs
@@ -1,0 +1,6 @@
+use lorawan::packet_length;
+
+#[test]
+fn test_mac_join_max() {
+    assert_eq!(33, packet_length::phy::mac::JOIN_ACCEPT_MAX);
+}


### PR DESCRIPTION
Parts of commit extracted from PR #142, and eventualy dependency for #198.
