### PR TITLE
lorawan-radio: add the low power feature

### DIFF
--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -156,6 +156,9 @@ where
             Err(Error::NoRxParams)
         }
     }
+    async fn low_power(&mut self) -> Result<(), Self::PhyError> {
+        self.lora.sleep(false).await.map_err(|e| e.into())
+    }
 }
 
 impl RxMode {


### PR DESCRIPTION
This feature allows to set the radio in low power mode when we are using a lorawan device.

The `low_power` is automatically called after a lorawan transmission,
this function is now calling the lora chip sleep function.

Consumption has been measured in sleep mode after a lorawan communication with a SX1262 module and is in the expected range (1µA), the others 6µA comes from others components.

![327426836-2c795886-8783-467a-9e88-cf8bc7916b95](https://github.com/lora-rs/lora-rs/assets/57074781/def5b78d-6409-475f-a5f4-d795414ee033)
