### PR TITLE
lora-phy: refactor sx127x to have chip trait instead of enum

### DIFF
--- a/examples/stm32l0/src/bin/lora_cad.rs
+++ b/examples/stm32l0/src/bin/lora_cad.rs
@@ -12,7 +12,7 @@ use embassy_stm32::time::khz;
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
-use lora_phy::sx127x::{Sx127x, Sx127xVariant};
+use lora_phy::sx127x::{Sx127x, Sx1276};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx127x};
 use {defmt_rtt as _, panic_probe as _};
@@ -37,7 +37,7 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spi, nss, Delay);
 
     let config = sx127x::Config {
-        chip: Sx127xVariant::Sx1276,
+        chip: Sx1276,
         tcxo_used: true,
         rx_boost: true,
         tx_boost: false,

--- a/examples/stm32l0/src/bin/lora_lorawan.rs
+++ b/examples/stm32l0/src/bin/lora_lorawan.rs
@@ -14,7 +14,7 @@ use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
 use lora_phy::lorawan_radio::LorawanRadio;
-use lora_phy::sx127x::{self, Sx127x, Sx127xVariant};
+use lora_phy::sx127x::{self, Sx127x, Sx1276};
 use lora_phy::LoRa;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
@@ -47,7 +47,7 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spi, nss, Delay);
 
     let config = sx127x::Config {
-        chip: Sx127xVariant::Sx1276,
+        chip: Sx1276,
         tcxo_used: true,
         rx_boost: false,
         tx_boost: false,

--- a/examples/stm32l0/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_receive.rs
@@ -12,7 +12,7 @@ use embassy_stm32::time::khz;
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
-use lora_phy::sx127x::{Sx127x, Sx127xVariant};
+use lora_phy::sx127x::{Sx127x, Sx1276};
 use lora_phy::{mod_params::*, sx127x};
 use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
@@ -37,7 +37,7 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spi, nss, Delay);
 
     let config = sx127x::Config {
-        chip: Sx127xVariant::Sx1276,
+        chip: Sx1276,
         tcxo_used: true,
         rx_boost: false,
         tx_boost: false,

--- a/examples/stm32l0/src/bin/lora_p2p_send.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_send.rs
@@ -12,7 +12,7 @@ use embassy_stm32::time::khz;
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
-use lora_phy::sx127x::{Sx127x, Sx127xVariant};
+use lora_phy::sx127x::{Sx127x, Sx1276};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx127x};
 use {defmt_rtt as _, panic_probe as _};
@@ -37,7 +37,7 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spi, nss, Delay);
 
     let config = sx127x::Config {
-        chip: Sx127xVariant::Sx1276,
+        chip: Sx1276,
         tcxo_used: true,
         rx_boost: false,
         tx_boost: true,

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -1,4 +1,8 @@
 mod radio_kind_params;
+mod sx1272;
+pub use sx1272::Sx1272;
+mod sx1276;
+pub use sx1276::Sx1276;
 
 use defmt::debug;
 use embedded_hal_async::delay::DelayNs;
@@ -29,20 +33,10 @@ const SX1276_RSSI_OFFSET_LF: i16 = -164;
 const SX1276_RSSI_OFFSET_HF: i16 = -157;
 const SX1276_RF_MID_BAND_THRESH: u32 = 525_000_000;
 
-/// Supported SX127x chip variants
-#[derive(Clone, Copy)]
-pub enum Sx127xVariant {
-    /// Semtech SX1272
-    Sx1272,
-    /// Semtech SX1276
-    // TODO: should we add variants for 77, 78 and 79 as well?)
-    Sx1276,
-}
-
 /// Configuration for SX127x-based boards
-pub struct Config {
+pub struct Config<C: Sx127xVariant> {
     /// LoRa chip used on specific board
-    pub chip: Sx127xVariant,
+    pub chip: C,
     /// Whether board is using crystal oscillator or external clock
     pub tcxo_used: bool,
     /// Whether to use PA_BOOST for transmit instead of RFO (sx1272) or RFO_LF (sx1276).
@@ -53,18 +47,19 @@ pub struct Config {
 }
 
 /// Base for the RadioKind implementation for the LoRa chip kind and board type
-pub struct Sx127x<SPI, IV> {
+pub struct Sx127x<SPI, IV, C: Sx127xVariant + Sized> {
     intf: SpiInterface<SPI, IV>,
-    config: Config,
+    config: Config<C>,
 }
 
-impl<SPI, IV> Sx127x<SPI, IV>
+impl<SPI, IV, C> Sx127x<SPI, IV, C>
 where
     SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
+    C: Sx127xVariant,
 {
     /// Create an instance of the RadioKind implementation for the LoRa chip kind and board type
-    pub fn new(spi: SPI, iv: IV, config: Config) -> Self {
+    pub fn new(spi: SPI, iv: IV, config: Config<C>) -> Self {
         let intf = SpiInterface::new(spi, iv);
         Self { intf, config }
     }
@@ -106,99 +101,17 @@ where
     async fn set_ocp(&mut self, ocp_trim: OcpTrim) -> Result<(), RadioError> {
         self.write_register(Register::RegOcp, ocp_trim.value()).await
     }
-
-    /// TODO: tx_boost depends on following:
-    /// a) board configuration
-    /// b) channel selection
-    /// c) other?
-    async fn set_tx_power_sx1272(&mut self, p_out: i32, tx_boost: bool) -> Result<(), RadioError> {
-        // SX1272 has two output pins:
-        // 1) RFO: (-1 to +14 dBm)
-        // 2) PA_BOOST: (+2 to +17 dBm and +5 to 20 +dBm)
-
-        // RegPaConfig - 0x32
-        // [7] - PaSelect (0: RFO, 1: PA_BOOST)
-        // [6:4] - Unused: 0
-        // [3:0] - Output power in dB steps
-
-        // RegPaDac - 0x5a (SX1272)
-        // [7:3] - Reserved (0x10 as default)
-        // [2:0] - PaDac: 0x04 default, 0x07 - enable +20 dBm on PA_BOOST
-
-        // TODO: Shall we also touch OCP settings?
-        if tx_boost {
-            // Deal with two ranges, +17dBm enables extra boost
-            if p_out > 17 {
-                // PA_BOOST out: +5 .. +20 dBm
-                let val = (p_out.min(20).max(5) - 5) as u8 & 0x0f;
-                self.write_register(Register::RegPaConfig, (1 << 7) | val).await?;
-                self.write_register(Register::RegPaDacSX1272, 0x87).await?;
-            } else {
-                // PA_BOOST out: +2 .. +17 dBm
-                let val = (p_out.min(17).max(2) - 2) as u8 & 0x0f;
-                self.write_register(Register::RegPaConfig, (1 << 7) | val).await?;
-                self.write_register(Register::RegPaDacSX1272, 0x84).await?;
-            }
-        } else {
-            // RFO out: -1 to +14 dBm
-            let val = (p_out.min(14).max(-1) + 1) as u8 & 0x0f;
-            self.write_register(Register::RegPaConfig, val).await?;
-            self.write_register(Register::RegPaDacSX1272, 0x84).await?;
-        }
-
-        Ok(())
-    }
-
-    async fn set_tx_power_sx1276(&mut self, p_out: i32, tx_boost: bool) -> Result<(), RadioError> {
-        let pa_reg = Register::RegPaDacSX1276;
-        if tx_boost {
-            // Output via PA_BOOST: [2, 20] dBm
-            let txp = p_out.min(20).max(2);
-
-            // Pout=17-(15-OutputPower)
-            let output_power: i32 = txp - 2;
-
-            if txp > 17 {
-                self.write_register(pa_reg, PaDac::_20DbmOn.value()).await?;
-                self.set_ocp(OcpTrim::_240Ma).await?;
-            } else {
-                self.write_register(pa_reg, PaDac::_20DbmOff.value()).await?;
-                self.set_ocp(OcpTrim::_100Ma).await?;
-            }
-            self.write_register(Register::RegPaConfig, PaConfig::PaBoost.value() | (output_power as u8))
-                .await?;
-        } else {
-            // Clamp output: [-4, 14] dBm
-            let txp = p_out.min(14).max(-4);
-
-            // Pmax=10.8+0.6*MaxPower, where MaxPower is set below as 7 and therefore Pmax is 15
-            // Pout=Pmax-(15-OutputPower)
-            let output_power: i32 = txp;
-
-            self.write_register(pa_reg, PaDac::_20DbmOff.value()).await?;
-            self.set_ocp(OcpTrim::_100Ma).await?;
-            self.write_register(
-                Register::RegPaConfig,
-                PaConfig::MaxPower7NoPaBoost.value() | (output_power as u8),
-            )
-            .await?;
-        }
-        Ok(())
-    }
 }
 
-impl<SPI, IV> RadioKind for Sx127x<SPI, IV>
+impl<SPI, IV, C> RadioKind for Sx127x<SPI, IV, C>
 where
     SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
+    C: Sx127xVariant,
 {
     async fn init_lora(&mut self, is_public_network: bool) -> Result<(), RadioError> {
         if self.config.tcxo_used {
-            let reg = match self.config.chip {
-                Sx127xVariant::Sx1272 => Register::RegTcxoSX1272,
-                Sx127xVariant::Sx1276 => Register::RegTcxoSX1276,
-            };
-            self.write_register(reg, TCXO_FOR_OSCILLATOR).await?;
+            self.write_register(C::reg_txco(), TCXO_FOR_OSCILLATOR).await?;
         }
 
         let syncword = if is_public_network {
@@ -222,7 +135,7 @@ where
         // Parameter validation
         spreading_factor_value(spreading_factor)?;
         coding_rate_value(coding_rate)?;
-        self.config.chip.bandwidth_value(bandwidth)?;
+        C::bandwidth_value(bandwidth)?;
         if ((bandwidth == Bandwidth::_250KHz) || (bandwidth == Bandwidth::_500KHz)) && (frequency_in_hz < 400_000_000) {
             return Err(RadioError::InvalidBandwidthForFrequency);
         }
@@ -319,33 +232,20 @@ where
         debug!("tx power = {}", p_out);
 
         // Configure tx power and boost
-        match self.config.chip {
-            Sx127xVariant::Sx1272 => self.set_tx_power_sx1272(p_out, self.config.tx_boost).await,
-            Sx127xVariant::Sx1276 => self.set_tx_power_sx1276(p_out, self.config.tx_boost).await,
-        }?;
+        C::set_tx_power(self, p_out, self.config.tx_boost).await?;
 
         let ramp_time = match is_tx_prep {
             true => RampTime::Ramp40Us,   // for instance, prior to TX or CAD
             false => RampTime::Ramp250Us, // for instance, on initialization
         };
-        // Handle chip-specific differences for RegPaRamp 0x0a:
-        // Sx1272 - default: 0x19
-        // [4]: LowPnTxPllOff - use higher power, lower phase noise PLL
-        //      only when the transmitter is used (default: 1)
-        //      0 - Standard PLL used in Rx mode, Lower PN PLL in Tx
-        //      1 - Standard PLL used in both Tx and Rx modes
-        // Sx1276 - default: 0x09
-        // [4]: reserved (0x00)
-        let val = match self.config.chip {
-            Sx127xVariant::Sx1272 => Ok(ramp_time.value() | (1 << 4)),
-            Sx127xVariant::Sx1276 => Ok(ramp_time.value()),
-        }?;
+
+        let val = C::ramp_value(ramp_time);
         self.write_register(Register::RegPaRamp, val).await
     }
 
     async fn set_modulation_params(&mut self, mdltn_params: &ModulationParams) -> Result<(), RadioError> {
         let sf_val = spreading_factor_value(mdltn_params.spreading_factor)?;
-        let bw_val = self.config.chip.bandwidth_value(mdltn_params.bandwidth)?;
+        let bw_val = C::bandwidth_value(mdltn_params.bandwidth)?;
         let coding_rate_denominator_val = coding_rate_denominator_value(mdltn_params.coding_rate)?;
         debug!(
             "sf = {}, bw = {}, cr_denom = {}",
@@ -363,41 +263,7 @@ where
         self.write_register(Register::RegDetectionThreshold, thr).await?;
         // Spreading Factor, Bandwidth, codingrate, ldro
 
-        match self.config.chip {
-            Sx127xVariant::Sx1272 => {
-                let cfg1 = self.read_register(Register::RegModemConfig1).await?;
-                let ldro = mdltn_params.low_data_rate_optimize;
-                let cr_val = coding_rate_value(mdltn_params.coding_rate)?;
-                let val = (cfg1 & 0b110) | (bw_val << 6) | (cr_val << 3) | ldro;
-                self.write_register(Register::RegModemConfig1, val).await?;
-                let cfg2 = self.read_register(Register::RegModemConfig2).await?;
-                let val = (cfg2 & 0b1111) | (sf_val << 4);
-                self.write_register(Register::RegModemConfig2, val).await?;
-                Ok(())
-            }
-            Sx127xVariant::Sx1276 => {
-                let mut config_2 = self.read_register(Register::RegModemConfig2).await?;
-                config_2 = (config_2 & 0x0fu8) | ((sf_val << 4) & 0xf0u8);
-                self.write_register(Register::RegModemConfig2, config_2).await?;
-
-                let mut config_1 = self.read_register(Register::RegModemConfig1).await?;
-                config_1 = (config_1 & 0x0fu8) | (bw_val << 4);
-                self.write_register(Register::RegModemConfig1, config_1).await?;
-
-                let cr = coding_rate_denominator_val - 4;
-                config_1 = self.read_register(Register::RegModemConfig1).await?;
-                config_1 = (config_1 & 0xf1u8) | (cr << 1);
-                self.write_register(Register::RegModemConfig1, config_1).await?;
-
-                let mut ldro_agc_auto_flags = 0x00u8; // LDRO and AGC Auto both off
-                if mdltn_params.low_data_rate_optimize != 0 {
-                    ldro_agc_auto_flags = 0x08u8; // LDRO on and AGC Auto off
-                }
-                let mut config_3 = self.read_register(Register::RegModemConfig3).await?;
-                config_3 = (config_3 & 0xf3u8) | ldro_agc_auto_flags;
-                self.write_register(Register::RegModemConfig3, config_3).await
-            }
-        }?;
+        C::set_modulation_params(self, mdltn_params).await?;
 
         Ok(())
     }
@@ -411,38 +277,7 @@ where
         self.write_register(Register::RegPreambleLsb, (pkt_params.preamble_length & 0x00ff) as u8)
             .await?;
 
-        // TODO: Payload length? (Set when pkt_params.implicit_header == true)?
-
-        let modemcfg1 = self.read_register(Register::RegModemConfig1).await?;
-
-        match self.config.chip {
-            Sx127xVariant::Sx1272 => {
-                let hdr = pkt_params.implicit_header as u8;
-                let crc = pkt_params.crc_on as u8;
-
-                let cfg1 = (modemcfg1 & 0b1111_1001) | (hdr << 2) | (crc << 1);
-                self.write_register(Register::RegModemConfig1, cfg1).await?;
-                Ok(())
-            }
-            Sx127xVariant::Sx1276 => {
-                let mut config_1 = modemcfg1;
-                if pkt_params.implicit_header {
-                    config_1 |= 0x01u8;
-                } else {
-                    config_1 &= 0xfeu8;
-                }
-                self.write_register(Register::RegModemConfig1, config_1).await?;
-
-                let mut config_2 = self.read_register(Register::RegModemConfig2).await?;
-                if pkt_params.crc_on {
-                    config_2 |= 0x04u8;
-                } else {
-                    config_2 &= 0xfbu8;
-                }
-                self.write_register(Register::RegModemConfig2, config_2).await?;
-                Ok(())
-            }
-        }?;
+        C::set_packet_params(self, pkt_params).await?;
 
         // IQ inversion:
         // RegInvertiq - [0x33]
@@ -545,24 +380,7 @@ where
         let rssi = {
             let packet_rssi = self.read_register(Register::RegPktRssiValue).await?;
 
-            let rssi_offset = match self.config.chip {
-                Sx127xVariant::Sx1272 => SX1272_RSSI_OFFSET,
-                Sx127xVariant::Sx1276 => {
-                    let frequency_in_hz = {
-                        let msb = self.read_register(Register::RegFrfMsb).await? as u32;
-                        let mid = self.read_register(Register::RegFrfMid).await? as u32;
-                        let lsb = self.read_register(Register::RegFrfLsb).await? as u32;
-                        let frf = (msb << 16) + (mid << 8) + lsb;
-                        (frf as f64 * FREQUENCY_SYNTHESIZER_STEP) as u32
-                    };
-
-                    if frequency_in_hz > SX1276_RF_MID_BAND_THRESH {
-                        SX1276_RSSI_OFFSET_HF
-                    } else {
-                        SX1276_RSSI_OFFSET_LF
-                    }
-                }
-            };
+            let rssi_offset = C::rssi_offset(self).await?;
 
             if snr >= 0 {
                 rssi_offset + (packet_rssi as f32 * 16.0 / 15.0) as i16
@@ -653,24 +471,6 @@ where
         Ok(())
     }
 
-    /// Set the LoRa chip into the TxContinuousWave mode
-    async fn set_tx_continuous_wave_mode(&mut self) -> Result<(), RadioError> {
-        match self.config.chip {
-            Sx127xVariant::Sx1272 => todo!(),
-            Sx127xVariant::Sx1276 => {
-                self.intf.iv.enable_rf_switch_rx().await?;
-                let pa_config = self.read_register(Register::RegPaConfig).await?;
-                let new_pa_config = pa_config | 0b1000_0000;
-                self.write_register(Register::RegPaConfig, new_pa_config).await?;
-                self.write_register(Register::RegOpMode, 0b1100_0011).await?;
-                let modem_config = self.read_register(Register::RegModemConfig2).await?;
-                let new_modem_config = modem_config | 0b0000_1000;
-                self.write_register(Register::RegModemConfig2, new_modem_config).await?;
-            }
-        }
-        Ok(())
-    }
-
     async fn await_irq(&mut self) -> Result<(), RadioError> {
         self.intf.iv.await_irq().await
     }
@@ -733,5 +533,9 @@ where
 
         // If no specific IRQ condition is met, return None
         Ok(None)
+    }
+    /// Set the LoRa chip into the TxContinuousWave mode
+    async fn set_tx_continuous_wave_mode(&mut self) -> Result<(), RadioError> {
+        C::set_tx_continuous_wave_mode(self).await
     }
 }

--- a/lora-phy/src/sx127x/sx1272.rs
+++ b/lora-phy/src/sx127x/sx1272.rs
@@ -1,0 +1,122 @@
+use crate::mod_params::{ModulationParams, PacketParams, RadioError};
+use crate::mod_traits::InterfaceVariant;
+use crate::sx127x::radio_kind_params::{coding_rate_value, spreading_factor_value, RampTime, Register, Sx127xVariant};
+use crate::sx127x::{Sx127x, SX1272_RSSI_OFFSET};
+use embedded_hal_async::spi::SpiDevice;
+use lora_modulation::Bandwidth;
+
+/// Sx1272 implements the Sx127xVariant trait
+pub struct Sx1272;
+
+impl Sx127xVariant for Sx1272 {
+    fn bandwidth_value(bw: Bandwidth) -> Result<u8, RadioError> {
+        match bw {
+            Bandwidth::_125KHz => Ok(0x00),
+            Bandwidth::_250KHz => Ok(0x01),
+            Bandwidth::_500KHz => Ok(0x02),
+            _ => Err(RadioError::UnavailableBandwidth),
+        }
+    }
+
+    fn reg_txco() -> Register {
+        Register::RegTcxoSX1272
+    }
+
+    async fn set_tx_power<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        radio: &mut Sx127x<SPI, IV, Self>,
+        p_out: i32,
+        tx_boost: bool,
+    ) -> Result<(), RadioError> {
+        // SX1272 has two output pins:
+        // 1) RFO: (-1 to +14 dBm)
+        // 2) PA_BOOST: (+2 to +17 dBm and +5 to 20 +dBm)
+
+        // RegPaConfig - 0x32
+        // [7] - PaSelect (0: RFO, 1: PA_BOOST)
+        // [6:4] - Unused: 0
+        // [3:0] - Output power in dB steps
+
+        // RegPaDac - 0x5a (SX1272)
+        // [7:3] - Reserved (0x10 as default)
+        // [2:0] - PaDac: 0x04 default, 0x07 - enable +20 dBm on PA_BOOST
+
+        // TODO: Shall we also touch OCP settings?
+        if tx_boost {
+            // Deal with two ranges, +17dBm enables extra boost
+            if p_out > 17 {
+                // PA_BOOST out: +5 .. +20 dBm
+                let val = (p_out.min(20).max(5) - 5) as u8 & 0x0f;
+                radio.write_register(Register::RegPaConfig, (1 << 7) | val).await?;
+                radio.write_register(Register::RegPaDacSX1272, 0x87).await?;
+            } else {
+                // PA_BOOST out: +2 .. +17 dBm
+                let val = (p_out.min(17).max(2) - 2) as u8 & 0x0f;
+                radio.write_register(Register::RegPaConfig, (1 << 7) | val).await?;
+                radio.write_register(Register::RegPaDacSX1272, 0x84).await?;
+            }
+        } else {
+            // RFO out: -1 to +14 dBm
+            let val = (p_out.min(14).max(-1) + 1) as u8 & 0x0f;
+            radio.write_register(Register::RegPaConfig, val).await?;
+            radio.write_register(Register::RegPaDacSX1272, 0x84).await?;
+        }
+
+        Ok(())
+    }
+
+    fn ramp_value(ramp_time: RampTime) -> u8 {
+        // Sx1272 - default: 0x19
+        // [4]: LowPnTxPllOff - use higher power, lower phase noise PLL
+        //      only when the transmitter is used (default: 1)
+        //      0 - Standard PLL used in Rx mode, Lower PN PLL in Tx
+        //      1 - Standard PLL used in both Tx and Rx modes
+        ramp_time.value() | (1 << 4)
+    }
+
+    async fn set_modulation_params<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        radio: &mut Sx127x<SPI, IV, Self>,
+        mdltn_params: &ModulationParams,
+    ) -> Result<(), RadioError> {
+        let bw_val = Self::bandwidth_value(mdltn_params.bandwidth)?;
+        let sf_val = spreading_factor_value(mdltn_params.spreading_factor)?;
+
+        let cfg1 = radio.read_register(Register::RegModemConfig1).await?;
+        let ldro = mdltn_params.low_data_rate_optimize;
+        let cr_val = coding_rate_value(mdltn_params.coding_rate)?;
+        let val = (cfg1 & 0b110) | (bw_val << 6) | (cr_val << 3) | ldro;
+        radio.write_register(Register::RegModemConfig1, val).await?;
+        let cfg2 = radio.read_register(Register::RegModemConfig2).await?;
+        let val = (cfg2 & 0b1111) | (sf_val << 4);
+        radio.write_register(Register::RegModemConfig2, val).await?;
+        Ok(())
+    }
+
+    async fn set_packet_params<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        radio: &mut Sx127x<SPI, IV, Self>,
+        pkt_params: &PacketParams,
+    ) -> Result<(), RadioError>
+    where
+        Self: Sized,
+    {
+        let modemcfg1 = radio.read_register(Register::RegModemConfig1).await?;
+
+        let hdr = pkt_params.implicit_header as u8;
+        let crc = pkt_params.crc_on as u8;
+
+        let cfg1 = (modemcfg1 & 0b1111_1001) | (hdr << 2) | (crc << 1);
+        radio.write_register(Register::RegModemConfig1, cfg1).await?;
+        Ok(())
+    }
+
+    async fn rssi_offset<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        _: &mut Sx127x<SPI, IV, Self>,
+    ) -> Result<i16, RadioError> {
+        Ok(SX1272_RSSI_OFFSET)
+    }
+
+    async fn set_tx_continuous_wave_mode<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        _: &mut Sx127x<SPI, IV, Self>,
+    ) -> Result<(), RadioError> {
+        todo!()
+    }
+}

--- a/lora-phy/src/sx127x/sx1276.rs
+++ b/lora-phy/src/sx127x/sx1276.rs
@@ -1,0 +1,170 @@
+use crate::mod_params::{ModulationParams, PacketParams, RadioError};
+use crate::mod_traits::InterfaceVariant;
+use crate::sx127x::radio_kind_params::{
+    coding_rate_denominator_value, spreading_factor_value, OcpTrim, PaConfig, PaDac, RampTime, Register, Sx127xVariant,
+};
+use crate::sx127x::{
+    Sx127x, FREQUENCY_SYNTHESIZER_STEP, SX1276_RF_MID_BAND_THRESH, SX1276_RSSI_OFFSET_HF, SX1276_RSSI_OFFSET_LF,
+};
+use embedded_hal_async::spi::SpiDevice;
+use lora_modulation::Bandwidth;
+
+/// Sx1276 implements the Sx127xVariant trait
+pub struct Sx1276;
+
+impl Sx127xVariant for Sx1276 {
+    fn bandwidth_value(bw: Bandwidth) -> Result<u8, RadioError> {
+        match bw {
+            Bandwidth::_7KHz => Ok(0x00),
+            Bandwidth::_10KHz => Ok(0x01),
+            Bandwidth::_15KHz => Ok(0x02),
+            Bandwidth::_20KHz => Ok(0x03),
+            Bandwidth::_31KHz => Ok(0x04),
+            Bandwidth::_41KHz => Ok(0x05),
+            Bandwidth::_62KHz => Ok(0x06),
+            Bandwidth::_125KHz => Ok(0x07),
+            Bandwidth::_250KHz => Ok(0x08),
+            Bandwidth::_500KHz => Ok(0x09),
+        }
+    }
+
+    fn reg_txco() -> Register {
+        Register::RegTcxoSX1276
+    }
+
+    async fn set_tx_power<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        radio: &mut Sx127x<SPI, IV, Self>,
+        p_out: i32,
+        tx_boost: bool,
+    ) -> Result<(), RadioError> {
+        let pa_reg = Register::RegPaDacSX1276;
+        if tx_boost {
+            // Output via PA_BOOST: [2, 20] dBm
+            let txp = p_out.min(20).max(2);
+
+            // Pout=17-(15-OutputPower)
+            let output_power: i32 = txp - 2;
+
+            if txp > 17 {
+                radio.write_register(pa_reg, PaDac::_20DbmOn.value()).await?;
+                radio.set_ocp(OcpTrim::_240Ma).await?;
+            } else {
+                radio.write_register(pa_reg, PaDac::_20DbmOff.value()).await?;
+                radio.set_ocp(OcpTrim::_100Ma).await?;
+            }
+            radio
+                .write_register(Register::RegPaConfig, PaConfig::PaBoost.value() | (output_power as u8))
+                .await?;
+        } else {
+            // Clamp output: [-4, 14] dBm
+            let txp = p_out.min(14).max(-4);
+
+            // Pmax=10.8+0.6*MaxPower, where MaxPower is set below as 7 and therefore Pmax is 15
+            // Pout=Pmax-(15-OutputPower)
+            let output_power: i32 = txp;
+
+            radio.write_register(pa_reg, PaDac::_20DbmOff.value()).await?;
+            radio.set_ocp(OcpTrim::_100Ma).await?;
+            radio
+                .write_register(
+                    Register::RegPaConfig,
+                    PaConfig::MaxPower7NoPaBoost.value() | (output_power as u8),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    fn ramp_value(ramp_time: RampTime) -> u8 {
+        // Sx1276 - default: 0x09
+        // [4]: reserved (0x00)
+        ramp_time as u8
+    }
+
+    async fn set_modulation_params<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        radio: &mut Sx127x<SPI, IV, Self>,
+        mdltn_params: &ModulationParams,
+    ) -> Result<(), RadioError> {
+        let bw_val = Self::bandwidth_value(mdltn_params.bandwidth)?;
+        let sf_val = spreading_factor_value(mdltn_params.spreading_factor)?;
+        let coding_rate_denominator_val = coding_rate_denominator_value(mdltn_params.coding_rate)?;
+
+        let mut config_2 = radio.read_register(Register::RegModemConfig2).await?;
+        config_2 = (config_2 & 0x0fu8) | ((sf_val << 4) & 0xf0u8);
+        radio.write_register(Register::RegModemConfig2, config_2).await?;
+
+        let mut config_1 = radio.read_register(Register::RegModemConfig1).await?;
+        config_1 = (config_1 & 0x0fu8) | (bw_val << 4);
+        radio.write_register(Register::RegModemConfig1, config_1).await?;
+
+        let cr = coding_rate_denominator_val - 4;
+        config_1 = radio.read_register(Register::RegModemConfig1).await?;
+        config_1 = (config_1 & 0xf1u8) | (cr << 1);
+        radio.write_register(Register::RegModemConfig1, config_1).await?;
+
+        let mut ldro_agc_auto_flags = 0x00u8; // LDRO and AGC Auto both off
+        if mdltn_params.low_data_rate_optimize != 0 {
+            ldro_agc_auto_flags = 0x08u8; // LDRO on and AGC Auto off
+        }
+        let mut config_3 = radio.read_register(Register::RegModemConfig3).await?;
+        config_3 = (config_3 & 0xf3u8) | ldro_agc_auto_flags;
+        radio.write_register(Register::RegModemConfig3, config_3).await
+    }
+
+    async fn set_packet_params<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        radio: &mut Sx127x<SPI, IV, Self>,
+        pkt_params: &PacketParams,
+    ) -> Result<(), RadioError> {
+        let mut config_1 = radio.read_register(Register::RegModemConfig1).await?;
+
+        if pkt_params.implicit_header {
+            config_1 |= 0x01u8;
+        } else {
+            config_1 &= 0xfeu8;
+        }
+        radio.write_register(Register::RegModemConfig1, config_1).await?;
+
+        let mut config_2 = radio.read_register(Register::RegModemConfig2).await?;
+        if pkt_params.crc_on {
+            config_2 |= 0x04u8;
+        } else {
+            config_2 &= 0xfbu8;
+        }
+        radio.write_register(Register::RegModemConfig2, config_2).await?;
+        Ok(())
+    }
+
+    async fn rssi_offset<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        radio: &mut Sx127x<SPI, IV, Self>,
+    ) -> Result<i16, RadioError> {
+        let frequency_in_hz = {
+            let msb = radio.read_register(Register::RegFrfMsb).await? as u32;
+            let mid = radio.read_register(Register::RegFrfMid).await? as u32;
+            let lsb = radio.read_register(Register::RegFrfLsb).await? as u32;
+            let frf = (msb << 16) + (mid << 8) + lsb;
+            (frf as f64 * FREQUENCY_SYNTHESIZER_STEP) as u32
+        };
+
+        if frequency_in_hz > SX1276_RF_MID_BAND_THRESH {
+            Ok(SX1276_RSSI_OFFSET_HF)
+        } else {
+            Ok(SX1276_RSSI_OFFSET_LF)
+        }
+    }
+
+    async fn set_tx_continuous_wave_mode<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        radio: &mut Sx127x<SPI, IV, Self>,
+    ) -> Result<(), RadioError> {
+        radio.intf.iv.enable_rf_switch_rx().await?;
+        let pa_config = radio.read_register(Register::RegPaConfig).await?;
+        let new_pa_config = pa_config | 0b1000_0000;
+        radio.write_register(Register::RegPaConfig, new_pa_config).await?;
+        radio.write_register(Register::RegOpMode, 0b1100_0011).await?;
+        let modem_config = radio.read_register(Register::RegModemConfig2).await?;
+        let new_modem_config = modem_config | 0b0000_1000;
+        radio
+            .write_register(Register::RegModemConfig2, new_modem_config)
+            .await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is a rebased and conflict-resolved branch that supersedes #221
