### PR TITLE
Add cache to github actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Check formatting
         run: cargo fmt  -- --check
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.5.0


### PR DESCRIPTION
...and bump actions/checkout from v2 -> v4.

Caching seems to cut ~30s from repeat runs.