### PR TITLE
actions: Switch from actions-rs/toolchain@v1 to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,11 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           components: clippy, rustfmt
-          override: true
 
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.12.1


### PR DESCRIPTION
This gets rid of the github-actions deprecation messages.