### PR TITLE
lorawan-device: remove feature flag for async

### DIFF
--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -10,7 +10,7 @@ embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime
 embassy-nrf = { version = "0.1.0", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio"] }
-lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["async", "embassy-time", "default-crypto", "defmt"] }
+lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["embassy-time", "default-crypto", "defmt"] }
 lorawan = { path = "../../lorawan-encoding", default-features = false, features = ["default-crypto"] }
 
 defmt = "0.3"

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -11,7 +11,7 @@ embassy-sync = { version = "0.5.0", features = ["defmt"] }
 embassy-rp = { version = "0.1.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio"] }
-lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["async", "embassy-time", "default-crypto", "defmt"] }
+lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["embassy-time", "default-crypto", "defmt"] }
 lorawan = { path = "../../lorawan-encoding", default-features = false, features = ["default-crypto"] }
 
 defmt = "0.3"

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -11,7 +11,7 @@ embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-t
 embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio"] }
-lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["async", "embassy-time", "default-crypto", "defmt"] }
+lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["embassy-time", "default-crypto", "defmt"] }
 lorawan = { path = "../../lorawan-encoding", default-features = false, features = ["default-crypto"] }
 
 defmt = "0.3"

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -13,7 +13,7 @@ embassy-sync = { version = "0.5.0", features = ["defmt"] }
 embassy-futures = { version = "0", features = ["defmt"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio"] }
-lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["async", "embassy-time", "default-crypto", "defmt"] }
+lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["embassy-time", "default-crypto", "defmt"] }
 lorawan = { path = "../../lorawan-encoding", default-features = false, features = ["default-crypto"] }
 
 defmt = "0.3"

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -17,7 +17,6 @@ defmt = { version = "0.3" }
 lora-modulation = { path = "../lora-modulation", version = ">=0.1.2" }
 lorawan-device = { path = "../lorawan-device", version = ">=0.11.0", features = [
     "defmt",
-    "async",
 ], optional = true }
 num-traits = { version = "0.2", default-features = false }
 embedded-hal = { version = "1.0.0" }

--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -24,7 +24,7 @@ heapless = "0.7"
 generic-array = "0.14"
 defmt = { version = "0.3", optional = true }
 fastrand = { version = "2", default-features = false }
-futures = { version = "0.3", default-features = false, optional = true }
+futures = { version = "0.3", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 seq-macro = "0.3.5"
@@ -39,10 +39,6 @@ lorawan = { version = "0.7.3", path = "../lorawan-encoding" }
 
 [features]
 default = []
-
-## Provides asynchronous device implementation using the Rust's async-await driving
-## the state machine.
-async = ["futures"]
 
 ## Provide an `async_device::Timer` impl based on `embassy-time`.
 embassy-time = ["dep:embassy-time"]

--- a/lorawan-device/src/lib.rs
+++ b/lorawan-device/src/lib.rs
@@ -20,6 +20,8 @@ pub use region::Region;
 #[cfg(test)]
 mod test_util;
 
+pub mod async_device;
+
 pub mod nb_device;
 use nb_device::state::State;
 
@@ -37,11 +39,6 @@ pub use rng::Prng;
 
 mod log;
 
-#[cfg(feature = "async")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
-pub mod async_device;
-
-#[derive(Debug)]
 /// Provides the application payload and FPort of a downlink message.
 pub struct Downlink {
     pub data: Vec<u8, 256>,

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -20,7 +20,6 @@ pub use session::{Session, SessionKeys};
 mod otaa;
 pub use otaa::NetworkCredentials;
 
-#[cfg(feature = "async")]
 use crate::async_device;
 use crate::nb_device;
 
@@ -193,16 +192,6 @@ impl Mac {
     }
 
     /// Gets the radio configuration and timing for a given frame type and window.
-    pub(crate) fn get_rx_parameters(
-        &mut self,
-        buffer_ms: u32,
-        frame: &Frame,
-        window: &Window,
-    ) -> (RxConfig, u32) {
-        (self.get_rx_config(buffer_ms, frame, window), self.get_rx_delay(frame, window))
-    }
-
-    /// Gets the radio configuration and timing for a given frame type and window.
     pub(crate) fn get_rx_parameters_legacy(
         &mut self,
         frame: &Frame,
@@ -248,7 +237,6 @@ impl Mac {
     /// Handles a received RF frame during RXC window. Returns None if unparseable, fails decryption,
     /// or fails MIC verification. Upon successful data rx, provides Response::DownlinkReceived.
     /// User must later call `take_downlink()` on the device to get the application data.
-    #[cfg(feature = "async")]
     pub(crate) fn handle_rxc<C: CryptoFactory + Default, const N: usize, const D: usize>(
         &mut self,
         buf: &mut RadioBuffer<N>,
@@ -344,8 +332,6 @@ impl From<Response> for nb_device::Response {
     }
 }
 
-#[cfg(feature = "async")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 impl TryFrom<Response> for async_device::SendResponse {
     type Error = Error;
 
@@ -362,8 +348,6 @@ impl TryFrom<Response> for async_device::SendResponse {
     }
 }
 
-#[cfg(feature = "async")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 impl TryFrom<Response> for async_device::JoinResponse {
     type Error = Error;
 

--- a/lorawan-device/src/radio.rs
+++ b/lorawan-device/src/radio.rs
@@ -73,8 +73,6 @@ impl<const N: usize> RadioBuffer<N> {
         self.pos = 0;
     }
 
-    #[cfg(feature = "async")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
     pub(crate) fn set_pos(&mut self, pos: usize) {
         self.pos = pos;
     }

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -10,7 +10,7 @@ use lorawan::{
     parser::{parse, DataPayload, JoinAcceptPayload, PhyPayload},
 };
 use mac::Session;
-#[cfg(feature = "async")]
+
 use parser::FCtrl;
 use radio::{RfConfig, TxConfig};
 use std::{collections::HashMap, sync::Mutex, vec::Vec};
@@ -169,7 +169,6 @@ pub fn handle_data_uplink_with_link_adr_req<const FCNT_UP: u16, const FCNT_DOWN:
 }
 
 /// Handle an uplink and respond with two LinkAdrReq on Port 0
-#[cfg(feature = "async")]
 pub fn handle_class_c_uplink_after_join(
     uplink: Option<Uplink>,
     _config: RfConfig,
@@ -257,7 +256,6 @@ pub fn handle_data_uplink_with_link_adr_ans(
     }
 }
 
-#[cfg(feature = "async")]
 pub fn class_c_downlink<const FCNT_DOWN: u32>(
     _uplink: Option<Uplink>,
     _config: RfConfig,


### PR DESCRIPTION
Now that async does not require nightly, I don't think there is a reason to hide it behind a feature flag.