### PR TITLE
lora-phy: call wait_for_irq before process_irq_event in LoRa::cad

### DIFF
--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -290,6 +290,7 @@ where
     pub async fn cad(&mut self, mdltn_params: &ModulationParams) -> Result<bool, RadioError> {
         if self.radio_mode == RadioMode::ChannelActivityDetection {
             self.radio_kind.do_cad(mdltn_params).await?;
+            self.wait_for_irq().await?;
             let mut cad_activity_detected = false;
             match self
                 .radio_kind


### PR DESCRIPTION
In LoRa::cad, it doesn't wait for irq before processing it and panics on `unreachable!()`. This fixes the issue.

Tested on sx1276.
