### PR TITLE
lora-phy: Refactor lorawdo_rx() and lorawan-radio's setup_for_rx()

### DIFF
--- a/examples/nrf52840/src/bin/lora_p2p_receive.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive.rs
@@ -82,7 +82,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, None, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, false)
         .await
     {
         Ok(()) => {}

--- a/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
@@ -84,13 +84,12 @@ async fn main(_spawner: Spawner) {
     // See "RM0453 Reference manual STM32WL5x advanced Arm®-based 32-bit MCUs with sub-GHz radio solution" for the best explanation of Rx duty cycle processing.
     match lora
         .prepare_for_rx(
-            RxMode::Continuous,
-            &mdltn_params,
-            &rx_pkt_params,
-            Some(&DutyCycleParams {
+            RxMode::DutyCycle(DutyCycleParams {
                 rx_time: 300_000,    // 300_000 units * 15.625 us/unit = 4.69 s
                 sleep_time: 200_000, // 200_000 units * 15.625 us/unit = 3.13 s
             }),
+            &mdltn_params,
+            &rx_pkt_params,
             false,
         )
         .await

--- a/examples/rp/src/bin/lora_p2p_receive.rs
+++ b/examples/rp/src/bin/lora_p2p_receive.rs
@@ -77,7 +77,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, None, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, false)
         .await
     {
         Ok(()) => {}

--- a/examples/stm32l0/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_receive.rs
@@ -80,7 +80,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, None, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, false)
         .await
     {
         Ok(()) => {}

--- a/examples/stm32wl/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_receive.rs
@@ -100,7 +100,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, None, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, false)
         .await
     {
         Ok(()) => {}

--- a/lora-phy/CHANGELOG.md
+++ b/lora-phy/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implement functionality for continuous wave mode.
 - Support preamble detection allowing LoRaWAN RX1+RX2 reception.
 - Update embedded-hal-async version to 1.0.0.
-- Refactor `prepare_for_rx` args to take in RxMode enum.
+- Refactor `prepare_for_rx` to use RxMode enum and drop now unneeded args
 
 ## [v2.1.2] - 2023-09-25
 

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lora-phy"
-version = "3.0.0-alpha.2"
+version = "3.0.0-alpha.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/lora-phy"

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -261,6 +261,7 @@ where
         self.radio_kind.set_irq_params(Some(self.radio_mode)).await?;
         self.radio_kind
             .do_rx(
+                listen_mode,
                 duty_cycle_params,
                 self.rx_continuous,
                 rx_boosted_if_supported,

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -21,6 +21,8 @@ pub mod sx1261_2;
 /// Specific implementation to support Semtech Sx127x chips
 pub mod sx1276_7_8_9;
 
+pub use crate::mod_params::RxMode;
+
 pub use embedded_hal_async::delay::DelayNs;
 use interface::*;
 use mod_params::*;

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -243,6 +243,7 @@ where
         let (rxc, num_symbols) = match listen_mode {
             RxMode::Single(n) => (false, n),
             RxMode::Continuous => (true, 0),
+            RxMode::DutyCycle(_) => (false, 0),
         };
 
         self.rx_continuous = rxc;
@@ -254,10 +255,7 @@ where
         self.radio_kind.set_modulation_params(mdltn_params).await?;
         self.radio_kind.set_packet_params(rx_pkt_params).await?;
         self.radio_kind.set_channel(mdltn_params.frequency_in_hz).await?;
-        self.radio_mode = match duty_cycle_params {
-            Some(&_duty_cycle) => RadioMode::ReceiveDutyCycle,
-            None => RadioMode::Receive,
-        };
+        self.radio_mode = listen_mode.into();
         self.radio_kind.set_irq_params(Some(self.radio_mode)).await?;
         self.radio_kind
             .do_rx(

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -235,7 +235,6 @@ where
         listen_mode: RxMode,
         mdltn_params: &ModulationParams,
         rx_pkt_params: &PacketParams,
-        _duty_cycle_params: Option<&DutyCycleParams>,
         rx_boosted_if_supported: bool,
     ) -> Result<(), RadioError> {
         defmt::trace!("RX mode: {}", listen_mode);

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -26,19 +26,6 @@ use interface::*;
 use mod_params::*;
 use mod_traits::*;
 
-/// Listening mode for LoRaWAN packet detection/reception
-pub enum RxMode {
-    /// Single shot Rx Mode to listen until packet preamble is detected or RxTimeout occurs.
-    /// The device will stay in RX Mode until a packet is received.
-    /// Preamble length as symbols is configured via following registers:
-    /// sx126x: uses `SetLoRaSymbNumTimeout(0 < n < 255)` + `SetStopRxTimerOnPreamble(1)`
-    /// sx127x: uses `RegSymbTimeout (4 < n < 1023)`
-    // TODO: Single mode with time-based timeout is available on sx126x, but not sx127x
-    Single(u16),
-    /// Continuous Rx mode to listen for incoming packets continuously
-    Continuous,
-}
-
 /// Provides the physical layer API to support LoRa chips
 pub struct LoRa<RK, DLY>
 where

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -274,7 +274,6 @@ where
         self.radio_kind.set_irq_params(Some(self.radio_mode)).await?;
         self.radio_kind
             .do_rx(
-                rx_pkt_params,
                 duty_cycle_params,
                 self.rx_continuous,
                 rx_boosted_if_supported,

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -120,7 +120,7 @@ where
             .lora
             .create_rx_packet_params(8, false, 255, true, true, &mdltn_params)?;
         self.lora
-            .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, None, false)
+            .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, false)
             .await?;
         self.rx_pkt_params = Some(rx_pkt_params);
         Ok(())

--- a/lora-phy/src/mod_params.rs
+++ b/lora-phy/src/mod_params.rs
@@ -71,7 +71,7 @@ impl From<RxMode> for RadioMode {
 }
 
 /// Listening mode for LoRaWAN packet detection/reception
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, defmt::Format, PartialEq)]
 pub enum RxMode {
     /// Single shot Rx Mode to listen until packet preamble is detected or RxTimeout occurs.
     /// The device will stay in RX Mode until a packet is received.
@@ -115,7 +115,7 @@ impl PacketParams {
 }
 
 /// Receive duty cycle parameters
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, defmt::Format, PartialEq)]
 #[allow(missing_docs)]
 pub struct DutyCycleParams {
     pub rx_time: u32,    // receive interval

--- a/lora-phy/src/mod_params.rs
+++ b/lora-phy/src/mod_params.rs
@@ -1,5 +1,3 @@
-use core::fmt::Debug;
-
 pub use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 
 /// Errors types reported during LoRa physical layer processing
@@ -50,15 +48,21 @@ pub struct PacketStatus {
 
 /// The state of the radio
 #[derive(Clone, Copy, defmt::Format, PartialEq)]
-#[allow(missing_docs)]
 pub enum RadioMode {
-    Sleep,                    // sleep mode
-    Standby,                  // standby mode
-    FrequencySynthesis,       // frequency synthesis mode
-    Transmit,                 // transmit mode
-    Receive,                  // receive mode
-    ReceiveDutyCycle,         // receive duty cycle mode
-    ChannelActivityDetection, // channel activity detection mode
+    /// Sleep mode
+    Sleep,
+    /// Standby mode
+    Standby,
+    /// Frequency synthesis mode
+    FrequencySynthesis,
+    /// Transmit (TX) mode
+    Transmit,
+    /// Receive (RX) mode
+    Receive,
+    /// Receive duty cycle mode
+    ReceiveDutyCycle,
+    /// Channel activity detection (CAD) mode
+    ChannelActivityDetection,
 }
 
 impl From<RxMode> for RadioMode {
@@ -116,8 +120,9 @@ impl PacketParams {
 
 /// Receive duty cycle parameters
 #[derive(Clone, Copy, defmt::Format, PartialEq)]
-#[allow(missing_docs)]
 pub struct DutyCycleParams {
-    pub rx_time: u32,    // receive interval
-    pub sleep_time: u32, // sleep interval
+    /// receive interval
+    pub rx_time: u32,
+    /// sleep interval
+    pub sleep_time: u32,
 }

--- a/lora-phy/src/mod_params.rs
+++ b/lora-phy/src/mod_params.rs
@@ -62,6 +62,19 @@ pub enum RadioMode {
     ChannelActivityDetection, // channel activity detection mode
 }
 
+/// Listening mode for LoRaWAN packet detection/reception
+pub enum RxMode {
+    /// Single shot Rx Mode to listen until packet preamble is detected or RxTimeout occurs.
+    /// The device will stay in RX Mode until a packet is received.
+    /// Preamble length as symbols is configured via following registers:
+    /// sx126x: uses `SetLoRaSymbNumTimeout(0 < n < 255)` + `SetStopRxTimerOnPreamble(1)`
+    /// sx127x: uses `RegSymbTimeout (4 < n < 1023)`
+    // TODO: Single mode with time-based timeout is available on sx126x, but not sx127x
+    Single(u16),
+    /// Continuous Rx mode to listen for incoming packets continuously
+    Continuous,
+}
+
 /// Modulation parameters for a send and/or receive communication channel
 pub struct ModulationParams {
     pub(crate) spreading_factor: SpreadingFactor,

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -105,7 +105,6 @@ pub trait RadioKind {
     /// Set up to perform a receive operation (single-shot, continuous, or duty cycle)
     async fn do_rx(
         &mut self,
-        rx_pkt_params: &PacketParams,
         duty_cycle_params: Option<&DutyCycleParams>,
         rx_continuous: bool,
         rx_boosted_if_supported: bool,

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -105,6 +105,7 @@ pub trait RadioKind {
     /// Set up to perform a receive operation (single-shot, continuous, or duty cycle)
     async fn do_rx(
         &mut self,
+        rx_mode: RxMode,
         duty_cycle_params: Option<&DutyCycleParams>,
         rx_continuous: bool,
         rx_boosted_if_supported: bool,

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -103,14 +103,7 @@ pub trait RadioKind {
     /// Perform a send operation
     async fn do_tx(&mut self, timeout_in_ms: u32) -> Result<(), RadioError>;
     /// Set up to perform a receive operation (single-shot, continuous, or duty cycle)
-    async fn do_rx(
-        &mut self,
-        rx_mode: RxMode,
-        duty_cycle_params: Option<&DutyCycleParams>,
-        rx_continuous: bool,
-        rx_boosted_if_supported: bool,
-        symbol_timeout: u16,
-    ) -> Result<(), RadioError>;
+    async fn do_rx(&mut self, rx_mode: RxMode, rx_boost: bool) -> Result<(), RadioError>;
     /// Get an available packet made available as the result of a receive operation
     async fn get_rx_payload(
         &mut self,

--- a/lora-phy/src/sx1261_2/mod.rs
+++ b/lora-phy/src/sx1261_2/mod.rs
@@ -613,6 +613,7 @@ where
 
     async fn do_rx(
         &mut self,
+        _rx_mode: RxMode,
         duty_cycle_params: Option<&DutyCycleParams>,
         rx_continuous: bool,
         rx_boosted_if_supported: bool,

--- a/lora-phy/src/sx1261_2/mod.rs
+++ b/lora-phy/src/sx1261_2/mod.rs
@@ -614,14 +614,7 @@ where
         self.intf.write(&op_code_and_timeout, false).await
     }
 
-    async fn do_rx(
-        &mut self,
-        rx_mode: RxMode,
-        _duty_cycle_params: Option<&DutyCycleParams>,
-        _rx_continuous: bool,
-        rx_boost: bool,
-        _symbol_timeout: u16,
-    ) -> Result<(), RadioError> {
+    async fn do_rx(&mut self, rx_mode: RxMode, rx_boost: bool) -> Result<(), RadioError> {
         self.intf.iv.enable_rf_switch_rx().await?;
 
         // Stop the Rx timer on preamble detection

--- a/lora-phy/src/sx1261_2/radio_kind_params.rs
+++ b/lora-phy/src/sx1261_2/radio_kind_params.rs
@@ -59,7 +59,9 @@ pub enum Register {
     XTATrim = 0x0911,               // device internal trimming capacitor
     OCP = 0x08E7,                   // over current protection max value
     RetentionList = 0x029F,         // retention list
-    IQPolarity = 0x0736,            // optimize the inverted IQ operation (see DS_SX1261-2_V1.2 datasheet chapter 15.4)
+    /// Inverted IQ operation optimization - possible packet loss for longer packets
+    /// DS.SX1261-2.W.APP Rev.2.1 - Chapter 15.4
+    IQPolarity = 0x0736,
     TxModulation = 0x0889, // modulation quality with 500 kHz LoRa Bandwidth (see DS_SX1261-2_V1.2 datasheet chapter 15.1)
     TxClampCfg = 0x08D8,   // better resistance to antenna mismatch (see DS_SX1261-2_V1.2 datasheet chapter 15.2)
     RTCCtrl = 0x0902,      // RTC control

--- a/lora-phy/src/sx1276_7_8_9/mod.rs
+++ b/lora-phy/src/sx1276_7_8_9/mod.rs
@@ -500,6 +500,7 @@ where
 
     async fn do_rx(
         &mut self,
+        _rx_mode: RxMode,
         duty_cycle_params: Option<&DutyCycleParams>,
         rx_continuous: bool,
         rx_boosted_if_supported: bool,

--- a/lora-phy/src/sx1276_7_8_9/mod.rs
+++ b/lora-phy/src/sx1276_7_8_9/mod.rs
@@ -498,14 +498,7 @@ where
         self.write_register(Register::RegOpMode, LoRaMode::Tx.value()).await
     }
 
-    async fn do_rx(
-        &mut self,
-        rx_mode: RxMode,
-        _duty_cycle_params: Option<&DutyCycleParams>,
-        _rx_continuous: bool,
-        rx_boost: bool,
-        _symbol_timeout: u16,
-    ) -> Result<(), RadioError> {
+    async fn do_rx(&mut self, rx_mode: RxMode, rx_boost: bool) -> Result<(), RadioError> {
         let (num_symbols, mode) = match rx_mode {
             RxMode::DutyCycle(_) => Err(RadioError::DutyCycleUnsupported),
             RxMode::Single(ns) => Ok((ns.max(SX127X_MIN_LORA_SYMB_NUM_TIMEOUT), LoRaMode::RxSingle)),

--- a/lora-phy/src/sx1276_7_8_9/mod.rs
+++ b/lora-phy/src/sx1276_7_8_9/mod.rs
@@ -501,19 +501,16 @@ where
     async fn do_rx(
         &mut self,
         rx_mode: RxMode,
-        duty_cycle_params: Option<&DutyCycleParams>,
+        _duty_cycle_params: Option<&DutyCycleParams>,
         _rx_continuous: bool,
         rx_boost: bool,
         _symbol_timeout: u16,
     ) -> Result<(), RadioError> {
-        if let Some(&_duty_cycle) = duty_cycle_params {
-            return Err(RadioError::DutyCycleUnsupported);
-        }
-
         let (num_symbols, mode) = match rx_mode {
-            RxMode::Single(ns) => (ns.max(SX127X_MIN_LORA_SYMB_NUM_TIMEOUT), LoRaMode::RxSingle),
-            RxMode::Continuous => (0, LoRaMode::RxContinuous),
-        };
+            RxMode::DutyCycle(_) => Err(RadioError::DutyCycleUnsupported),
+            RxMode::Single(ns) => Ok((ns.max(SX127X_MIN_LORA_SYMB_NUM_TIMEOUT), LoRaMode::RxSingle)),
+            RxMode::Continuous => Ok((0, LoRaMode::RxContinuous)),
+        }?;
 
         self.intf.iv.enable_rf_switch_rx().await?;
 

--- a/lora-phy/src/sx1276_7_8_9/mod.rs
+++ b/lora-phy/src/sx1276_7_8_9/mod.rs
@@ -500,7 +500,6 @@ where
 
     async fn do_rx(
         &mut self,
-        _rx_pkt_params: &PacketParams,
         duty_cycle_params: Option<&DutyCycleParams>,
         rx_continuous: bool,
         rx_boosted_if_supported: bool,


### PR DESCRIPTION
Mostly shuffles around things inside lora-phy, but eventually also touches lorawan-radio's public interface, therefore warrants a version bump..