### PR TITLE
Drop GenericArray requirement from lorawan-device

### DIFF
--- a/examples/nrf52840/build.rs
+++ b/examples/nrf52840/build.rs
@@ -82,7 +82,7 @@ fn main() {
     // Put linker configuration in our output directory and ensure it's
     // on the linker search path.
     if cfg!(feature = "link-to-ram") {
-        File::create(out.join("link_ram_cortex_m.x"))
+        File::create(out.join("link_ram.x"))
             .unwrap()
             .write_all(include_bytes!("../link_ram_cortex_m.x"))
             .unwrap();

--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -22,7 +22,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 lora-modulation = { path = "../lora-modulation", version = ">=0.1.2", default-features = false }
 lorawan = { path = "../lorawan-encoding", version = "0.9", default-features = false }
 heapless = "0.7"
-generic-array = "0.14"
 defmt = { version = "0.3", optional = true }
 fastrand = { version = "2", default-features = false }
 futures = { version = "0.3", default-features = false }

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -3,13 +3,11 @@ use heapless::Vec;
 use lorawan::keys::CryptoFactory;
 use lorawan::maccommands::{DownlinkMacCommand, MacCommandIterator};
 use lorawan::{
-    creator::DataPayloadCreator,
+    creator::{DataPayloadArray, DataPayloadCreator},
     maccommands::SerializableMacCommand,
     parser::{parse_with_factory as lorawan_parse, *},
     parser::{DecryptedJoinAcceptPayload, DevAddr},
 };
-
-use generic_array::{typenum::U256, GenericArray};
 
 use crate::radio::RadioBuffer;
 
@@ -186,7 +184,7 @@ impl Session {
     ) -> FcntUp {
         tx_buffer.clear();
         let fcnt = self.fcnt_up;
-        let mut phy: DataPayloadCreator<GenericArray<u8, U256>, C> = DataPayloadCreator::default();
+        let mut phy: DataPayloadCreator<DataPayloadArray, C> = DataPayloadCreator::default();
 
         let mut fctrl = FCtrl(0x0, true);
         if self.uplink.confirms_downlink() {

--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -13,9 +13,6 @@ use super::default_crypto::DefaultFactory;
 
 use generic_array::GenericArray;
 
-#[cfg(feature = "default-crypto")]
-use aes::cipher::generic_array::typenum::U256;
-
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
@@ -27,6 +24,8 @@ pub enum Error {
 }
 
 const PIGGYBACK_MAC_COMMANDS_MAX_LEN: usize = 15;
+
+pub type DataPayloadArray = GenericArray<u8, generic_array::typenum::U256>;
 
 /// JoinAcceptCreator serves for creating binary representation of Physical
 /// Payload of JoinAccept.
@@ -530,7 +529,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> DataPayloadCreator<D, F> {
 }
 
 #[cfg(feature = "default-crypto")]
-impl DataPayloadCreator<GenericArray<u8, U256>, DefaultFactory> {
+impl DataPayloadCreator<DataPayloadArray, DefaultFactory> {
     /// Creates a well initialized DataPayloadCreator.
     ///
     /// By default the packet is unconfirmed data up packet.
@@ -551,7 +550,7 @@ impl DataPayloadCreator<GenericArray<u8, U256>, DefaultFactory> {
     /// let payload = phy.build(b"hello", &[], &nwk_skey, &app_skey).unwrap();
     /// ```
     pub fn new() -> Self {
-        let mut data: GenericArray<u8, U256> = GenericArray::default();
+        let mut data: DataPayloadArray = GenericArray::default();
         data[0] = 0x40;
         Self { data, data_f_port: None, fcnt: 0, factory: DefaultFactory }
     }


### PR DESCRIPTION
This is first step towards #126, though I have some doubts whether this is implemented in acceptable way...