### PR TITLE
lora_phy::sx126x: symbol calc bug fix

### DIFF
--- a/lora-phy/src/sx1261_2/mod.rs
+++ b/lora-phy/src/sx1261_2/mod.rs
@@ -126,7 +126,7 @@ where
     // Set the number of symbols the radio will wait to detect a reception
     async fn set_lora_symbol_num_timeout(&mut self, symbol_num: u16) -> Result<(), RadioError> {
         let mut exp = 0u8;
-        let mut mant: u8 = symbol_num.min(SX126X_MAX_LORA_SYMB_NUM_TIMEOUT.into()) as u8;
+        let mut mant = ((symbol_num.min(SX126X_MAX_LORA_SYMB_NUM_TIMEOUT.into()) + 1) >> 1) as u8;
         while mant > 31 {
             mant = (mant + 3) >> 2;
             exp += 1;


### PR DESCRIPTION
It seems a bit shift right was lost in translation from [here](https://github.com/Lora-net/sx126x_driver/blob/master/src/sx126x.c#L807C1-L810C11).