### PR TITLE
allow process_irq_event to continue on RFU

### DIFF
--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -21,20 +21,11 @@ pub trait InterfaceVariant {
 
 /// Specifies an IRQ processing state to run the loop to
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum TargetIrqState {
+pub enum IrqState {
     /// Runs the loop until after the preamble has been received
     PreambleReceived,
     /// Runs the loop until the operation is fully complete
     Done,
-}
-
-/// An actual operation state, including some details where necessary
-#[derive(Clone, Copy)]
-pub enum IrqState {
-    /// Preamble has been received
-    PreambleReceived,
-    /// The RX operation is complete
-    RxDone(u8, PacketStatus),
 }
 
 /// Functions implemented for a specific kind of LoRa chip, called internally by the outward facing
@@ -118,5 +109,5 @@ pub trait RadioKind {
         radio_mode: RadioMode,
         cad_activity_detected: Option<&mut bool>,
         clear_interrupts: bool,
-    ) -> Result<Option<TargetIrqState>, RadioError>;
+    ) -> Result<Option<IrqState>, RadioError>;
 }

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -867,7 +867,7 @@ where
         let read_status = self.intf.read_with_status(&op_code, &mut irq_status).await?;
         let irq_flags = ((irq_status[0] as u16) << 8) | (irq_status[1] as u16);
 
-        if clear_interrupts {
+        if clear_interrupts && irq_flags != 0 {
             let op_code_and_irq_status = [OpCode::ClrIrqStatus.value(), irq_status[0], irq_status[1]];
             self.intf.write(&op_code_and_irq_status, false).await?;
         }


### PR DESCRIPTION
Stm32wl returns a lot of RFU events. These break both rx an tx.