### PR TITLE
lora-phy: add get_rssi() to RadioKind trait

### DIFF
--- a/examples/stm32l0/src/bin/lora_get_rssi.rs
+++ b/examples/stm32l0/src/bin/lora_get_rssi.rs
@@ -1,0 +1,68 @@
+//! This example runs on the STM32 LoRa Discovery board, which has a builtin Semtech Sx1276 radio.
+//! It demonstrates LORA get rssi functionality.
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::exti::{Channel, ExtiInput};
+use embassy_stm32::gpio::{Input, Level, Output, Pin, Pull, Speed};
+use embassy_stm32::spi;
+use embassy_stm32::time::khz;
+use embassy_time::{Delay, Duration, Timer};
+use embedded_hal_bus::spi::ExclusiveDevice;
+use lora_phy::iv::GenericSx127xInterfaceVariant;
+use lora_phy::sx127x::{Sx127x, Sx1276};
+use lora_phy::LoRa;
+use lora_phy::{mod_params::*, sx127x};
+use {defmt_rtt as _, panic_probe as _};
+
+const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_stm32::Config::default();
+    config.rcc.hsi = true;
+    config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSI;
+    let p = embassy_stm32::init(config);
+
+    let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
+    let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);
+    let irq_pin = Input::new(p.PB4.degrade(), Pull::Up);
+    let irq = ExtiInput::new(irq_pin, p.EXTI4.degrade());
+
+    let mut spi_config = spi::Config::default();
+    spi_config.frequency = khz(200);
+    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
+    let spi = ExclusiveDevice::new(spi, nss, Delay);
+
+    let config = sx127x::Config {
+        chip: Sx1276,
+        tcxo_used: true,
+        rx_boost: true,
+        tx_boost: false,
+    };
+    let iv = GenericSx127xInterfaceVariant::new(reset, irq, None, None).unwrap();
+    let mut lora = LoRa::new(Sx127x::new(spi, iv, config), false, Delay).await.unwrap();
+
+    match lora.listen(LORA_FREQUENCY_IN_HZ).await {
+        Ok(()) => {}
+        Err(err) => {
+            info!("Radio error = {}", err);
+            return;
+        }
+    };
+
+    loop {
+        match lora.get_rssi().await {
+            Ok(rssi) => {
+                info!("RSSI: {}", rssi);
+            }
+            Err(err) => {
+                info!("Radio error = {}", err);
+            }
+        }
+
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -275,6 +275,11 @@ where
         }
     }
 
+    /// Get the current rssi
+    pub async fn get_rssi(&mut self) -> Result<i16, RadioError> {
+        self.radio_kind.get_rssi().await
+    }
+
     /// Prepare the Semtech chip for a channel activity detection operation
     pub async fn prepare_for_cad(&mut self, mdltn_params: &ModulationParams) -> Result<(), RadioError> {
         self.prepare_modem(mdltn_params).await?;

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -170,7 +170,7 @@ where
         output_power: i32,
         buffer: &[u8],
     ) -> Result<(), RadioError> {
-        self.prepare_modem(mdltn_params).await?;
+        self.prepare_modem(mdltn_params.frequency_in_hz).await?;
 
         self.radio_kind.set_modulation_params(mdltn_params).await?;
         self.radio_kind
@@ -229,7 +229,7 @@ where
         rx_pkt_params: &PacketParams,
     ) -> Result<(), RadioError> {
         defmt::trace!("RX mode: {}", listen_mode);
-        self.prepare_modem(mdltn_params).await?;
+        self.prepare_modem(mdltn_params.frequency_in_hz).await?;
 
         self.radio_kind.set_modulation_params(mdltn_params).await?;
         self.radio_kind.set_packet_params(rx_pkt_params).await?;
@@ -282,7 +282,7 @@ where
 
     /// Prepare the Semtech chip for a channel activity detection operation
     pub async fn prepare_for_cad(&mut self, mdltn_params: &ModulationParams) -> Result<(), RadioError> {
-        self.prepare_modem(mdltn_params).await?;
+        self.prepare_modem(mdltn_params.frequency_in_hz).await?;
 
         self.radio_kind.set_modulation_params(mdltn_params).await?;
         self.radio_kind.set_channel(mdltn_params.frequency_in_hz).await?;
@@ -326,7 +326,7 @@ where
         mdltn_params: &ModulationParams,
         output_power: i32,
     ) -> Result<(), RadioError> {
-        self.prepare_modem(mdltn_params).await?;
+        self.prepare_modem(mdltn_params.frequency_in_hz).await?;
 
         let tx_pkt_params = self
             .radio_kind
@@ -348,7 +348,7 @@ where
         self.radio_kind.set_tx_continuous_wave_mode().await
     }
 
-    async fn prepare_modem(&mut self, mdltn_params: &ModulationParams) -> Result<(), RadioError> {
+    async fn prepare_modem(&mut self, frequency_in_hz: u32) -> Result<(), RadioError> {
         self.radio_kind.ensure_ready(self.radio_mode).await?;
         if self.radio_mode != RadioMode::Standby {
             self.radio_kind.set_standby().await?;
@@ -360,7 +360,7 @@ where
         }
 
         if self.calibrate_image {
-            self.radio_kind.calibrate_image(mdltn_params.frequency_in_hz).await?;
+            self.radio_kind.calibrate_image(frequency_in_hz).await?;
             self.calibrate_image = false;
         }
 

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -275,6 +275,17 @@ where
         }
     }
 
+    /// Start listening to a given frequency
+    pub async fn listen(&mut self, frequency_in_hz: u32) -> Result<(), RadioError> {
+        self.prepare_modem(frequency_in_hz).await?;
+
+        self.radio_kind.set_channel(frequency_in_hz).await?;
+        self.radio_mode = RadioMode::Listen;
+        self.radio_kind.do_rx(RxMode::Continuous).await?;
+
+        Ok(())
+    }
+
     /// Get the current rssi
     pub async fn get_rssi(&mut self) -> Result<i16, RadioError> {
         self.radio_kind.get_rssi().await

--- a/lora-phy/src/mod_params.rs
+++ b/lora-phy/src/mod_params.rs
@@ -50,6 +50,8 @@ pub enum RadioMode {
     Transmit,
     /// Receive (RX) mode
     Receive(RxMode),
+    /// Listen mode
+    Listen,
     /// Channel activity detection (CAD) mode
     ChannelActivityDetection,
 }

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -94,6 +94,8 @@ pub trait RadioKind {
     ) -> Result<u8, RadioError>;
     /// Get the RSSI and SNR for the packet made available as the result of a receive operation
     async fn get_rx_packet_status(&mut self) -> Result<PacketStatus, RadioError>;
+    /// Get the current RSSI
+    async fn get_rssi(&mut self) -> Result<i16, RadioError>;
     /// Perform a channel activity detection operation
     async fn do_cad(&mut self, mdltn_params: &ModulationParams) -> Result<(), RadioError>;
     /// Set the LoRa chip to provide notification of specific events based on radio state

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -761,6 +761,10 @@ where
         Ok(PacketStatus { rssi, snr })
     }
 
+    async fn get_rssi(&mut self) -> Result<i16, RadioError> {
+        todo!()
+    }
+
     async fn do_cad(&mut self, mdltn_params: &ModulationParams) -> Result<(), RadioError> {
         self.intf.iv.enable_rf_switch_rx().await?;
 

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -965,8 +965,8 @@ where
                     return Ok(Some(IrqState::Done));
                 }
             }
-            RadioMode::Sleep | RadioMode::Standby => {
-                defmt::warn!("IRQ during sleep/standby?");
+            RadioMode::Sleep | RadioMode::Standby | RadioMode::Listen => {
+                defmt::warn!("IRQ during sleep/standby/listen?");
             }
             RadioMode::FrequencySynthesis => todo!(),
         }

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -530,8 +530,8 @@ where
                     return Ok(Some(IrqState::Done));
                 }
             }
-            RadioMode::Sleep | RadioMode::Standby => {
-                defmt::warn!("IRQ during sleep/standby?");
+            RadioMode::Sleep | RadioMode::Standby | RadioMode::Listen => {
+                defmt::warn!("IRQ during sleep/standby/listen?");
             }
             RadioMode::FrequencySynthesis => todo!(),
             RadioMode::Receive(RxMode::DutyCycle(_)) => todo!(),

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -392,6 +392,12 @@ where
         Ok(PacketStatus { rssi, snr })
     }
 
+    async fn get_rssi(&mut self) -> Result<i16, RadioError> {
+        let rssi_value = self.read_register(Register::RegRssiValue).await?;
+        let rssi_offset = C::rssi_offset(self).await?;
+        Ok(rssi_offset + rssi_value as i16)
+    }
+
     async fn do_cad(&mut self, _mdltn_params: &ModulationParams) -> Result<(), RadioError> {
         self.intf.iv.enable_rf_switch_rx().await?;
 

--- a/lora-phy/src/sx127x/radio_kind_params.rs
+++ b/lora-phy/src/sx127x/radio_kind_params.rs
@@ -159,6 +159,7 @@ pub enum Register {
     RegPktSnrValue = 0x19,
     RegModemStat = 0x18,
     RegPktRssiValue = 0x1a,
+    RegRssiValue = 0x1b,
     RegModemConfig1 = 0x1d,
     RegModemConfig2 = 0x1e,
     RegSymbTimeoutLsb = 0x1f,


### PR DESCRIPTION
I need to do carrier sensing using the current RSSI value. The CAD isn't enough because I want to detect waves besides LoRa. So I added `get_rssi()` to the `RadioKind` trait and exposed it. I also added `RadioMode::Listen` in which the radio keeps listening to a given frequency so that the `RegRssiValue` register is updated continuously. I'm not sure if it's ok to add a new RadioMode though.

I don't own sx126x chips, so I implemented `get_rssi()` only for sx127x and tested on sx1276. I'd appreciate it if someone could implement it for sx126x.
