### PR TITLE
lora-phy: Drop the timeout_in_ms argument for tx()

### DIFF
--- a/examples/nrf52840/src/bin/lora_p2p_send.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_send.rs
@@ -86,7 +86,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.tx(0xffffff).await {
+    match lora.tx().await {
         Ok(()) => {
             info!("TX DONE");
         }

--- a/examples/rp/src/bin/lora_p2p_send.rs
+++ b/examples/rp/src/bin/lora_p2p_send.rs
@@ -86,7 +86,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.tx(0xffffff).await {
+    match lora.tx().await {
         Ok(()) => {
             info!("TX DONE");
         }

--- a/examples/rp/src/bin/lora_p2p_send_multicore.rs
+++ b/examples/rp/src/bin/lora_p2p_send_multicore.rs
@@ -122,7 +122,7 @@ async fn core1_task(
             }
         };
 
-        match lora.tx(0xffffff).await {
+        match lora.tx().await {
             Ok(()) => {
                 info!("TX DONE");
             }

--- a/examples/stm32l0/src/bin/lora_p2p_send.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_send.rs
@@ -83,7 +83,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.tx(0xffffff).await {
+    match lora.tx().await {
         Ok(()) => {
             info!("TX DONE");
         }

--- a/examples/stm32wl/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_send.rs
@@ -103,7 +103,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.tx(0xffffff).await {
+    match lora.tx().await {
         Ok(()) => {
             info!("TX DONE");
         }

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -192,9 +192,9 @@ where
     }
 
     /// Execute a send operation
-    pub async fn tx(&mut self, timeout_in_ms: u32) -> Result<(), RadioError> {
+    pub async fn tx(&mut self) -> Result<(), RadioError> {
         if let RadioMode::Transmit = self.radio_mode {
-            self.radio_kind.do_tx(timeout_in_ms).await?;
+            self.radio_kind.do_tx().await?;
             self.wait_for_irq().await?;
             match self.radio_kind.process_irq_event(self.radio_mode, None, true).await {
                 Ok(Some(TargetIrqState::Done | TargetIrqState::PreambleReceived)) => {

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -109,7 +109,7 @@ where
         self.lora
             .prepare_for_tx(&mdltn_params, &mut tx_pkt_params, config.pw.into(), buffer)
             .await?;
-        self.lora.tx(0xffffff).await?;
+        self.lora.tx().await?;
         Ok(0)
     }
 

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -91,8 +91,8 @@ pub trait RadioKind {
     async fn set_channel(&mut self, frequency_in_hz: u32) -> Result<(), RadioError>;
     /// Set a payload for a subsequent send operation
     async fn set_payload(&mut self, payload: &[u8]) -> Result<(), RadioError>;
-    /// Perform a send operation
-    async fn do_tx(&mut self, timeout_in_ms: u32) -> Result<(), RadioError>;
+    /// Perform a transmit operation
+    async fn do_tx(&mut self) -> Result<(), RadioError>;
     /// Set up to perform a receive operation (single-shot, continuous, or duty cycle)
     async fn do_rx(&mut self, rx_mode: RxMode) -> Result<(), RadioError>;
     /// Get an available packet made available as the result of a receive operation

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -629,16 +629,17 @@ where
         self.intf.write_with_payload(&op_code_and_offset, payload, false).await
     }
 
-    async fn do_tx(&mut self, timeout_in_ms: u32) -> Result<(), RadioError> {
+    async fn do_tx(&mut self) -> Result<(), RadioError> {
         self.intf.iv.enable_rf_switch_tx().await?;
 
-        let op_code_and_timeout = [
+        // Disable timeout
+        let cmd = [
             OpCode::SetTx.value(),
-            Self::timeout_1(timeout_in_ms),
-            Self::timeout_2(timeout_in_ms),
-            Self::timeout_3(timeout_in_ms),
+            Self::timeout_1(0),
+            Self::timeout_2(0),
+            Self::timeout_3(0),
         ];
-        self.intf.write(&op_code_and_timeout, false).await
+        self.intf.write(&cmd, false).await
     }
 
     async fn do_rx(&mut self, rx_mode: RxMode) -> Result<(), RadioError> {

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -485,7 +485,7 @@ where
             .await
     }
 
-    async fn do_tx(&mut self, _timeout_in_ms: u32) -> Result<(), RadioError> {
+    async fn do_tx(&mut self) -> Result<(), RadioError> {
         self.intf.iv.enable_rf_switch_tx().await?;
 
         self.write_register(Register::RegOpMode, LoRaMode::Tx.value()).await


### PR DESCRIPTION
Firstly, this argument aws unused for sx127x radios, and on sx126x radios it wasn't in milliseconds, instead each unit was 15.625us.

On sx126x timeout can be used as safety net to ensure that if Tx is aborted or does not succeed (TxDone IRQ never triggers), radio will trigger TxTimeout. But value given for the timeout should be calculated for a given packet size, given modulation and packet parameters.

Therefore in our case where we just pushed maximum value of 262s, it was used wrongly anyway.

If really needed, we could introduce optional `tx_with_timeout()` method.