### PR TITLE
Fix CI by applying Clippy suggestions and enable cache also when building examples

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,12 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
+          workspaces: |
+            .
+            examples/nrf52840
+            examples/rp
+            examples/stm32l0
+            examples/stm32wl
 
       # Format and Clippy steps are executed in separate 'check' workflow
       - name: Build

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -386,7 +386,7 @@ where
                 const LOW_POWER_MIN: i32 = -17;
                 const LOW_POWER_MAX: i32 = 15;
                 // Clamp power between [-17, 15] dBm
-                let txp = output_power.min(LOW_POWER_MAX).max(LOW_POWER_MIN);
+                let txp = output_power.clamp(LOW_POWER_MIN, LOW_POWER_MAX);
 
                 if txp == 15 {
                     if let Some(m_p) = mdltn_params {
@@ -422,7 +422,7 @@ where
                 const HIGH_POWER_MIN: i32 = -9;
                 const HIGH_POWER_MAX: i32 = 22;
                 // Clamp power between [-9, 22] dBm
-                let txp = output_power.min(HIGH_POWER_MAX).max(HIGH_POWER_MIN);
+                let txp = output_power.clamp(HIGH_POWER_MIN, HIGH_POWER_MAX);
                 // Provide better resistance of the SX1262 Tx to antenna mismatch (see DS_SX1261-2_V1.2 datasheet chapter 15.2)
                 let mut tx_clamp_cfg = [0x00u8];
                 self.intf

--- a/lora-phy/src/sx127x/sx1272.rs
+++ b/lora-phy/src/sx127x/sx1272.rs
@@ -45,18 +45,18 @@ impl Sx127xVariant for Sx1272 {
             // Deal with two ranges, +17dBm enables extra boost
             if p_out > 17 {
                 // PA_BOOST out: +5 .. +20 dBm
-                let val = (p_out.min(20).max(5) - 5) as u8 & 0x0f;
+                let val = (p_out.clamp(5, 20) - 5) as u8 & 0x0f;
                 radio.write_register(Register::RegPaConfig, (1 << 7) | val).await?;
                 radio.write_register(Register::RegPaDacSX1272, 0x87).await?;
             } else {
                 // PA_BOOST out: +2 .. +17 dBm
-                let val = (p_out.min(17).max(2) - 2) as u8 & 0x0f;
+                let val = (p_out.clamp(2, 17) - 2) as u8 & 0x0f;
                 radio.write_register(Register::RegPaConfig, (1 << 7) | val).await?;
                 radio.write_register(Register::RegPaDacSX1272, 0x84).await?;
             }
         } else {
             // RFO out: -1 to +14 dBm
-            let val = (p_out.min(14).max(-1) + 1) as u8 & 0x0f;
+            let val = (p_out.clamp(-1, 14) + 1) as u8 & 0x0f;
             radio.write_register(Register::RegPaConfig, val).await?;
             radio.write_register(Register::RegPaDacSX1272, 0x84).await?;
         }

--- a/lora-phy/src/sx127x/sx1276.rs
+++ b/lora-phy/src/sx127x/sx1276.rs
@@ -40,7 +40,7 @@ impl Sx127xVariant for Sx1276 {
         let pa_reg = Register::RegPaDacSX1276;
         if tx_boost {
             // Output via PA_BOOST: [2, 20] dBm
-            let txp = p_out.min(20).max(2);
+            let txp = p_out.clamp(2, 20);
 
             // Pout=17-(15-OutputPower)
             let output_power: i32 = txp - 2;
@@ -57,7 +57,7 @@ impl Sx127xVariant for Sx1276 {
                 .await?;
         } else {
             // Clamp output: [-4, 14] dBm
-            let txp = p_out.min(14).max(-4);
+            let txp = p_out.clamp(-4, 14);
 
             // Pmax=10.8+0.6*MaxPower, where MaxPower is set below as 7 and therefore Pmax is 15
             // Pout=Pmax-(15-OutputPower)


### PR DESCRIPTION
CI Fix + Cache for examples. At least on my test fork, it finishes faster than 90 seconds where previously it took at least 3 minutes.