### PR TITLE
lora-phy: sx127x: fix snr and rssi calculation

### DIFF
--- a/lora-phy/src/sx1276_7_8_9/mod.rs
+++ b/lora-phy/src/sx1276_7_8_9/mod.rs
@@ -24,9 +24,9 @@ const SX127X_MIN_LORA_SYMB_NUM_TIMEOUT: u16 = 4;
 const SX127X_MAX_LORA_SYMB_NUM_TIMEOUT: u16 = 1023;
 
 // Constant values need to compute the RSSI value
-const RSSI_OFFSET_LF: i16 = -164;
-const RSSI_OFFSET_HF: i16 = -157;
-const RF_MID_BAND_THRESH: u32 = 525_000_000;
+const SX1276_RSSI_OFFSET_LF: i16 = -164;
+const SX1276_RSSI_OFFSET_HF: i16 = -157;
+const SX1276_RF_MID_BAND_THRESH: u32 = 525_000_000;
 
 /// Supported SX127x chip variants
 #[derive(Clone, Copy)]
@@ -565,10 +565,10 @@ where
                 (frf as f64 * FREQUENCY_SYNTHESIZER_STEP) as u32
             };
 
-            let rssi_offset = if frequency_in_hz > RF_MID_BAND_THRESH {
-                RSSI_OFFSET_HF
+            let rssi_offset = if frequency_in_hz > SX1276_RF_MID_BAND_THRESH {
+                SX1276_RSSI_OFFSET_HF
             } else {
-                RSSI_OFFSET_LF
+                SX1276_RSSI_OFFSET_LF
             };
 
             if snr >= 0 {

--- a/lora-phy/src/sx1276_7_8_9/mod.rs
+++ b/lora-phy/src/sx1276_7_8_9/mod.rs
@@ -24,6 +24,7 @@ const SX127X_MIN_LORA_SYMB_NUM_TIMEOUT: u16 = 4;
 const SX127X_MAX_LORA_SYMB_NUM_TIMEOUT: u16 = 1023;
 
 // Constant values need to compute the RSSI value
+const SX1272_RSSI_OFFSET: i16 = -139;
 const SX1276_RSSI_OFFSET_LF: i16 = -164;
 const SX1276_RSSI_OFFSET_HF: i16 = -157;
 const SX1276_RF_MID_BAND_THRESH: u32 = 525_000_000;
@@ -549,8 +550,6 @@ where
     }
 
     async fn get_rx_packet_status(&mut self) -> Result<PacketStatus, RadioError> {
-        // TODO: Fix for sx1272
-
         let snr = {
             let packet_snr = self.read_register(Register::RegPktSnrValue).await?;
             packet_snr as i8 as i16 / 4
@@ -559,18 +558,23 @@ where
         let rssi = {
             let packet_rssi = self.read_register(Register::RegPktRssiValue).await?;
 
-            let frequency_in_hz = {
-                let msb = self.read_register(Register::RegFrfMsb).await? as u32;
-                let mid = self.read_register(Register::RegFrfMid).await? as u32;
-                let lsb = self.read_register(Register::RegFrfLsb).await? as u32;
-                let frf = (msb << 16) + (mid << 8) + lsb;
-                (frf as f64 * FREQUENCY_SYNTHESIZER_STEP) as u32
-            };
+            let rssi_offset = match self.config.chip {
+                Sx127xVariant::Sx1272 => SX1272_RSSI_OFFSET,
+                Sx127xVariant::Sx1276 => {
+                    let frequency_in_hz = {
+                        let msb = self.read_register(Register::RegFrfMsb).await? as u32;
+                        let mid = self.read_register(Register::RegFrfMid).await? as u32;
+                        let lsb = self.read_register(Register::RegFrfLsb).await? as u32;
+                        let frf = (msb << 16) + (mid << 8) + lsb;
+                        (frf as f64 * FREQUENCY_SYNTHESIZER_STEP) as u32
+                    };
 
-            let rssi_offset = if frequency_in_hz > SX1276_RF_MID_BAND_THRESH {
-                SX1276_RSSI_OFFSET_HF
-            } else {
-                SX1276_RSSI_OFFSET_LF
+                    if frequency_in_hz > SX1276_RF_MID_BAND_THRESH {
+                        SX1276_RSSI_OFFSET_HF
+                    } else {
+                        SX1276_RSSI_OFFSET_LF
+                    }
+                }
             };
 
             if snr >= 0 {

--- a/lora-phy/src/sx1276_7_8_9/mod.rs
+++ b/lora-phy/src/sx1276_7_8_9/mod.rs
@@ -549,6 +549,8 @@ where
     }
 
     async fn get_rx_packet_status(&mut self) -> Result<PacketStatus, RadioError> {
+        // TODO: Fix for sx1272
+
         let snr = {
             let packet_snr = self.read_register(Register::RegPktSnrValue).await?;
             packet_snr as i8 as i16 / 4


### PR DESCRIPTION
Fix snr and rssi calculation according to the [datasheet](https://semtech.my.salesforce.com/sfc/p/#E0000000JelG/a/2R0000001Rbr/6EfVZUorrpoKFfvaF_Fkpgp5kzjiNyiAbqcpqh9qSjE) and [an implementation by Semtech](https://os.mbed.com/teams/Semtech/code/SX1276Lib//file/737e89f8d4f3/sx1276/sx1276.cpp/) in cpp:

* Casts packet_snr as i8 before as i16 to maintain the sign then divides it by 4.
* Takes snr and frf into account to calc rssi.