### PR TITLE
move rx_boost and tx_boost to RadioKind config

### DIFF
--- a/examples/nrf52840/src/bin/lora_cad.rs
+++ b/examples/nrf52840/src/bin/lora_cad.rs
@@ -43,6 +43,7 @@ async fn main(_spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
     let mut lora = LoRa::new(Sx126x::new(spi, iv, config), false, Delay).await.unwrap();
@@ -69,7 +70,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.prepare_for_cad(&mdltn_params, true).await {
+    match lora.prepare_for_cad(&mdltn_params).await {
         Ok(()) => {}
         Err(err) => {
             info!("Radio error = {}", err);

--- a/examples/nrf52840/src/bin/lora_lorawan.rs
+++ b/examples/nrf52840/src/bin/lora_lorawan.rs
@@ -59,6 +59,7 @@ async fn main(_spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
     let lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();

--- a/examples/nrf52840/src/bin/lora_p2p_receive.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive.rs
@@ -43,6 +43,7 @@ async fn main(_spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
     let mut lora = LoRa::new(Sx126x::new(spi, iv, config), false, Delay).await.unwrap();
@@ -82,7 +83,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params)
         .await
     {
         Ok(()) => {}

--- a/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
@@ -43,6 +43,7 @@ async fn main(_spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
     let mut lora = LoRa::new(Sx126x::new(spi, iv, config), false, Delay).await.unwrap();
@@ -90,7 +91,6 @@ async fn main(_spawner: Spawner) {
             }),
             &mdltn_params,
             &rx_pkt_params,
-            false,
         )
         .await
     {

--- a/examples/nrf52840/src/bin/lora_p2p_send.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_send.rs
@@ -43,6 +43,7 @@ async fn main(_spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
     let mut lora = LoRa::new(Sx126x::new(spi, iv, config), false, Delay).await.unwrap();
@@ -72,7 +73,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.prepare_for_tx(&mdltn_params, 20, false).await {
+    match lora.prepare_for_tx(&mdltn_params, 20).await {
         Ok(()) => {}
         Err(err) => {
             info!("Radio error = {}", err);

--- a/examples/rp/src/bin/lora_lorawan.rs
+++ b/examples/rp/src/bin/lora_lorawan.rs
@@ -12,7 +12,7 @@ use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
 use lora_phy::lorawan_radio::LorawanRadio;
-use lora_phy::sx126x::{self, Sx126xVariant, TcxoCtrlVoltage, Sx126x};
+use lora_phy::sx126x::{self, Sx126x, Sx126xVariant, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
@@ -48,6 +48,7 @@ async fn main(_spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, None, None).unwrap();
     let lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();

--- a/examples/rp/src/bin/lora_p2p_receive.rs
+++ b/examples/rp/src/bin/lora_p2p_receive.rs
@@ -11,7 +11,7 @@ use embassy_rp::spi::{Config, Spi};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
-use lora_phy::sx126x::{Sx126xVariant, TcxoCtrlVoltage, Sx126x};
+use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
 use lora_phy::{mod_params::*, sx126x};
 use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
@@ -43,6 +43,7 @@ async fn main(_spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, None, None).unwrap();
     let mut lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();
@@ -77,7 +78,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params)
         .await
     {
         Ok(()) => {}

--- a/examples/rp/src/bin/lora_p2p_send.rs
+++ b/examples/rp/src/bin/lora_p2p_send.rs
@@ -11,7 +11,7 @@ use embassy_rp::spi::{Config, Spi};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
-use lora_phy::sx126x::{Sx126xVariant, TcxoCtrlVoltage, Sx126x};
+use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx126x};
 use {defmt_rtt as _, panic_probe as _};
@@ -43,6 +43,7 @@ async fn main(_spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, None, None).unwrap();
     let mut lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();
@@ -72,7 +73,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.prepare_for_tx(&mdltn_params, 20, false).await {
+    match lora.prepare_for_tx(&mdltn_params, 20).await {
         Ok(()) => {}
         Err(err) => {
             info!("Radio error = {}", err);

--- a/examples/rp/src/bin/lora_p2p_send_multicore.rs
+++ b/examples/rp/src/bin/lora_p2p_send_multicore.rs
@@ -15,7 +15,7 @@ use embassy_sync::channel::Channel;
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
-use lora_phy::sx126x::{Sx126xVariant, TcxoCtrlVoltage, Sx126x};
+use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx126x};
 use static_cell::StaticCell;
@@ -80,6 +80,7 @@ async fn core1_task(
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let mut lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();
 
@@ -110,7 +111,7 @@ async fn core1_task(
 
     loop {
         let buffer: [u8; 3] = CHANNEL.receive().await;
-        match lora.prepare_for_tx(&mdltn_params, 20, false).await {
+        match lora.prepare_for_tx(&mdltn_params, 20).await {
             Ok(()) => {}
             Err(err) => {
                 info!("Radio error = {}", err);

--- a/examples/stm32l0/src/bin/lora_cad.rs
+++ b/examples/stm32l0/src/bin/lora_cad.rs
@@ -12,7 +12,7 @@ use embassy_stm32::time::khz;
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
-use lora_phy::sx127x::{Sx127xVariant, Sx127x};
+use lora_phy::sx127x::{Sx127x, Sx127xVariant};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx127x};
 use {defmt_rtt as _, panic_probe as _};
@@ -39,11 +39,11 @@ async fn main(_spawner: Spawner) {
     let config = sx127x::Config {
         chip: Sx127xVariant::Sx1276,
         tcxo_used: true,
+        rx_boost: true,
+        tx_boost: false,
     };
     let iv = GenericSx127xInterfaceVariant::new(reset, irq, None, None).unwrap();
-    let mut lora = LoRa::new(Sx127x::new(spi, iv, config), false, Delay)
-        .await
-        .unwrap();
+    let mut lora = LoRa::new(Sx127x::new(spi, iv, config), false, Delay).await.unwrap();
 
     let mut debug_indicator = Output::new(p.PB5, Level::Low, Speed::Low);
     let mut start_indicator = Output::new(p.PB6, Level::Low, Speed::Low);
@@ -67,7 +67,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.prepare_for_cad(&mdltn_params, true).await {
+    match lora.prepare_for_cad(&mdltn_params).await {
         Ok(()) => {}
         Err(err) => {
             info!("Radio error = {}", err);

--- a/examples/stm32l0/src/bin/lora_lorawan.rs
+++ b/examples/stm32l0/src/bin/lora_lorawan.rs
@@ -14,7 +14,7 @@ use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
 use lora_phy::lorawan_radio::LorawanRadio;
-use lora_phy::sx127x::{self, Sx127xVariant, Sx127x};
+use lora_phy::sx127x::{self, Sx127x, Sx127xVariant};
 use lora_phy::LoRa;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
@@ -49,11 +49,11 @@ async fn main(_spawner: Spawner) {
     let config = sx127x::Config {
         chip: Sx127xVariant::Sx1276,
         tcxo_used: true,
+        rx_boost: false,
+        tx_boost: false,
     };
     let iv = GenericSx127xInterfaceVariant::new(reset, irq, None, None).unwrap();
-    let lora = LoRa::new(Sx127x::new(spi, iv, config), true, Delay)
-        .await
-        .unwrap();
+    let lora = LoRa::new(Sx127x::new(spi, iv, config), true, Delay).await.unwrap();
 
     let radio: LorawanRadio<_, _, MAX_TX_POWER> = lora.into();
     let region: region::Configuration = region::Configuration::new(LORAWAN_REGION);

--- a/examples/stm32l0/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_receive.rs
@@ -12,7 +12,7 @@ use embassy_stm32::time::khz;
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
-use lora_phy::sx127x::{Sx127xVariant, Sx127x};
+use lora_phy::sx127x::{Sx127x, Sx127xVariant};
 use lora_phy::{mod_params::*, sx127x};
 use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
@@ -39,11 +39,11 @@ async fn main(_spawner: Spawner) {
     let config = sx127x::Config {
         chip: Sx127xVariant::Sx1276,
         tcxo_used: true,
+        rx_boost: false,
+        tx_boost: false,
     };
     let iv = GenericSx127xInterfaceVariant::new(reset, irq, None, None).unwrap();
-    let mut lora = LoRa::new(Sx127x::new(spi, iv, config), false, Delay)
-        .await
-        .unwrap();
+    let mut lora = LoRa::new(Sx127x::new(spi, iv, config), false, Delay).await.unwrap();
 
     let mut debug_indicator = Output::new(p.PB5, Level::Low, Speed::Low);
     let mut start_indicator = Output::new(p.PB6, Level::Low, Speed::Low);
@@ -80,7 +80,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params)
         .await
     {
         Ok(()) => {}

--- a/examples/stm32l0/src/bin/lora_p2p_send.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_send.rs
@@ -12,7 +12,7 @@ use embassy_stm32::time::khz;
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
-use lora_phy::sx127x::{Sx127xVariant, Sx127x};
+use lora_phy::sx127x::{Sx127x, Sx127xVariant};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx127x};
 use {defmt_rtt as _, panic_probe as _};
@@ -39,11 +39,11 @@ async fn main(_spawner: Spawner) {
     let config = sx127x::Config {
         chip: Sx127xVariant::Sx1276,
         tcxo_used: true,
+        rx_boost: false,
+        tx_boost: true,
     };
     let iv = GenericSx127xInterfaceVariant::new(reset, irq, None, None).unwrap();
-    let mut lora = LoRa::new(Sx127x::new(spi, iv, config), false, Delay)
-        .await
-        .unwrap();
+    let mut lora = LoRa::new(Sx127x::new(spi, iv, config), false, Delay).await.unwrap();
 
     let mdltn_params = {
         match lora.create_modulation_params(
@@ -70,7 +70,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.prepare_for_tx(&mdltn_params, 17, true).await {
+    match lora.prepare_for_tx(&mdltn_params, 17).await {
         Ok(()) => {}
         Err(err) => {
             info!("Radio error = {}", err);

--- a/examples/stm32wl/src/bin/lora_lorawan.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan.rs
@@ -15,7 +15,7 @@ use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, peripherals};
 use embassy_time::Delay;
 use lora_phy::lorawan_radio::LorawanRadio;
-use lora_phy::sx126x::{self, Sx126xVariant, TcxoCtrlVoltage, Sx126x};
+use lora_phy::sx126x::{self, Sx126x, Sx126xVariant, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
@@ -68,6 +68,7 @@ async fn main(_spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
     let lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();

--- a/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
@@ -23,7 +23,7 @@ use embassy_sync::{
 use embassy_time::Delay;
 
 use lora_phy::lorawan_radio::LorawanRadio;
-use lora_phy::sx126x::{self, Sx126xVariant, TcxoCtrlVoltage, Sx126x};
+use lora_phy::sx126x::{self, Sx126x, Sx126xVariant, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lorawan_device::async_device::{Device, EmbassyTimer, JoinMode, JoinResponse, SendResponse};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
@@ -80,6 +80,7 @@ async fn main(spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: false,
+        rx_boost: false,
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
     let lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();

--- a/examples/stm32wl/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_receive.rs
@@ -13,7 +13,7 @@ use embassy_stm32::gpio::{Level, Output, Pin, Speed};
 use embassy_stm32::spi::Spi;
 use embassy_stm32::time::Hertz;
 use embassy_time::{Delay, Timer};
-use lora_phy::sx126x::{Sx126xVariant, TcxoCtrlVoltage, Sx126x};
+use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
 use lora_phy::{mod_params::*, sx126x};
 use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
@@ -61,6 +61,7 @@ async fn main(_spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
     let mut lora = LoRa::new(Sx126x::new(spi, iv, config), false, Delay).await.unwrap();
@@ -100,7 +101,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params, false)
+        .prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params)
         .await
     {
         Ok(()) => {}

--- a/examples/stm32wl/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_send.rs
@@ -13,7 +13,7 @@ use embassy_stm32::gpio::{Level, Output, Pin, Speed};
 use embassy_stm32::spi::Spi;
 use embassy_stm32::time::Hertz;
 use embassy_time::Delay;
-use lora_phy::sx126x::{Sx126xVariant, TcxoCtrlVoltage, Sx126x};
+use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx126x};
 use {defmt_rtt as _, panic_probe as _};
@@ -61,6 +61,7 @@ async fn main(_spawner: Spawner) {
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         use_dio2_as_rfswitch: true,
+        rx_boost: false,
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
     let mut lora = LoRa::new(Sx126x::new(spi, iv, config), false, Delay).await.unwrap();
@@ -90,7 +91,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.prepare_for_tx(&mdltn_params, 20, false).await {
+    match lora.prepare_for_tx(&mdltn_params, 20).await {
         Ok(()) => {}
         Err(err) => {
             info!("Radio error = {}", err);

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -106,9 +106,7 @@ where
             .lora
             .create_tx_packet_params(8, false, true, false, &mdltn_params)?;
 
-        // TODO: 3rd argument (boost_if_possible) shouldn't be exposed, as it depends
-        // on physical board layout. Needs to be eventually handled from lora-phy side.
-        self.lora.prepare_for_tx(&mdltn_params, config.pw.into(), false).await?;
+        self.lora.prepare_for_tx(&mdltn_params, config.pw.into()).await?;
         self.lora
             .tx(&mdltn_params, &mut tx_pkt_params, buffer, 0xffffff)
             .await?;
@@ -126,12 +124,7 @@ where
             .lora
             .create_rx_packet_params(8, false, 255, true, true, &mdltn_params)?;
         self.lora
-            .prepare_for_rx(
-                RxMode::from(config.mode, config.rf.bb),
-                &mdltn_params,
-                &rx_pkt_params,
-                false,
-            )
+            .prepare_for_rx(RxMode::from(config.mode, config.rf.bb), &mdltn_params, &rx_pkt_params)
             .await?;
         self.rx_pkt_params = Some(rx_pkt_params);
         Ok(())

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -79,7 +79,6 @@ pub trait RadioKind {
         &mut self,
         output_power: i32,
         mdltn_params: Option<&ModulationParams>,
-        tx_boosted_if_possible: bool,
         is_tx_prep: bool,
     ) -> Result<(), RadioError>;
     /// Set the LoRa chip modulation parameters prior to using a communication channel
@@ -95,7 +94,7 @@ pub trait RadioKind {
     /// Perform a send operation
     async fn do_tx(&mut self, timeout_in_ms: u32) -> Result<(), RadioError>;
     /// Set up to perform a receive operation (single-shot, continuous, or duty cycle)
-    async fn do_rx(&mut self, rx_mode: RxMode, rx_boost: bool) -> Result<(), RadioError>;
+    async fn do_rx(&mut self, rx_mode: RxMode) -> Result<(), RadioError>;
     /// Get an available packet made available as the result of a receive operation
     async fn get_rx_payload(
         &mut self,
@@ -105,11 +104,7 @@ pub trait RadioKind {
     /// Get the RSSI and SNR for the packet made available as the result of a receive operation
     async fn get_rx_packet_status(&mut self) -> Result<PacketStatus, RadioError>;
     /// Perform a channel activity detection operation
-    async fn do_cad(
-        &mut self,
-        mdltn_params: &ModulationParams,
-        rx_boosted_if_supported: bool,
-    ) -> Result<(), RadioError>;
+    async fn do_cad(&mut self, mdltn_params: &ModulationParams) -> Result<(), RadioError>;
     /// Set the LoRa chip to provide notification of specific events based on radio state
     async fn set_irq_params(&mut self, radio_mode: Option<RadioMode>) -> Result<(), RadioError>;
     /// Set the LoRa chip into the TxContinuousWave mode

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -45,7 +45,8 @@ pub struct Config {
     pub chip: Sx127xVariant,
     /// Whether board is using crystal oscillator or external clock
     pub tcxo_used: bool,
-    /// Whether to boost transmit
+    /// Whether to use PA_BOOST for transmit instead of RFO (sx1272) or RFO_LF (sx1276).
+    /// NB! Depends on board layout.
     pub tx_boost: bool,
     /// Whether to boost receive
     pub rx_boost: bool,


### PR DESCRIPTION
This change simplifies the API and removes parameters that does nothing (ex tx_boost does not exist on sx126x). In the future this could be expressed as gain or whatever makes sense for the used module but to keep the scope of this PR small this will do for now.