### PR TITLE
encoding: Migrate to hybrid_array

### DIFF
--- a/lorawan-encoding/Cargo.toml
+++ b/lorawan-encoding/Cargo.toml
@@ -14,12 +14,12 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aes = { version = "0.8", optional = true }
-cmac = { version = "0.7", optional = true }
-generic-array = "0"
+aes = { version = "0.9.0-pre.2", optional = true }
+cmac = { version = "0.8.0-pre.2", optional = true }
 hex = { version = "0", default-features = false }
 defmt = { version = "0.3", optional = true }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true}
+hybrid-array = { version = "0.2.0-pre.10" }
 
 [dev-dependencies]
 criterion = "0"

--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -11,10 +11,10 @@ use super::securityhelpers;
 #[cfg(feature = "default-crypto")]
 use super::default_crypto::DefaultFactory;
 
-use generic_array::GenericArray;
+use hybrid_array::Array as GenericArray;
 
 #[cfg(feature = "default-crypto")]
-use aes::cipher::generic_array::typenum::U256;
+use aes::cipher::array::sizes::U256;
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/lorawan-encoding/src/default_crypto.rs
+++ b/lorawan-encoding/src/default_crypto.rs
@@ -5,9 +5,9 @@ use super::parser::{
     DecryptedDataPayload, DecryptedJoinAcceptPayload, EncryptedDataPayload,
     EncryptedJoinAcceptPayload, JoinRequestPayload,
 };
-use super::securityhelpers::generic_array::{typenum::U16, GenericArray};
+use super::securityhelpers::generic_array::{typenum::U16, Array as GenericArray};
 use crate::parser::Error;
-use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+use aes::cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit};
 use aes::Aes128;
 
 pub type Cmac = cmac::Cmac<Aes128>;
@@ -37,13 +37,13 @@ impl CryptoFactory for DefaultFactory {
 
 impl Encrypter for Aes128 {
     fn encrypt_block(&self, block: &mut GenericArray<u8, U16>) {
-        BlockEncrypt::encrypt_block(self, block);
+        BlockCipherEncrypt::encrypt_block(self, block);
     }
 }
 
 impl Decrypter for Aes128 {
     fn decrypt_block(&self, block: &mut GenericArray<u8, U16>) {
-        BlockDecrypt::decrypt_block(self, block);
+        BlockCipherDecrypt::decrypt_block(self, block);
     }
 }
 

--- a/lorawan-encoding/src/keys.rs
+++ b/lorawan-encoding/src/keys.rs
@@ -1,5 +1,5 @@
 use super::parser::EUI64;
-use super::securityhelpers::generic_array::{typenum::U16, GenericArray};
+use super::securityhelpers::generic_array::{typenum::U16, Array as GenericArray};
 
 macro_rules! lorawan_key {
     (

--- a/lorawan-encoding/src/parser.rs
+++ b/lorawan-encoding/src/parser.rs
@@ -26,7 +26,7 @@ use super::keys::{AppKey, AppSKey, CryptoFactory, Encrypter, AES128, MIC};
 use super::maccommands::{ChannelMask, DLSettings, Frequency};
 
 use super::securityhelpers;
-use super::securityhelpers::generic_array::GenericArray;
+use super::securityhelpers::generic_array::Array as GenericArray;
 
 use super::packet_length::phy::{join::*, mac::FPORT_LEN, MHDR_LEN, MIC_LEN, PHY_PAYLOAD_MIN_LEN};
 

--- a/lorawan-encoding/src/securityhelpers.rs
+++ b/lorawan-encoding/src/securityhelpers.rs
@@ -1,6 +1,6 @@
 use super::keys;
-pub use generic_array;
-use generic_array::GenericArray;
+pub use hybrid_array as generic_array;
+use hybrid_array::Array as GenericArray;
 
 /// calculate_data_mic computes the MIC of a correct data packet.
 pub fn calculate_data_mic<M: keys::Mac>(data: &[u8], key: M, fcnt: u32) -> keys::MIC {


### PR DESCRIPTION
Migrating from generic_array to hybrid_array as per #126 