### PR TITLE
make sx126x variants trait based

### DIFF
--- a/examples/nrf52840/src/bin/lora_cad.rs
+++ b/examples/nrf52840/src/bin/lora_cad.rs
@@ -11,7 +11,7 @@ use embassy_nrf::{bind_interrupts, peripherals, spim};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
-use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{Sx1262, Sx126x, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx126x};
 use {defmt_rtt as _, panic_probe as _};
@@ -39,10 +39,9 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spim, nss, Delay);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Sx1262,
+        chip: Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();

--- a/examples/nrf52840/src/bin/lora_lorawan.rs
+++ b/examples/nrf52840/src/bin/lora_lorawan.rs
@@ -13,7 +13,7 @@ use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
 use lora_phy::lorawan_radio::LorawanRadio;
-use lora_phy::sx126x::{self, Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{self, Sx1262, Sx126x, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
@@ -55,10 +55,9 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spim, nss, Delay);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Sx1262,
+        chip: Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();

--- a/examples/nrf52840/src/bin/lora_p2p_receive.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive.rs
@@ -11,7 +11,7 @@ use embassy_nrf::{bind_interrupts, peripherals, spim};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
-use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{Sx1262, Sx126x, TcxoCtrlVoltage};
 use lora_phy::{mod_params::*, sx126x};
 use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
@@ -39,10 +39,9 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spim, nss, Delay);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Sx1262,
+        chip: Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();

--- a/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
@@ -11,7 +11,7 @@ use embassy_nrf::{bind_interrupts, peripherals, spim};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
-use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{Sx1262, Sx126x, TcxoCtrlVoltage};
 use lora_phy::{mod_params::*, sx126x};
 use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
@@ -39,10 +39,9 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spim, nss, Delay);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Sx1262,
+        chip: Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();

--- a/examples/nrf52840/src/bin/lora_p2p_send.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_send.rs
@@ -11,7 +11,7 @@ use embassy_nrf::{bind_interrupts, peripherals, spim};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
-use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{Sx1262, Sx126x, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx126x};
 use {defmt_rtt as _, panic_probe as _};
@@ -39,10 +39,9 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spim, nss, Delay);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Sx1262,
+        chip: Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();

--- a/examples/rp/src/bin/lora_lorawan.rs
+++ b/examples/rp/src/bin/lora_lorawan.rs
@@ -12,7 +12,7 @@ use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
 use lora_phy::lorawan_radio::LorawanRadio;
-use lora_phy::sx126x::{self, Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{self, Sx1262, Sx126x, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
@@ -44,10 +44,9 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spi, nss, Delay);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Sx1262,
+        chip: Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, None, None).unwrap();

--- a/examples/rp/src/bin/lora_p2p_receive.rs
+++ b/examples/rp/src/bin/lora_p2p_receive.rs
@@ -11,7 +11,7 @@ use embassy_rp::spi::{Config, Spi};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
-use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{Sx1262, Sx126x, TcxoCtrlVoltage};
 use lora_phy::{mod_params::*, sx126x};
 use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
@@ -39,10 +39,9 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spi, nss, Delay);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Sx1262,
+        chip: Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, None, None).unwrap();

--- a/examples/rp/src/bin/lora_p2p_send.rs
+++ b/examples/rp/src/bin/lora_p2p_send.rs
@@ -11,7 +11,7 @@ use embassy_rp::spi::{Config, Spi};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
-use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{Sx1262, Sx126x, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx126x};
 use {defmt_rtt as _, panic_probe as _};
@@ -39,10 +39,9 @@ async fn main(_spawner: Spawner) {
     let spi = ExclusiveDevice::new(spi, nss, Delay);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Sx1262,
+        chip: Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, None, None).unwrap();

--- a/examples/rp/src/bin/lora_p2p_send_multicore.rs
+++ b/examples/rp/src/bin/lora_p2p_send_multicore.rs
@@ -15,7 +15,7 @@ use embassy_sync::channel::Channel;
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
-use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{Sx1262, Sx126x, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx126x};
 use static_cell::StaticCell;
@@ -76,10 +76,9 @@ async fn core1_task(
     info!("Hello from core 1");
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Sx1262,
+        chip: Sx1262,
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let mut lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();

--- a/examples/stm32l0/src/bin/lora_cad.rs
+++ b/examples/stm32l0/src/bin/lora_cad.rs
@@ -12,7 +12,7 @@ use embassy_stm32::time::khz;
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
-use lora_phy::sx127x::{Sx127x, Sx1276};
+use lora_phy::sx127x::{Sx1276, Sx127x};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx127x};
 use {defmt_rtt as _, panic_probe as _};

--- a/examples/stm32wl/src/bin/lora_lorawan.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan.rs
@@ -15,7 +15,7 @@ use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, peripherals};
 use embassy_time::Delay;
 use lora_phy::lorawan_radio::LorawanRadio;
-use lora_phy::sx126x::{self, Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{self, Stm32wl, Sx126x, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
@@ -64,10 +64,11 @@ async fn main(_spawner: Spawner) {
     let spi = SubghzSpiDevice(spi);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Stm32wl,
+        chip: Stm32wl {
+            use_high_power_pa: true,
+        },
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();

--- a/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
@@ -23,7 +23,7 @@ use embassy_sync::{
 use embassy_time::Delay;
 
 use lora_phy::lorawan_radio::LorawanRadio;
-use lora_phy::sx126x::{self, Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{self, Stm32wl, Sx126x, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lorawan_device::async_device::{Device, EmbassyTimer, JoinMode, JoinResponse, SendResponse};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
@@ -76,10 +76,11 @@ async fn main(spawner: Spawner) {
     let spi = SubghzSpiDevice(spi);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Stm32wl,
+        chip: Stm32wl {
+            use_high_power_pa: true,
+        },
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: false,
         rx_boost: false,
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
@@ -96,6 +97,7 @@ type Stm32wlLoRa<'d> = LoRa<
     Sx126x<
         iv::SubghzSpiDevice<Spi<'d, peripherals::SUBGHZSPI, peripherals::DMA1_CH1, peripherals::DMA1_CH2>>,
         Stm32wlInterfaceVariant<Output<'d, AnyPin>>,
+        Stm32wl,
     >,
     Delay,
 >;

--- a/examples/stm32wl/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_receive.rs
@@ -13,7 +13,7 @@ use embassy_stm32::gpio::{Level, Output, Pin, Speed};
 use embassy_stm32::spi::Spi;
 use embassy_stm32::time::Hertz;
 use embassy_time::{Delay, Timer};
-use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{Stm32wl, Sx126x, TcxoCtrlVoltage};
 use lora_phy::{mod_params::*, sx126x};
 use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
@@ -57,10 +57,11 @@ async fn main(_spawner: Spawner) {
     let spi = SubghzSpiDevice(spi);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Stm32wl,
+        chip: Stm32wl {
+            use_high_power_pa: true,
+        },
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();

--- a/examples/stm32wl/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_send.rs
@@ -13,7 +13,7 @@ use embassy_stm32::gpio::{Level, Output, Pin, Speed};
 use embassy_stm32::spi::Spi;
 use embassy_stm32::time::Hertz;
 use embassy_time::Delay;
-use lora_phy::sx126x::{Sx126x, Sx126xVariant, TcxoCtrlVoltage};
+use lora_phy::sx126x::{Stm32wl, Sx126x, TcxoCtrlVoltage};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx126x};
 use {defmt_rtt as _, panic_probe as _};
@@ -57,10 +57,11 @@ async fn main(_spawner: Spawner) {
     let spi = SubghzSpiDevice(spi);
 
     let config = sx126x::Config {
-        chip: Sx126xVariant::Stm32wl,
+        chip: Stm32wl {
+            use_high_power_pa: true,
+        },
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
-        use_dio2_as_rfswitch: true,
         rx_boost: false,
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();

--- a/lora-phy/src/sx126x/variant.rs
+++ b/lora-phy/src/sx126x/variant.rs
@@ -1,0 +1,47 @@
+use super::DeviceSel;
+
+/// Implement this trait on your custom variant or use provided impls
+pub trait Sx126xVariant {
+    /// whether to use high or low power PA
+    fn get_device_sel(&self) -> DeviceSel;
+
+    /// use dio2 as rf switch output
+    fn use_dio2_as_rfswitch(&self) -> bool {
+        true
+    }
+}
+
+/// Sx1261 uses only LowPowerPA
+pub struct Sx1261;
+impl Sx126xVariant for Sx1261 {
+    fn get_device_sel(&self) -> super::DeviceSel {
+        super::DeviceSel::LowPowerPA
+    }
+}
+
+/// Sx1262 uses only HighPowerPA
+pub struct Sx1262;
+
+impl Sx126xVariant for Sx1262 {
+    fn get_device_sel(&self) -> super::DeviceSel {
+        super::DeviceSel::HighPowerPA
+    }
+}
+
+/// Stm32wl variant.
+pub struct Stm32wl {
+    /// select which output to use. (Switching is not supported)
+    pub use_high_power_pa: bool,
+}
+impl Sx126xVariant for Stm32wl {
+    fn get_device_sel(&self) -> super::DeviceSel {
+        if self.use_high_power_pa {
+            DeviceSel::HighPowerPA
+        } else {
+            DeviceSel::LowPowerPA
+        }
+    }
+    fn use_dio2_as_rfswitch(&self) -> bool {
+        false
+    }
+}


### PR DESCRIPTION
Do the same for sx126x as https://github.com/lora-rs/lora-rs/pull/248 did for sx127x. This PR should only refactor code but not change how it works.

These changes are made to make the code base more uniform between chips but also for allowing better control over HP/LP modes especially for stm32wl.