### PR TITLE
Fix lora-phy[lorawan-radio] <-> lorawan-device dependency

### DIFF
--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-time = { version = "0.3.1", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-nrf = { version = "0.1.0", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio"] }
@@ -16,8 +16,8 @@ defmt = "0.3"
 defmt-rtt = "0.4"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
-cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
-cortex-m-rt = "0.7.0"
+cortex-m = { version = "0.7.7", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = "0.7.3"
 embedded-hal-bus = { version = "0.1.0", features = ["async"]}
 
 [profile.release]

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -24,8 +24,19 @@ embedded-hal-bus = { version = "0.1.0", features = ["async"]}
 debug = 2
 
 [features]
-default = []
+default = ["region-eu868"]
 ## Customize target binary to make it runnable from RAM
 link-to-ram = []
 # Add teleprobe specific hooks to code
 teleprobe = ["link-to-ram"]
+
+# Size optimization (TODO: Update code to allow other regions)
+# region-as923-1 = ["lorawan-device/region-as923-1"]
+# region-as923-2 = ["lorawan-device/region-as923-2"]
+# region-as923-3 = ["lorawan-device/region-as923-3"]
+# region-as923-4 = ["lorawan-device/region-as923-4"]
+# region-au915 = ["lorawan-device/region-au915"]
+# region-eu433 = ["lorawan-device/region-eu433"]
+region-eu868 = ["lorawan-device/region-eu868"]
+# region-in865 = ["lorawan-device/region-in865"]
+# region-us915 = ["lorawan-device/region-us915"]

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -11,7 +11,7 @@ embassy-sync = { version = "0.5.0", features = ["defmt"] }
 embassy-rp = { version = "0.1.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio"] }
-lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["embassy-time", "default-crypto", "defmt"] }
+lorawan-device = { path = "../../lorawan-device", features = ["embassy-time", "default-crypto", "defmt"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -11,7 +11,7 @@ embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-t
 embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio"] }
-lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["embassy-time", "default-crypto", "defmt"] }
+lorawan-device = { path = "../../lorawan-device", features = ["embassy-time", "default-crypto", "defmt"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -13,7 +13,7 @@ embassy-sync = { version = "0.5.0", features = ["defmt"] }
 embassy-futures = { version = "0", features = ["defmt"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio"] }
-lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["embassy-time", "default-crypto", "defmt"] }
+lorawan-device = { path = "../../lorawan-device", features = ["embassy-time", "default-crypto", "defmt"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 defmt = { version = "0.3" }
 lora-modulation = { path = "../lora-modulation", version = ">=0.1.2" }
-lorawan-device = { path = "../lorawan-device", version = "0.12", features = [
+lorawan-device = { path = "../lorawan-device", default-features = false, version = "0.12", features = [
     "defmt",
 ], optional = true }
 num-traits = { version = "0.2", default-features = false }


### PR DESCRIPTION
When `lora-phy[lorawan-radio]` was enabled, it called in lorawan-device with default features enabled, thus making it impossible to override default feature flags.