### PR TITLE
Prepare for `edition_2024` by denying Rust 2018 idioms

### DIFF
--- a/lora-modulation/src/lib.rs
+++ b/lora-modulation/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rust_2018_idioms)]
 #![cfg_attr(not(test), no_std)]
 #![doc = include_str!("../README.md")]
 

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(rust_2018_idioms)]
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/lorawan-device/src/lib.rs
+++ b/lorawan-device/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rust_2018_idioms)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
@@ -47,7 +48,7 @@ pub struct Downlink {
 
 #[cfg(feature = "defmt")]
 impl defmt::Format for Downlink {
-    fn format(&self, f: defmt::Formatter) {
+    fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f, "Downlink {{ fport: {}, data: ", self.fport,);
 
         for byte in self.data.iter() {

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -52,7 +52,7 @@ impl Configuration {
         &mut self,
         region: &mut region::Configuration,
         uplink: &mut uplink::Uplink,
-        cmds: lorawan::maccommands::MacCommandIterator<DownlinkMacCommand>,
+        cmds: lorawan::maccommands::MacCommandIterator<'_, DownlinkMacCommand<'_>>,
     ) {
         use uplink::MacAnsTrait;
         for cmd in cmds {
@@ -163,7 +163,7 @@ impl Mac {
         &mut self,
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
-        send_data: &SendData,
+        send_data: &SendData<'_>,
     ) -> Result<(radio::TxConfig, FcntUp)> {
         let fcnt = match &mut self.state {
             State::Joined(ref mut session) => Ok(session.prepare_buffer::<C, N>(send_data, buf)),

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -124,13 +124,15 @@ impl Session {
                         configuration.handle_downlink_macs(
                             region,
                             &mut self.uplink,
-                            MacCommandIterator::<DownlinkMacCommand>::new(decrypted.fhdr().data()),
+                            MacCommandIterator::<DownlinkMacCommand<'_>>::new(
+                                decrypted.fhdr().data(),
+                            ),
                         );
                         if let FRMPayload::MACCommands(mac_cmds) = decrypted.frm_payload() {
                             configuration.handle_downlink_macs(
                                 region,
                                 &mut self.uplink,
-                                MacCommandIterator::<DownlinkMacCommand>::new(mac_cmds.data()),
+                                MacCommandIterator::<DownlinkMacCommand<'_>>::new(mac_cmds.data()),
                             );
                         }
                     }
@@ -179,7 +181,7 @@ impl Session {
 
     pub(crate) fn prepare_buffer<C: CryptoFactory + Default, const N: usize>(
         &mut self,
-        data: &SendData,
+        data: &SendData<'_>,
         tx_buffer: &mut RadioBuffer<N>,
     ) -> FcntUp {
         tx_buffer.clear();

--- a/lorawan-device/src/mac/uplink.rs
+++ b/lorawan-device/src/mac/uplink.rs
@@ -72,7 +72,7 @@ impl Uplink {
         self.rx_delay_ans.add();
     }
 
-    pub fn get_cmds(&mut self, macs: &mut Vec<UplinkMacCommand, 8>) {
+    pub fn get_cmds(&mut self, macs: &mut Vec<UplinkMacCommand<'_>, 8>) {
         for _ in 0..self.adr_ans.get() {
             macs.push(UplinkMacCommand::LinkADRAns(LinkADRAnsPayload::new(&[0x07]).unwrap()))
                 .unwrap();

--- a/lorawan-device/src/nb_device/mod.rs
+++ b/lorawan-device/src/nb_device/mod.rs
@@ -97,7 +97,7 @@ where
         self.shared.downlink.pop()
     }
 
-    pub fn handle_event(&mut self, event: Event<R>) -> Result<Response, Error<R>> {
+    pub fn handle_event(&mut self, event: Event<'_, R>) -> Result<Response, Error<R>> {
         let (new_state, result) = self.state.handle_event::<R, C, RNG, N, D>(
             &mut self.shared.mac,
             &mut self.shared.radio,

--- a/lorawan-device/src/nb_device/radio.rs
+++ b/lorawan-device/src/nb_device/radio.rs
@@ -44,7 +44,7 @@ pub trait PhyRxTx {
 
     // we require mutability so we may decrypt in place
     fn get_received_packet(&mut self) -> &mut [u8];
-    fn handle_event(&mut self, event: Event<Self>) -> Result<Response<Self>, Self::PhyError>
+    fn handle_event(&mut self, event: Event<'_, Self>) -> Result<Response<Self>, Self::PhyError>
     where
         Self: Sized;
 }

--- a/lorawan-device/src/nb_device/state.rs
+++ b/lorawan-device/src/nb_device/state.rs
@@ -114,7 +114,7 @@ impl State {
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
         dl: &mut Vec<Downlink, D>,
-        event: Event<R>,
+        event: Event<'_, R>,
     ) -> (Self, Result<Response, super::Error<R>>) {
         match self {
             State::Idle(s) => s.handle_event::<R, C, RNG, N>(mac, radio, rng, buf, event),
@@ -140,7 +140,7 @@ impl Idle {
         radio: &mut R,
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
-        event: Event<R>,
+        event: Event<'_, R>,
     ) -> (State, Result<Response, super::Error<R>>) {
         enum IntermediateResponse<R: radio::PhyRxTx> {
             RadioTx((Frame, radio::TxConfig, u32)),
@@ -170,7 +170,7 @@ impl Idle {
         match response {
             IntermediateResponse::EarlyReturn(response) => (State::Idle(self), response),
             IntermediateResponse::RadioTx((frame, tx_config, fcnt_up)) => {
-                let event: radio::Event<R> =
+                let event: radio::Event<'_, R> =
                     radio::Event::TxRequest(tx_config, buf.as_ref_for_read());
                 match radio.handle_event(event) {
                     Ok(response) => {
@@ -206,7 +206,7 @@ impl SendingData {
         self,
         mac: &mut Mac,
         radio: &mut R,
-        event: Event<R>,
+        event: Event<'_, R>,
     ) -> (State, Result<Response, super::Error<R>>) {
         match event {
             // we are waiting for the async tx to complete
@@ -249,7 +249,7 @@ impl WaitingForRxWindow {
         self,
         mac: &mut Mac,
         radio: &mut R,
-        event: Event<R>,
+        event: Event<'_, R>,
     ) -> (State, Result<Response, super::Error<R>>) {
         match event {
             // we are waiting for a Timeout
@@ -320,7 +320,7 @@ impl WaitingForRx {
         mac: &mut Mac,
         radio: &mut R,
         buf: &mut RadioBuffer<N>,
-        event: Event<R>,
+        event: Event<'_, R>,
         dl: &mut Vec<Downlink, D>,
     ) -> (State, Result<Response, super::Error<R>>) {
         match event {

--- a/lorawan-device/src/nb_device/test/util.rs
+++ b/lorawan-device/src/nb_device/test/util.rs
@@ -56,7 +56,7 @@ impl PhyRxTx for TestRadio {
         &mut self.buffer[..self.buffer_index]
     }
 
-    fn handle_event(&mut self, event: Event<Self>) -> Result<Response<Self>, Self::PhyError>
+    fn handle_event(&mut self, event: Event<'_, Self>) -> Result<Response<Self>, Self::PhyError>
     where
         Self: Sized,
     {

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -228,8 +228,8 @@ pub fn handle_data_uplink_with_link_adr_ans(
             let uplink =
                 data.decrypt(Some(&get_key().into()), Some(&get_key().into()), fcnt).unwrap();
             let fhdr = uplink.fhdr();
-            let mac_cmds: Vec<UplinkMacCommand> =
-                MacCommandIterator::<UplinkMacCommand>::new(fhdr.data()).collect();
+            let mac_cmds: Vec<UplinkMacCommand<'_>> =
+                MacCommandIterator::<UplinkMacCommand<'_>>::new(fhdr.data()).collect();
 
             assert_eq!(mac_cmds.len(), 2);
             assert!(matches!(mac_cmds[0], UplinkMacCommand::LinkADRAns(_)));

--- a/lorawan-encoding/src/lib.rs
+++ b/lorawan-encoding/src/lib.rs
@@ -1,5 +1,6 @@
 //! This module implements LoRaWAN packet handling and parsing.
 #![no_std]
+#![deny(rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::upper_case_acronyms)]
 #![doc = include_str!("../README.md")]

--- a/lorawan-encoding/src/maccommands.rs
+++ b/lorawan-encoding/src/maccommands.rs
@@ -206,7 +206,7 @@ macro_rules! mac_cmds_enum {
         impl<'a> From<&'a super::parser::FHDR<'a>>
             for MacCommandIterator<$($outer_lifetime)*, $outer_type$(<$outer_lifetime>)*>
         {
-            fn from(fhdr: &'a super::parser::FHDR) -> Self {
+            fn from(fhdr: &'a super::parser::FHDR<'_>) -> Self {
                 Self {
                     data: &fhdr.data(),
                     index: 0,
@@ -218,7 +218,7 @@ macro_rules! mac_cmds_enum {
         impl<'a> From<&'a super::parser::FRMMacCommands<'a>>
             for MacCommandIterator<$($outer_lifetime)*, $outer_type$(<$outer_lifetime>)*>
         {
-            fn from(frmm: &'a super::parser::FRMMacCommands) -> Self {
+            fn from(frmm: &'a super::parser::FRMMacCommands<'_>) -> Self {
                 Self {
                     data: frmm.data(),
                     index: 0,
@@ -402,7 +402,7 @@ macro_rules! create_value_reader_fn {
 /// let mac_cmds: Vec<lorawan::maccommands::UplinkMacCommand> =
 ///     lorawan::maccommands::parse_uplink_mac_commands(&data).collect();
 /// ```
-pub fn parse_uplink_mac_commands(data: &[u8]) -> MacCommandIterator<UplinkMacCommand> {
+pub fn parse_uplink_mac_commands(data: &[u8]) -> MacCommandIterator<'_, UplinkMacCommand<'_>> {
     MacCommandIterator::new(data)
 }
 /// Parses bytes to downlink MAC commands if possible.
@@ -420,7 +420,7 @@ pub fn parse_uplink_mac_commands(data: &[u8]) -> MacCommandIterator<UplinkMacCom
 /// let mac_cmds: Vec<lorawan::maccommands::DownlinkMacCommand> =
 ///     lorawan::maccommands::parse_downlink_mac_commands(&data).collect();
 /// ```
-pub fn parse_downlink_mac_commands(data: &[u8]) -> MacCommandIterator<DownlinkMacCommand> {
+pub fn parse_downlink_mac_commands(data: &[u8]) -> MacCommandIterator<'_, DownlinkMacCommand<'_>> {
     MacCommandIterator::new(data)
 }
 
@@ -533,7 +533,7 @@ struct ChannelMaskDeserializer<const N: usize>;
 impl<'de, const N: usize> serde::de::Visitor<'de> for ChannelMaskDeserializer<N> {
     type Value = ChannelMask<N>;
 
-    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         formatter.write_str("ChannelMask byte.")
     }
 
@@ -719,7 +719,7 @@ impl<'a> RXParamSetupReqPayload<'a> {
     }
 
     /// RX2 frequency.
-    pub fn frequency(&self) -> Frequency {
+    pub fn frequency(&self) -> Frequency<'_> {
         Frequency::new_from_raw(&self.0[1..])
     }
 }
@@ -848,7 +848,7 @@ impl<'a> NewChannelReqPayload<'a> {
     );
 
     /// The frequency of the new or modified channel.
-    pub fn frequency(&self) -> Frequency {
+    pub fn frequency(&self) -> Frequency<'_> {
         Frequency::new_from_raw(&self.0[1..4])
     }
 
@@ -969,7 +969,7 @@ impl DlChannelReqPayload<'_> {
     );
 
     /// The frequency of the new or modified channel.
-    pub fn frequency(&self) -> Frequency {
+    pub fn frequency(&self) -> Frequency<'_> {
         Frequency::new_from_raw(&self.0[1..4])
     }
 }

--- a/lorawan-encoding/src/parser.rs
+++ b/lorawan-encoding/src/parser.rs
@@ -134,7 +134,7 @@ pub enum PhyPayload<T, F> {
 
 #[cfg(feature = "defmt")]
 impl<T: defmt::Format, F> defmt::Format for PhyPayload<T, F> {
-    fn format(&self, f: defmt::Formatter) {
+    fn format(&self, f: defmt::Formatter<'_>) {
         match self {
             PhyPayload::JoinRequest(r) => {
                 defmt::write!(f, "JoinRequestPayload({})", r.0);
@@ -548,7 +548,7 @@ impl<T: AsRef<[u8]>, F> DecryptedJoinAcceptPayload<T, F> {
     }
 
     /// Gives the channel frequency list of the JoinAccept.
-    pub fn c_f_list(&self) -> Option<CfList> {
+    pub fn c_f_list(&self) -> Option<CfList<'_>> {
         if self.0.as_ref().len() == JOIN_ACCEPT_LEN {
             return None;
         }
@@ -603,7 +603,7 @@ pub trait DataHeader {
     fn as_data_bytes(&self) -> &[u8];
 
     /// Gives the FHDR of the DataPayload.
-    fn fhdr(&self) -> FHDR {
+    fn fhdr(&self) -> FHDR<'_> {
         FHDR::new_from_raw(&self.as_data_bytes()[1..(1 + self.fhdr_length())], self.is_uplink())
     }
 
@@ -801,7 +801,7 @@ impl<T> DecryptedDataPayload<T> {
 
 #[cfg(feature = "defmt")]
 impl<T: AsRef<[u8]>> defmt::Format for DecryptedDataPayload<T> {
-    fn format(&self, fmt: defmt::Formatter) {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
         defmt::write!(fmt, "DecryptedDataPayload {{ {:?} }}", self.0.as_ref())
     }
 }
@@ -815,7 +815,7 @@ impl<T: AsRef<[u8]>> DataHeader for DecryptedDataPayload<T> {
 impl<T: AsRef<[u8]>> DecryptedDataPayload<T> {
     /// Returns FRMPayload that can represent either application payload or mac commands if fport
     /// is 0.
-    pub fn frm_payload(&self) -> FRMPayload {
+    pub fn frm_payload(&self) -> FRMPayload<'_> {
         let data = self.as_data_bytes();
         let len = data.len();
         let fhdr_length = self.fhdr_length();
@@ -1022,11 +1022,11 @@ fixed_len_struct! {
 pub struct FHDR<'a>(&'a [u8], bool);
 
 impl<'a> FHDR<'a> {
-    pub fn new_from_raw(bytes: &'a [u8], uplink: bool) -> FHDR {
+    pub fn new_from_raw(bytes: &'a [u8], uplink: bool) -> FHDR<'_> {
         FHDR(bytes, uplink)
     }
 
-    pub fn new(bytes: &'a [u8], uplink: bool) -> Option<FHDR> {
+    pub fn new(bytes: &'a [u8], uplink: bool) -> Option<FHDR<'_>> {
         let data_len = bytes.len();
         if data_len < 7 {
             return None;


### PR DESCRIPTION
It was somewhat easier than I anticipated, fixes #277 