### PR TITLE
update many change-logs and prepare lorawan and lorawan-device release

### DIFF
--- a/lora-modulation/CHANGELOG.md
+++ b/lora-modulation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
-# Unreleased
+## [v0.1.4]
+- Add `BaseBandModulationParams::symbols_to_ms`
 
 ---
 

--- a/lora-modulation/Cargo.toml
+++ b/lora-modulation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lora-modulation"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Louis Thiery <thiery.louis@gmail.com>"]
 license = "MIT"

--- a/lora-phy/CHANGELOG.md
+++ b/lora-phy/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support preamble detection allowing LoRaWAN RX1+RX2 reception.
 - Update embedded-hal-async version to 1.0.0.
 - Refactor `prepare_for_rx` to use RxMode enum and drop now unneeded args
+- Refactor `external-lora-phy` in `lorawan-device` as `lorawan-radio` in `lora-phy` ([#189](https://github.com/lora-rs/lora-rs/pull/189))
+- Refactor `setup_rx` to take in `enum RxMode` and drop previous `timeout_in_seconds` argument ([#207](https://github.com/lora-rs/lora-rs/pull/207))
+- Refactor `do_rx` and lorawan-radio's `setup_for_rx`[#208](https://github.com/lora-rs/lora-rs/pull/208)
+- Refactor sx126x power amplifier control and clarify `Sx126xVariant` implications ([#209](https://github.com/lora-rs/lora-rs/pull/209))
 
 ## [v2.1.2] - 2023-09-25
 

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -15,12 +15,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 defmt = { version = "0.3" }
 lora-modulation = { path = "../lora-modulation", version = ">=0.1.2" }
-lorawan-device = { path = "../lorawan-device", version = ">=0.11.0", features = [
+lorawan-device = { path = "../lorawan-device", version = "0.12", features = [
     "defmt",
 ], optional = true }
 num-traits = { version = "0.2", default-features = false }
-embedded-hal = { version = "1.0.0" }
-embedded-hal-async = { version = "1.0.0" }
+embedded-hal = { version = "1" }
+embedded-hal-async = { version = "1" }
 
 [features]
 lorawan-radio = ["dep:lorawan-device"]

--- a/lorawan-device/CHANGELOG.md
+++ b/lorawan-device/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [v1.0.0] - Unreleased
+## [v0.12.0]
 
 - Fixes bug related to FCntUp and confirmed uplink ([#182](https://github.com/lora-rs/lora-rs/pull/182))
 - Extend PhyRxTx to support antenna gain and max power ([#159](https://github.com/lora-rs/lora-rs/pull/159))
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
   ([#110](https://github.com/lora-rs/lora-rs/pull/110) / [#170](https://github.com/lora-rs/lora-rs/pull/170) )
 - Develops `async_device` API to provide `JoinResponse` and `SendResponse` (#[144](https://github.com/lora-rs/lora-rs/pull/144))
 - Develops `nb_device` API around sending a join to be consistent with  `async_device` (#[144](https://github.com/lora-rs/lora-rs/pull/144))
+- Refactor `external-lora-phy` in `lorawan-device` as `lorawan-radio` in `lora-phy` ([#189](https://github.com/lora-rs/lora-rs/pull/189))
+- Add `Timer` implementation based on embassy-time ([#171](https://github.com/lora-rs/lora-rs/pull/171))
+- Use radio timeout for end of RX1 and RX2 windows; preamble detection cancels timeout ([#204](https://github.com/lora-rs/lora-rs/pull/204))
+- Remove `async` feature-flag as async fn in traits is stable 
 
----
 Change tracking starting at version 0.11.0.

--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorawan-device"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Louis Thiery <thiery.louis@gmail.com>", "Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2021"
 categories = [

--- a/lorawan-encoding/CHANGELOG.md
+++ b/lorawan-encoding/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [v0.7.5] - Unreleased
+## [v0.8.0]
 
 - Add `packet_length` module containing constants for packet component sizes.
+- update AES and CMAC libraries ([#190](https://github.com/lora-rs/lora-rs/pull/190))
+- MacCommandCreator enhancements with add ADR fields ([#194](https://github.com/lora-rs/lora-rs/pull/194))
+- Split MacCommands into Uplink and Dowlinks ([#178](https://github.com/lora-rs/lora-rs/pull/178)
+- Specify AppKey, NewSKey, AppSKey in API instead of generic AES128 ([#177](https://github.com/lora-rs/lora-rs/pull/177)
+- Use `enum Error` instead of `&str` for API's Result ([#175](https://github.com/lora-rs/lora-rs/pull/175) 
 
 ---
 

--- a/lorawan-encoding/Cargo.toml
+++ b/lorawan-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorawan"
-version = "0.7.5"
+version = "0.8.0"
 edition = "2021"
 authors = ["Ivaylo Petrov <ivajloip@gmail.com>"]
 description = "Crate lorawan provides structures and tools for reading and writing LoRaWAN messages from and to a slice of bytes."

--- a/lorawan-encoding/README.md
+++ b/lorawan-encoding/README.md
@@ -12,7 +12,7 @@ LoRaWAN 1.0.2 messages from and to slices of bytes.
 
 ```toml
 [dependencies]
-lorawan = "0.7.0"
+lorawan = "0.8"
 ```
 
 ### Packet generation


### PR DESCRIPTION
From this hash, I'd like to tag:

lora-modulation 0.1.3 ->  0.1.4
lorawan 0.7.5 -> 0.8.0
lorawan-device 0.11.0 -> 0.12.0

They will not build until pushed to crates.io as they specify their dependencies via versions that are not on crates.io yet. That is to say, I have to push lora-modulation and lorawan before lorawan will build. And I need to push lorawan before lora-phy builds.