### PR TITLE
async_device: Make rng accessible externally

### DIFF
--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -54,7 +54,8 @@ where
 {
     crypto: PhantomData<C>,
     radio: R,
-    rng: G,
+    /// Access to provided (pseudo)-random number generator.
+    pub rng: G,
     timer: T,
     mac: Mac,
     radio_buffer: RadioBuffer<N>,
@@ -173,7 +174,6 @@ where
 
     /// Enables Class C behavior. Note that Class C downlinks are not possible until a confirmed
     /// uplink is sent to the LNS.
-
     pub fn enable_class_c(&mut self) {
         self.class_c = true;
     }


### PR DESCRIPTION
One use-case for rng usage is using random delay before attempting to join the network:

```rust
use rand::Rng as _;

// Generate random timeout when attempting to join...
let timeout = lora_device.rng.gen_range(15..=150);
Timer::after(Duration::from_secs(timeout)).await;

// Attempt LoRaWAN Join
let join_result = lora_device.join(&join_mode).await;

...
```

Also, I would like to add this to examples as well but my RAK4630 device doesn't allow flashing anymore...