### PR TITLE
Implement RX1/RX2 listening using RxTimeout from radio

### DIFF
--- a/lora-modulation/src/lib.rs
+++ b/lora-modulation/src/lib.rs
@@ -124,6 +124,10 @@ impl BaseBandModulationParams {
         Self { sf, bw, cr, ldro, t_sym_us }
     }
 
+    pub const fn delay_in_symbols(&self, delay_in_ms: u32) -> u16 {
+        (delay_in_ms * 1000 / self.t_sym_us) as u16
+    }
+
     /// Calculates time on air for a given payload and modulation parameters.
     /// If `preamble` is None, the whole preamble including syncword is excluded from calculation.
     pub const fn time_on_air_us(

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -14,7 +14,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 defmt = { version = "0.3" }
-lora-modulation = { version = ">=0.1.2" }
+lora-modulation = { path = "../lora-modulation", version = ">=0.1.2" }
 lorawan-device = { path = "../lorawan-device", version = ">=0.11.0", features = [
     "defmt",
     "async",

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -224,12 +224,12 @@ where
         }
     }
 
-    /// Prepare the Semtech chip for a receive operation (single mode, continuous, or duty cycled) and initiate the operation
-    ///
+    /// Prepare radio to receive a frame in either single or continuous packet mode.
     /// Notes:
     /// * sx126x SetRx(0 < timeout < MAX) will listen util LoRa packet header is detected,
     /// therefore we only use 0 (Single Mode) and MAX (continuous) values.
     /// TODO: Find a way to express timeout for sx126x, allowing waiting for packet upto 262s
+    /// TODO: Allow DutyCycle as well?
     pub async fn prepare_for_rx(
         &mut self,
         listen_mode: RxMode,

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -3,8 +3,9 @@
 use super::mod_params::{PacketParams, RadioError};
 use super::mod_traits::RadioKind;
 use super::{DelayNs, LoRa, RxMode};
+
 use lorawan_device::async_device::{
-    radio::{PhyRxTx, RxConfig, RxQuality, RxStatus, TxConfig},
+    radio::{PhyRxTx, RxConfig, RxMode as LorawanRxMode, RxQuality, RxStatus, TxConfig},
     Timings,
 };
 
@@ -124,7 +125,7 @@ where
             .lora
             .create_rx_packet_params(8, false, 255, true, true, &mdltn_params)?;
         self.lora
-            .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, false)
+            .prepare_for_rx(config.mode.into(), &mdltn_params, &rx_pkt_params, false)
             .await?;
         self.rx_pkt_params = Some(rx_pkt_params);
         Ok(())
@@ -154,6 +155,15 @@ where
             }
         } else {
             Err(Error::NoRxParams)
+        }
+    }
+}
+
+impl From<LorawanRxMode> for RxMode {
+    fn from(mode: LorawanRxMode) -> Self {
+        match mode {
+            LorawanRxMode::Continuous => RxMode::Continuous,
+            LorawanRxMode::Single(symbols) => RxMode::Single(symbols),
         }
     }
 }

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -148,7 +148,7 @@ where
             Err(Error::NoRxParams)
         }
     }
-    async fn rx(&mut self, receiving_buffer: &mut [u8]) -> Result<(usize, RxQuality), Self::PhyError> {
+    async fn rx_continuous(&mut self, receiving_buffer: &mut [u8]) -> Result<(usize, RxQuality), Self::PhyError> {
         if let Some(rx_params) = &self.rx_pkt_params {
             match self.lora.rx(rx_params, receiving_buffer).await {
                 Ok((received_len, rx_pkt_status)) => {
@@ -170,6 +170,8 @@ impl RxMode {
         match mode {
             LorawanRxMode::Continuous => RxMode::Continuous,
             LorawanRxMode::Single { ms } => {
+                // Since both sx126x and sx127x have a preamble-based timeout, we translate
+                // the additional millisecond delay into symbols and add it to the amount of preamble symbols.
                 const PREAMBLE_SYMBOLS: u16 = 13; // 12.25
                 let num_symbols = PREAMBLE_SYMBOLS + bb.delay_in_symbols(ms);
                 RxMode::Single(num_symbols)

--- a/lora-phy/src/sx1261_2/mod.rs
+++ b/lora-phy/src/sx1261_2/mod.rs
@@ -82,7 +82,6 @@ where
     }
 
     // Utility functions
-
     async fn add_register_to_retention_list(&mut self, register: Register) -> Result<(), RadioError> {
         let mut buffer = [0x00u8; (1 + (2 * MAX_NUMBER_REGS_IN_RETENTION)) as usize];
 

--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-lora-modulation = { version = ">=0.1.2", default-features = false }
+lora-modulation = { path = "../lora-modulation", version = ">=0.1.2", default-features = false }
 lorawan = { path = "../lorawan-encoding", default-features = false }
 heapless = "0.7"
 generic-array = "0.14"

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -241,7 +241,7 @@ where
 
                 // Receive join response within RX window
                 self.timer.reset();
-                Ok(self.rx_with_timeout(&Frame::Join, ms).await?.try_into()?)
+                Ok(self.rx_downlink(&Frame::Join, ms).await?.try_into()?)
             }
             JoinMode::ABP { newskey, appskey, devaddr } => {
                 self.mac.join_abp(*newskey, *appskey, *devaddr);
@@ -281,7 +281,7 @@ where
 
         // Wait for received data within window
         self.timer.reset();
-        Ok(self.rx_with_timeout(&Frame::Data, ms).await?.try_into()?)
+        Ok(self.rx_downlink(&Frame::Data, ms).await?.try_into()?)
     }
 
     /// Take the downlink data from the device. This is typically called after a
@@ -343,9 +343,8 @@ where
     }
 
     /// Attempt to receive data within RX1 and RX2 windows. This function will populate the
-    /// provided buffer with data if received. Will return a RxTimeout error if no RX within
-    /// the windows.
-    async fn rx_with_timeout(
+    /// provided buffer with data if received.
+    async fn rx_downlink(
         &mut self,
         frame: &Frame,
         window_delay: u32,

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -27,7 +27,7 @@ pub use embassy_time::EmbassyTimer;
 #[cfg(test)]
 mod test;
 
-use crate::radio::RxQuality;
+use self::radio::RxQuality;
 use core::cmp::min;
 
 /// Type representing a LoRaWAN capable device.

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -293,7 +293,7 @@ where
 
     async fn window_complete(&mut self) -> Result<(), Error<R::PhyError>> {
         if self.class_c {
-            let rf_config = self.mac.region.get_rxc_config(self.mac.configuration.data_rate);
+            let rf_config = self.mac.get_rxc_config();
             self.radio.setup_rx(rf_config).await.map_err(Error::Radio)
         } else {
             self.radio.low_power().await.map_err(Error::Radio)
@@ -310,7 +310,7 @@ where
             return Ok(None);
         }
         // Class C listen while waiting for the window
-        let rf_config = self.mac.region.get_rxc_config(self.mac.configuration.data_rate);
+        let rf_config = self.mac.get_rxc_config();
         self.radio.setup_rx(rf_config).await.map_err(Error::Radio)?;
         let mut response = None;
         let timeout_fut = self.timer.at(duration.into());
@@ -370,8 +370,7 @@ where
 
         let window = {
             // Prepare for RX using correct configuration
-            let rx_config =
-                self.mac.region.get_rx_config(self.mac.configuration.data_rate, frame, &Window::_1);
+            let rx_config = self.mac.get_rx_config(frame, &Window::_1);
             // Cap window duration so RX2 can start on time
             let mut window_duration = min(rx1_end_delay, rx2_start_delay);
 
@@ -434,8 +433,7 @@ where
         let response = {
             // RX2
             // Prepare for RX using correct configuration
-            let rx_config =
-                self.mac.region.get_rx_config(self.mac.configuration.data_rate, frame, &Window::_2);
+            let rx_config = self.mac.get_rx_config(frame, &Window::_2);
             let window_duration = self.radio.get_rx_window_duration_ms();
 
             // Pass the full radio buffer slice to RX

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -6,7 +6,7 @@ use super::mac::{self, Frame, Window};
 pub use super::{
     mac::{NetworkCredentials, SendData, Session},
     region::{self, Region},
-    Downlink, JoinMode, Timings,
+    Downlink, JoinMode,
 };
 use core::marker::PhantomData;
 use futures::{future::select, future::Either, pin_mut};
@@ -351,15 +351,14 @@ where
         window_delay: u32,
     ) -> Result<mac::Response, Error<R::PhyError>> {
         // The initial window configuration uses window 1 adjusted by window_delay and radio offset
-        let rx1_start_delay = (self.mac.get_rx_delay(frame, &Window::_1) as i32
-            + window_delay as i32
-            + self.radio.get_rx_window_offset_ms()) as u32;
+        let rx1_start_delay = self.mac.get_rx_delay(frame, &Window::_1) + window_delay
+            - self.radio.get_rx_window_lead_time_ms();
 
-        let rx1_end_delay = rx1_start_delay + self.radio.get_rx_window_duration_ms();
+        // XXX
+        let rx1_end_delay = rx1_start_delay + 1000;
 
-        let rx2_start_delay = (self.mac.get_rx_delay(frame, &Window::_2) as i32
-            + window_delay as i32
-            + self.radio.get_rx_window_offset_ms()) as u32;
+        let rx2_start_delay = self.mac.get_rx_delay(frame, &Window::_2) + window_delay
+            - self.radio.get_rx_window_lead_time_ms();
         self.radio_buffer.clear();
         let _ = self.between_windows(rx1_start_delay).await?;
 
@@ -370,7 +369,8 @@ where
 
         let window = {
             // Prepare for RX using correct configuration
-            let rx_config = self.mac.get_rx_config(frame, &Window::_1);
+            let rx_config =
+                self.mac.get_rx_config(self.radio.get_rx_window_buffer(), frame, &Window::_1);
             // Cap window duration so RX2 can start on time
             let mut window_duration = min(rx1_end_delay, rx2_start_delay);
 
@@ -433,8 +433,10 @@ where
         let response = {
             // RX2
             // Prepare for RX using correct configuration
-            let rx_config = self.mac.get_rx_config(frame, &Window::_2);
-            let window_duration = self.radio.get_rx_window_duration_ms();
+            let rx_config =
+                self.mac.get_rx_config(self.radio.get_rx_window_buffer(), frame, &Window::_2);
+            // XXX
+            let window_duration = 2000;
 
             // Pass the full radio buffer slice to RX
             self.radio.setup_rx(rx_config).await.map_err(Error::Radio)?;
@@ -527,5 +529,20 @@ where
                 }
             }
         }
+    }
+}
+
+/// Allows to fine-tune the beginning and end of the receive windows for a specific board and runtime.
+pub trait Timings {
+    /// How many milliseconds before the RX window should the SPI transaction start?
+    /// This value needs to account for the time it takes to wake up the radio and start the SPI transaction, as
+    /// well as any non-deterministic delays in the system.
+    fn get_rx_window_lead_time_ms(&self) -> u32;
+
+    /// Explicitly set the amount of milliseconds to listen before the window starts. By default, the pessimistic assumption
+    /// of `Self::get_rx_window_lead_time_ms` will be used. If you override, be sure that: `Self::get_rx_window_buffer
+    /// < Self::get_rx_window_lead_time_ms`.
+    fn get_rx_window_buffer(&self) -> u32 {
+        self.get_rx_window_lead_time_ms()
     }
 }

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -410,7 +410,7 @@ where
     where
         F: futures::Future<Output = ()> + Sized + Unpin,
     {
-        let rx_fut = radio.rx(rx_buf.as_mut());
+        let rx_fut = radio.rx_continuous(rx_buf.as_mut());
         pin_mut!(rx_fut);
         // Wait until either a RF frame is received or if we've reached window close
         match select(rx_fut, timeout_fut).await {
@@ -434,7 +434,7 @@ where
     pub async fn rxc_listen(&mut self) -> Result<mac::Response, Error<R::PhyError>> {
         loop {
             let (sz, _rx_quality) =
-                self.radio.rx(self.radio_buffer.as_mut()).await.map_err(Error::Radio)?;
+                self.radio.rx_continuous(self.radio_buffer.as_mut()).await.map_err(Error::Radio)?;
             self.radio_buffer.set_pos(sz);
             match self.mac.handle_rxc::<C, N, D>(&mut self.radio_buffer, &mut self.downlink)? {
                 mac::Response::NoUpdate => {

--- a/lorawan-device/src/async_device/radio.rs
+++ b/lorawan-device/src/async_device/radio.rs
@@ -9,6 +9,11 @@ impl<R> From<Error<R>> for super::Error<R> {
     }
 }
 
+pub enum RxStatus {
+    Rx(usize, RxQuality),
+    RxTimeout,
+}
+
 /// An asynchronous timer that allows the state machine to await
 /// between RX windows.
 pub trait Timer {
@@ -47,6 +52,8 @@ pub trait PhyRxTx: Sized {
     /// future should only complete when RX data have been received. Furthermore, it should be
     /// possible to await the future again without settings up the receive config again.
     async fn rx(&mut self, rx_buf: &mut [u8]) -> Result<(usize, RxQuality), Self::PhyError>;
+
+    async fn rx_single(&mut self, buf: &mut [u8]) -> Result<RxStatus, Self::PhyError>;
 
     /// Puts the radio into a low-power mode
     async fn low_power(&mut self) -> Result<(), Self::PhyError> {

--- a/lorawan-device/src/async_device/radio.rs
+++ b/lorawan-device/src/async_device/radio.rs
@@ -1,4 +1,4 @@
-pub use crate::radio::{RfConfig, RxQuality, TxConfig};
+pub use crate::radio::{RfConfig, RxConfig, RxMode, RxQuality, TxConfig};
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Error<E>(pub E);
@@ -41,7 +41,7 @@ pub trait PhyRxTx: Sized {
     async fn tx(&mut self, config: TxConfig, buf: &[u8]) -> Result<u32, Self::PhyError>;
 
     /// Configures the radio to receive data. This future should not actually await the data itself.
-    async fn setup_rx(&mut self, config: RfConfig) -> Result<(), Self::PhyError>;
+    async fn setup_rx(&mut self, config: RxConfig) -> Result<(), Self::PhyError>;
 
     /// Receive data into the provided buffer with the given transceiver configuration. The returned
     /// future should only complete when RX data have been received. Furthermore, it should be

--- a/lorawan-device/src/async_device/radio.rs
+++ b/lorawan-device/src/async_device/radio.rs
@@ -49,10 +49,15 @@ pub trait PhyRxTx: Sized {
     async fn setup_rx(&mut self, config: RxConfig) -> Result<(), Self::PhyError>;
 
     /// Receive data into the provided buffer with the given transceiver configuration. The returned
-    /// future should only complete when RX data have been received. Furthermore, it should be
+    /// future should only complete when RX data has been received. Furthermore, it should be
     /// possible to await the future again without settings up the receive config again.
-    async fn rx(&mut self, rx_buf: &mut [u8]) -> Result<(usize, RxQuality), Self::PhyError>;
+    async fn rx_continuous(
+        &mut self,
+        rx_buf: &mut [u8],
+    ) -> Result<(usize, RxQuality), Self::PhyError>;
 
+    /// Receive data into the provided buffer with the given transceiver configuration. The returned
+    /// future should complete when RX data has been received or when the timeout has expired.
     async fn rx_single(&mut self, buf: &mut [u8]) -> Result<RxStatus, Self::PhyError>;
 
     /// Puts the radio into a low-power mode

--- a/lorawan-device/src/async_device/test/mod.rs
+++ b/lorawan-device/src/async_device/test/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    radio::{RfConfig, RxQuality, TxConfig},
+    radio::{RxQuality, TxConfig},
     region,
     test_util::*,
 };

--- a/lorawan-device/src/async_device/test/radio.rs
+++ b/lorawan-device/src/async_device/test/radio.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::async_device::radio::{PhyRxTx, RxConfig};
+use crate::async_device::radio::{PhyRxTx, RxConfig, RxStatus};
 use std::sync::Arc;
 use tokio::{
     sync::{mpsc, Mutex},
@@ -63,6 +63,9 @@ impl PhyRxTx for TestRadio {
                 }
             }
         }
+    }
+    async fn rx_single(&mut self, _rx_buf: &mut [u8]) -> Result<RxStatus, Self::PhyError> {
+        Ok(RxStatus::RxTimeout)
     }
 }
 

--- a/lorawan-device/src/async_device/test/radio.rs
+++ b/lorawan-device/src/async_device/test/radio.rs
@@ -48,7 +48,10 @@ impl PhyRxTx for TestRadio {
         Ok(())
     }
 
-    async fn rx(&mut self, rx_buf: &mut [u8]) -> Result<(usize, RxQuality), Self::PhyError> {
+    async fn rx_continuous(
+        &mut self,
+        rx_buf: &mut [u8],
+    ) -> Result<(usize, RxQuality), Self::PhyError> {
         let msg = self.rx.recv().await.unwrap();
         match msg {
             Msg::RxTx(handler) => {

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -22,7 +22,6 @@ pub use otaa::NetworkCredentials;
 
 #[cfg(feature = "async")]
 use crate::async_device;
-
 use crate::nb_device;
 
 pub(crate) mod uplink;
@@ -288,6 +287,14 @@ impl Mac {
             State::Otaa(_) => None,
             State::Unjoined => None,
         }
+    }
+
+    pub(crate) fn get_rx_config(&self, frame: &Frame, window: &Window) -> RfConfig {
+        self.region.get_rx_config(self.configuration.data_rate, frame, window)
+    }
+
+    pub(crate) fn get_rxc_config(&self) -> RfConfig {
+        self.region.get_rxc_config(self.configuration.data_rate)
     }
 }
 

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -3,7 +3,7 @@
 //! decrypting from send and receive buffers.
 
 use crate::{
-    radio::{self, RadioBuffer},
+    radio::{self, RadioBuffer, RfConfig, RxConfig, RxMode},
     region, AppSKey, Downlink, NewSKey,
 };
 use heapless::Vec;
@@ -16,8 +16,8 @@ pub type FcntUp = u32;
 mod session;
 use rand_core::RngCore;
 pub use session::{Session, SessionKeys};
+
 mod otaa;
-use crate::radio::RfConfig;
 pub use otaa::NetworkCredentials;
 
 #[cfg(feature = "async")]
@@ -193,7 +193,21 @@ impl Mac {
     }
 
     /// Gets the radio configuration and timing for a given frame type and window.
-    pub(crate) fn get_rx_parameters(&mut self, frame: &Frame, window: &Window) -> (RfConfig, u32) {
+    pub(crate) fn get_rx_parameters(
+        &mut self,
+        buffer_ms: u32,
+        frame: &Frame,
+        window: &Window,
+    ) -> (RxConfig, u32) {
+        (self.get_rx_config(buffer_ms, frame, window), self.get_rx_delay(frame, window))
+    }
+
+    /// Gets the radio configuration and timing for a given frame type and window.
+    pub(crate) fn get_rx_parameters_legacy(
+        &mut self,
+        frame: &Frame,
+        window: &Window,
+    ) -> (RfConfig, u32) {
         (
             self.region.get_rx_config(self.configuration.data_rate, frame, window),
             self.get_rx_delay(frame, window),
@@ -289,12 +303,21 @@ impl Mac {
         }
     }
 
-    pub(crate) fn get_rx_config(&self, frame: &Frame, window: &Window) -> RfConfig {
-        self.region.get_rx_config(self.configuration.data_rate, frame, window)
+    pub(crate) fn get_rx_config(&self, buffer_ms: u32, frame: &Frame, window: &Window) -> RxConfig {
+        const PREAMBLE_SYMBOLS: u16 = 13; // 12.25
+        let rf = self.region.get_rx_config(self.configuration.data_rate, frame, window);
+        let num_symbols = PREAMBLE_SYMBOLS + rf.bb.delay_in_symbols(buffer_ms);
+        RxConfig {
+            rf: self.region.get_rx_config(self.configuration.data_rate, frame, window),
+            mode: RxMode::Single(num_symbols),
+        }
     }
 
-    pub(crate) fn get_rxc_config(&self) -> RfConfig {
-        self.region.get_rxc_config(self.configuration.data_rate)
+    pub(crate) fn get_rxc_config(&self) -> RxConfig {
+        RxConfig {
+            rf: self.region.get_rxc_config(self.configuration.data_rate),
+            mode: RxMode::Continuous,
+        }
     }
 }
 

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -304,12 +304,9 @@ impl Mac {
     }
 
     pub(crate) fn get_rx_config(&self, buffer_ms: u32, frame: &Frame, window: &Window) -> RxConfig {
-        const PREAMBLE_SYMBOLS: u16 = 13; // 12.25
-        let rf = self.region.get_rx_config(self.configuration.data_rate, frame, window);
-        let num_symbols = PREAMBLE_SYMBOLS + rf.bb.delay_in_symbols(buffer_ms);
         RxConfig {
             rf: self.region.get_rx_config(self.configuration.data_rate, frame, window),
-            mode: RxMode::Single(num_symbols),
+            mode: RxMode::Single { ms: buffer_ms },
         }
     }
 

--- a/lorawan-device/src/nb_device/state.rs
+++ b/lorawan-device/src/nb_device/state.rs
@@ -255,7 +255,7 @@ impl WaitingForRxWindow {
             // we are waiting for a Timeout
             Event::TimeoutFired => {
                 let (rx_config, window_start) =
-                    mac.get_rx_parameters(&self.frame, &self.window.into());
+                    mac.get_rx_parameters_legacy(&self.frame, &self.window.into());
                 // configure the radio for the RX
                 match radio.handle_event(radio::Event::RxRequest(rx_config)) {
                     Ok(_) => {

--- a/lorawan-device/src/radio.rs
+++ b/lorawan-device/src/radio.rs
@@ -9,6 +9,20 @@ pub struct RfConfig {
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RxMode {
+    Continuous,
+    Single(u16),
+}
+
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RxConfig {
+    pub rf: RfConfig,
+    pub mode: RxMode,
+}
+
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TxConfig {
     pub pw: i8,
     pub rf: RfConfig,

--- a/lorawan-device/src/radio.rs
+++ b/lorawan-device/src/radio.rs
@@ -11,7 +11,11 @@ pub struct RfConfig {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RxMode {
     Continuous,
-    Single(u16),
+    /// Single shot receive.
+    /// `ms` is buffer time in milliseconds added to the timeout
+    Single {
+        ms: u32,
+    },
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/lorawan-device/src/radio.rs
+++ b/lorawan-device/src/radio.rs
@@ -11,8 +11,8 @@ pub struct RfConfig {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RxMode {
     Continuous,
-    /// Single shot receive.
-    /// `ms` is buffer time in milliseconds added to the timeout
+    /// Single shot receive. Argument `ms` indicates how many milliseconds of extra buffer time should
+    /// be added to the preamble detection timeout.
     Single {
         ms: u32,
     },


### PR DESCRIPTION
This PR implements preamble-detection using Radio timeout and rips out most of the timer functionality during RX1 and RX2 windows. This probably makes #198 obsolete.

Tested with:
* sx1262
* sx1272