### PR TITLE
examples: nrf52840/RAK4630: Use Input(Pull::None) for busy pin.

### DIFF
--- a/examples/nrf52840/src/bin/lora_cad.rs
+++ b/examples/nrf52840/src/bin/lora_cad.rs
@@ -29,7 +29,7 @@ async fn main(_spawner: Spawner) {
     let nss = Output::new(p.P1_10.degrade(), Level::High, OutputDrive::Standard);
     let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
     let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
-    let busy = Input::new(p.P1_14.degrade(), Pull::Down);
+    let busy = Input::new(p.P1_14.degrade(), Pull::None);
     let rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
     let rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
 

--- a/examples/nrf52840/src/bin/lora_lorawan.rs
+++ b/examples/nrf52840/src/bin/lora_lorawan.rs
@@ -45,7 +45,7 @@ async fn main(_spawner: Spawner) {
     let nss = Output::new(p.P1_10.degrade(), Level::High, OutputDrive::Standard);
     let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
     let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
-    let busy = Input::new(p.P1_14.degrade(), Pull::Down);
+    let busy = Input::new(p.P1_14.degrade(), Pull::None);
     let rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
     let rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
 

--- a/examples/nrf52840/src/bin/lora_p2p_receive.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive.rs
@@ -29,7 +29,7 @@ async fn main(_spawner: Spawner) {
     let nss = Output::new(p.P1_10.degrade(), Level::High, OutputDrive::Standard);
     let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
     let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
-    let busy = Input::new(p.P1_14.degrade(), Pull::Down);
+    let busy = Input::new(p.P1_14.degrade(), Pull::None);
     let rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
     let rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
 

--- a/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
@@ -29,7 +29,7 @@ async fn main(_spawner: Spawner) {
     let nss = Output::new(p.P1_10.degrade(), Level::High, OutputDrive::Standard);
     let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
     let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
-    let busy = Input::new(p.P1_14.degrade(), Pull::Down);
+    let busy = Input::new(p.P1_14.degrade(), Pull::None);
     let rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
     let rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
 

--- a/examples/nrf52840/src/bin/lora_p2p_send.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_send.rs
@@ -29,7 +29,7 @@ async fn main(_spawner: Spawner) {
     let nss = Output::new(p.P1_10.degrade(), Level::High, OutputDrive::Standard);
     let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
     let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
-    let busy = Input::new(p.P1_14.degrade(), Pull::Down);
+    let busy = Input::new(p.P1_14.degrade(), Pull::None);
     let rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
     let rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
 


### PR DESCRIPTION
From Sx1261-2 user manual:
> The BUSY control line is used to indicate the status of the internal state
> machine. When the BUSY line is held low, it indicates that the internal
> state machine is in idle mode and that the radio is ready to accept a
> command from the host controller.

Fixes #260.

Tested-by: Priit Laes <plaes@plaes.org>