### PR TITLE
Use RadioMode as source of truth for the device

### DIFF
--- a/lora-phy/src/mod_params.rs
+++ b/lora-phy/src/mod_params.rs
@@ -48,19 +48,14 @@ pub enum RadioMode {
     /// Transmit (TX) mode
     Transmit,
     /// Receive (RX) mode
-    Receive,
-    /// Receive duty cycle mode
-    ReceiveDutyCycle,
+    Receive(RxMode),
     /// Channel activity detection (CAD) mode
     ChannelActivityDetection,
 }
 
 impl From<RxMode> for RadioMode {
-    fn from(rxmode: RxMode) -> Self {
-        match rxmode {
-            RxMode::Single(_) | RxMode::Continuous => Self::Receive,
-            RxMode::DutyCycle(_) => Self::ReceiveDutyCycle,
-        }
+    fn from(rx_mode: RxMode) -> Self {
+        RadioMode::Receive(rx_mode)
     }
 }
 

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -122,7 +122,6 @@ pub trait RadioKind {
         &mut self,
         radio_mode: RadioMode,
         cad_activity_detected: Option<&mut bool>,
-        rx_continuous: bool,
         clear_interrupts: bool,
     ) -> Result<Option<TargetIrqState>, RadioError>;
 }

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -861,7 +861,6 @@ where
         &mut self,
         radio_mode: RadioMode,
         cad_activity_detected: Option<&mut bool>,
-        rx_continuous: bool,
         clear_interrupts: bool,
     ) -> Result<Option<TargetIrqState>, RadioError> {
         let op_code = [OpCode::GetIrqStatus.value()];
@@ -906,7 +905,7 @@ where
                     return Err(RadioError::TransmitTimeout);
                 }
             }
-            RadioMode::Receive(_) => {
+            RadioMode::Receive(rx_mode) => {
                 if (irq_flags & IrqMask::HeaderError.value()) == IrqMask::HeaderError.value() {
                     debug!("HeaderError in radio mode {}", radio_mode);
                 }
@@ -915,7 +914,7 @@ where
                 }
                 if (irq_flags & IrqMask::RxDone.value()) == IrqMask::RxDone.value() {
                     debug!("RxDone in radio mode {}", radio_mode);
-                    if !rx_continuous {
+                    if rx_mode != RxMode::Continuous {
                         // implicit header mode timeout behavior (see DS_SX1261-2_V1.2 datasheet chapter 15.3)
                         let register_and_clear = [
                             OpCode::WriteRegister.value(),

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -684,8 +684,6 @@ where
         &mut self,
         radio_mode: RadioMode,
         cad_activity_detected: Option<&mut bool>,
-        // Not needed for sx127x
-        _rx_continuous: bool,
         clear_interrupts: bool,
     ) -> Result<Option<TargetIrqState>, RadioError> {
         let irq_flags = self.read_register(Register::RegIrqFlags).await?;

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -604,7 +604,7 @@ where
 
                 self.write_register(Register::RegIrqFlags, 0x00u8).await?;
             }
-            Some(RadioMode::Receive) => {
+            Some(RadioMode::Receive(_)) => {
                 self.write_register(
                     Register::RegIrqFlagsMask,
                     IrqMask::All.value()
@@ -700,7 +700,7 @@ where
                     return Ok(Some(TargetIrqState::Done));
                 }
             }
-            RadioMode::Receive => {
+            RadioMode::Receive(RxMode::Continuous) | RadioMode::Receive(RxMode::Single(_)) => {
                 if (irq_flags & IrqMask::RxDone.value()) == IrqMask::RxDone.value() {
                     debug!("RxDone in radio mode {}", radio_mode);
                     return Ok(Some(TargetIrqState::Done));
@@ -729,7 +729,8 @@ where
             RadioMode::Sleep | RadioMode::Standby => {
                 defmt::warn!("IRQ during sleep/standby?");
             }
-            RadioMode::FrequencySynthesis | RadioMode::ReceiveDutyCycle => todo!(),
+            RadioMode::FrequencySynthesis => todo!(),
+            RadioMode::Receive(RxMode::DutyCycle(_)) => todo!(),
         }
 
         // If no specific IRQ condition is met, return None


### PR DESCRIPTION
by making RxMode part of RadioMode::Receive we don't need to have rx_continuous as a state in the LoRa struct.

rx_continuous does not make sense if the RadioMode is other than Receive so this change makes it clearer what is going on.