### PR TITLE
Update to embassy crates.io releases

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,0 @@
-[net]
-git-fetch-with-cli = true
-
-[patch.crates-io]
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "0027a76bb61f19fcae1fe588ba3ff62660d7f7e3" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "0027a76bb61f19fcae1fe588ba3ff62660d7f7e3" }
-embassy-rp = { git = "https://github.com/embassy-rs/embassy.git", rev = "0027a76bb61f19fcae1fe588ba3ff62660d7f7e3" }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "0027a76bb61f19fcae1fe588ba3ff62660d7f7e3" }
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "0027a76bb61f19fcae1fe588ba3ff62660d7f7e3" }

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -5,8 +5,8 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-executor = { version = "0.4.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.2.0", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
+embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-nrf = { version = "0.1.0", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio"] }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -5,8 +5,8 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-executor = { version = "0.4.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.2.0", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
+embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-sync = { version = "0.5.0", features = ["defmt"] }
 embassy-rp = { version = "0.1.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
 

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32l072cz to your chip name, if necessary. Also change it in .cargo/config.toml
 embassy-stm32 = { version = "0.1.0", features = ["defmt", "stm32l072cz", "time-driver-any", "exti", "memory-x"]  }
-embassy-executor = { version = "0.4.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.2.0", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
+embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio"] }
 lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["async", "embassy-time", "default-crypto", "defmt"] }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32wle5jc to your chip name, if necessary. Also update .cargo/config.toml
 embassy-stm32 = { version = "0.1.0", features = ["defmt", "stm32wle5jc", "time-driver-any", "memory-x", "unstable-pac", "exti", "chrono"] }
-embassy-executor = { version = "0.4.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.2.0", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
+embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-sync = { version = "0.5.0", features = ["defmt"] }
 embassy-futures = { version = "0", features = ["defmt"] }
 

--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -29,7 +29,7 @@ rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 seq-macro = "0.3.5"
 document-features = "0.2.7"
-embassy-time = { version = "0.2.0", optional = true }
+embassy-time = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time", "sync"]}


### PR DESCRIPTION
Note that lorawan-device's embassy-time update would require a major bump if 1.0. I'm not entirely sure what needs to be done around that in 0.x.