### PR TITLE
sx127x: Use integer math for freq / pll_step calculations

### DIFF
--- a/lora-phy/src/sx127x/sx1276.rs
+++ b/lora-phy/src/sx127x/sx1276.rs
@@ -4,7 +4,7 @@ use crate::sx127x::radio_kind_params::{
     coding_rate_denominator_value, spreading_factor_value, OcpTrim, PaConfig, PaDac, RampTime, Register, Sx127xVariant,
 };
 use crate::sx127x::{
-    Sx127x, FREQUENCY_SYNTHESIZER_STEP, SX1276_RF_MID_BAND_THRESH, SX1276_RSSI_OFFSET_HF, SX1276_RSSI_OFFSET_LF,
+    pll_step_to_freq, Sx127x, SX1276_RF_MID_BAND_THRESH, SX1276_RSSI_OFFSET_HF, SX1276_RSSI_OFFSET_LF,
 };
 use embedded_hal_async::spi::SpiDevice;
 use lora_modulation::Bandwidth;
@@ -141,8 +141,8 @@ impl Sx127xVariant for Sx1276 {
             let msb = radio.read_register(Register::RegFrfMsb).await? as u32;
             let mid = radio.read_register(Register::RegFrfMid).await? as u32;
             let lsb = radio.read_register(Register::RegFrfLsb).await? as u32;
-            let frf = (msb << 16) + (mid << 8) + lsb;
-            (frf as f64 * FREQUENCY_SYNTHESIZER_STEP) as u32
+
+            pll_step_to_freq((msb << 16) + (mid << 8) + lsb)
         };
 
         if frequency_in_hz > SX1276_RF_MID_BAND_THRESH {

--- a/lora-phy/src/sx127x/sx1276.rs
+++ b/lora-phy/src/sx127x/sx1276.rs
@@ -138,6 +138,7 @@ impl Sx127xVariant for Sx1276 {
         radio: &mut Sx127x<SPI, IV, Self>,
     ) -> Result<i16, RadioError> {
         let frequency_in_hz = {
+            // TODO: Keep frequency in radio settings?
             let msb = radio.read_register(Register::RegFrfMsb).await? as u32;
             let mid = radio.read_register(Register::RegFrfMid).await? as u32;
             let lsb = radio.read_register(Register::RegFrfLsb).await? as u32;


### PR DESCRIPTION
No need to use floats, integer freq -> pll_step conversion is good enough when dealing with full megahertz calculations.

This switches frequency <-> pll step calculations to integer math in sx127x driver. (Issue #282)

See also:
https://github.com/Lora-net/SWL2001/issues/87