### PR TITLE
Refactor lora-phy's setup_rx to take in RxMode enum and drop previous timeout_in_seconds argument

### DIFF
--- a/examples/nrf52840/src/bin/lora_lorawan.rs
+++ b/examples/nrf52840/src/bin/lora_lorawan.rs
@@ -12,9 +12,9 @@ use embassy_nrf::{bind_interrupts, peripherals, rng, spim};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
+use lora_phy::lorawan_radio::LorawanRadio;
 use lora_phy::sx1261_2::{self, Sx126xVariant, TcxoCtrlVoltage, SX1261_2};
 use lora_phy::LoRa;
-use lora_phy::lorawan_radio::LorawanRadio;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
 use lorawan_device::{AppEui, AppKey, DevEui};
@@ -54,7 +54,7 @@ async fn main(_spawner: Spawner) {
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
     let lora = LoRa::new(SX1261_2::new(spi, iv, config), true, Delay).await.unwrap();
 
-    let radio: LorawanRadio::<_, _, MAX_TX_POWER> = lora.into();
+    let radio: LorawanRadio<_, _, MAX_TX_POWER> = lora.into();
     let region: region::Configuration = region::Configuration::new(LORAWAN_REGION);
     let mut device: Device<_, Crypto, _, _> = Device::new(region, radio, EmbassyTimer::new(), Rng::new(p.RNG, Irqs));
 

--- a/examples/nrf52840/src/bin/lora_p2p_receive.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive.rs
@@ -12,8 +12,8 @@ use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
 use lora_phy::sx1261_2::{Sx126xVariant, TcxoCtrlVoltage, SX1261_2};
-use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx1261_2};
+use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
 
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
@@ -82,7 +82,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, None, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, None, false)
         .await
     {
         Ok(()) => {}

--- a/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
@@ -12,8 +12,8 @@ use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
 use lora_phy::sx1261_2::{Sx126xVariant, TcxoCtrlVoltage, SX1261_2};
-use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx1261_2};
+use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
 
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
@@ -84,9 +84,9 @@ async fn main(_spawner: Spawner) {
     // See "RM0453 Reference manual STM32WL5x advanced Arm®-based 32-bit MCUs with sub-GHz radio solution" for the best explanation of Rx duty cycle processing.
     match lora
         .prepare_for_rx(
+            RxMode::Continuous,
             &mdltn_params,
             &rx_pkt_params,
-            None,
             Some(&DutyCycleParams {
                 rx_time: 300_000,    // 300_000 units * 15.625 us/unit = 4.69 s
                 sleep_time: 200_000, // 200_000 units * 15.625 us/unit = 3.13 s

--- a/examples/rp/src/bin/lora_lorawan.rs
+++ b/examples/rp/src/bin/lora_lorawan.rs
@@ -11,9 +11,9 @@ use embassy_rp::spi::{Config, Spi};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
-use lora_phy::LoRa;
-use lora_phy::sx1261_2::{self, Sx126xVariant, TcxoCtrlVoltage, SX1261_2};
 use lora_phy::lorawan_radio::LorawanRadio;
+use lora_phy::sx1261_2::{self, Sx126xVariant, TcxoCtrlVoltage, SX1261_2};
+use lora_phy::LoRa;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
 use lorawan_device::{AppEui, AppKey, DevEui};
@@ -52,7 +52,7 @@ async fn main(_spawner: Spawner) {
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, None, None).unwrap();
     let lora = LoRa::new(SX1261_2::new(spi, iv, config), true, Delay).await.unwrap();
 
-    let radio: LorawanRadio::<_, _, MAX_TX_POWER> = lora.into();
+    let radio: LorawanRadio<_, _, MAX_TX_POWER> = lora.into();
     let region: region::Configuration = region::Configuration::new(LORAWAN_REGION);
     let mut device: Device<_, Crypto, _, _> =
         Device::new(region, radio, EmbassyTimer::new(), embassy_rp::clocks::RoscRng);

--- a/examples/rp/src/bin/lora_p2p_receive.rs
+++ b/examples/rp/src/bin/lora_p2p_receive.rs
@@ -12,8 +12,8 @@ use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
 use lora_phy::sx1261_2::{Sx126xVariant, TcxoCtrlVoltage, SX1261_2};
-use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx1261_2};
+use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
 
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
@@ -77,7 +77,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, None, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, None, false)
         .await
     {
         Ok(()) => {}

--- a/examples/stm32l0/src/bin/lora_lorawan.rs
+++ b/examples/stm32l0/src/bin/lora_lorawan.rs
@@ -13,9 +13,9 @@ use embassy_stm32::{bind_interrupts, peripherals, rng, spi};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::Stm32l0InterfaceVariant;
-use lora_phy::LoRa;
 use lora_phy::lorawan_radio::LorawanRadio;
 use lora_phy::sx1276_7_8_9::{self, Sx127xVariant, SX1276_7_8_9};
+use lora_phy::LoRa;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
 use lorawan_device::{AppEui, AppKey, DevEui};
@@ -55,7 +55,7 @@ async fn main(_spawner: Spawner) {
         .await
         .unwrap();
 
-    let radio: LorawanRadio::<_, _, MAX_TX_POWER> = lora.into();
+    let radio: LorawanRadio<_, _, MAX_TX_POWER> = lora.into();
     let region: region::Configuration = region::Configuration::new(LORAWAN_REGION);
     let mut device: Device<_, Crypto, _, _> = Device::new(region, radio, EmbassyTimer::new(), Rng::new(p.RNG, Irqs));
 

--- a/examples/stm32l0/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_receive.rs
@@ -13,8 +13,8 @@ use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::Stm32l0InterfaceVariant;
 use lora_phy::sx1276_7_8_9::{Sx127xVariant, SX1276_7_8_9};
-use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx1276_7_8_9};
+use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
 
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
@@ -80,7 +80,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, None, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, None, false)
         .await
     {
         Ok(()) => {}

--- a/examples/stm32wl/src/bin/lora_lorawan.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan.rs
@@ -14,9 +14,9 @@ use embassy_stm32::spi::Spi;
 use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, peripherals};
 use embassy_time::Delay;
+use lora_phy::lorawan_radio::LorawanRadio;
 use lora_phy::sx1261_2::{self, Sx126xVariant, TcxoCtrlVoltage, SX1261_2};
 use lora_phy::LoRa;
-use lora_phy::lorawan_radio::LorawanRadio;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
 use lorawan_device::{AppEui, AppKey, DevEui};
@@ -72,7 +72,7 @@ async fn main(_spawner: Spawner) {
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
     let lora = LoRa::new(SX1261_2::new(spi, iv, config), true, Delay).await.unwrap();
 
-    let radio: LorawanRadio::<_, _, MAX_TX_POWER> = lora.into();
+    let radio: LorawanRadio<_, _, MAX_TX_POWER> = lora.into();
     let region: region::Configuration = region::Configuration::new(LORAWAN_REGION);
     let mut device: Device<_, Crypto, _, _> = Device::new(region, radio, EmbassyTimer::new(), Rng::new(p.RNG, Irqs));
 

--- a/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
@@ -22,9 +22,9 @@ use embassy_sync::{
 };
 use embassy_time::Delay;
 
+use lora_phy::lorawan_radio::LorawanRadio;
 use lora_phy::sx1261_2::{self, Sx126xVariant, TcxoCtrlVoltage, SX1261_2};
 use lora_phy::LoRa;
-use lora_phy::lorawan_radio::LorawanRadio;
 use lorawan_device::async_device::{Device, EmbassyTimer, JoinMode, JoinResponse, SendResponse};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
 use lorawan_device::region::{Subband, US915};
@@ -105,7 +105,7 @@ async fn lora_task(
     rng: Rng<'static, peripherals::RNG>,
     rx: Receiver<'static, ThreadModeRawMutex, ButtonState, 3>,
 ) {
-    let radio: LorawanRadio::<_, _, MAX_TX_POWER> = lora.into();
+    let radio: LorawanRadio<_, _, MAX_TX_POWER> = lora.into();
     let mut us915 = US915::new();
     // Setting join bias causes the device to attempt the first join on subband 2.
     // If it fails, it will proceed with the other subbands sequentially.

--- a/examples/stm32wl/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_receive.rs
@@ -14,8 +14,8 @@ use embassy_stm32::spi::Spi;
 use embassy_stm32::time::Hertz;
 use embassy_time::{Delay, Timer};
 use lora_phy::sx1261_2::{Sx126xVariant, TcxoCtrlVoltage, SX1261_2};
-use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx1261_2};
+use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
 
 use self::iv::{InterruptHandler, Stm32wlInterfaceVariant, SubghzSpiDevice};
@@ -100,7 +100,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, None, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, None, false)
         .await
     {
         Ok(()) => {}

--- a/lora-phy/CHANGELOG.md
+++ b/lora-phy/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implement functionality for continuous wave mode.
 - Support preamble detection allowing LoRaWAN RX1+RX2 reception.
 - Update embedded-hal-async version to 1.0.0.
+- Refactor `prepare_for_rx` args to take in RxMode enum.
 
 ## [v2.1.2] - 2023-09-25
 

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lora-phy"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/lora-phy"

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -5,7 +5,7 @@ use lorawan_device::Timings;
 
 use super::mod_params::{PacketParams, RadioError};
 use super::mod_traits::RadioKind;
-use super::{DelayNs, LoRa};
+use super::{DelayNs, LoRa, RxMode};
 
 const DEFAULT_RX_WINDOW_DURATION_MS: u32 = 1050;
 const DEFAULT_RX_WINDOW_OFFSET_MS: i32 = -50;
@@ -120,7 +120,7 @@ where
             .lora
             .create_rx_packet_params(8, false, 255, true, true, &mdltn_params)?;
         self.lora
-            .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, None, false)
+            .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, None, false)
             .await?;
         self.rx_pkt_params = Some(rx_pkt_params);
         Ok(())

--- a/lora-phy/src/mod_params.rs
+++ b/lora-phy/src/mod_params.rs
@@ -19,7 +19,6 @@ pub enum RadioError {
     InvalidBaseAddress(usize, usize),
     PayloadSizeUnexpected(usize),
     PayloadSizeMismatch(usize, usize),
-    InvalidSymbolTimeout,
     RetentionListExceeded,
     UnavailableSpreadingFactor,
     UnavailableBandwidth,

--- a/lora-phy/src/sx1261_2/radio_kind_params.rs
+++ b/lora-phy/src/sx1261_2/radio_kind_params.rs
@@ -45,9 +45,11 @@ impl IrqMask {
 #[allow(dead_code)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum Register {
-    PacketParams = 0x0704,          // packet configuration
-    PayloadLength = 0x0702,         // payload size
-    SynchTimeout = 0x0706,          // recalculated number of symbols
+    PacketParams = 0x0704,  // packet configuration
+    PayloadLength = 0x0702, // payload size
+    /// Number of symbols given as SX126X_REG_LR_SYNCH_TIMEOUT[7:3] * 2 ^ (2*SX126X_REG_LR_SYNCH_TIMEOUT[2:0] + 1)
+    /// Info from SDK (not present in user manual).
+    SynchTimeout = 0x0706,
     Syncword = 0x06C0,              // Syncword values
     LoRaSyncword = 0x0740,          // LoRa Syncword value
     GeneratedRandomNumber = 0x0819, //32-bit generated random number


### PR DESCRIPTION
This mostly cleans up some sx126x-specific assumptions in the public lora-phy API, though I'm not still sure whether previous code actually achieved what it was meant to do...