### PR TITLE
lora-phy: Add API for specifying the sync word

### DIFF
--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -72,7 +72,11 @@ where
         Ok(lora)
     }
 
-    /// Build and return a new instance of the LoRa physical layer API to control an initialized LoRa radio
+    /// Build and return a new instance of the LoRa physical layer API to
+    /// control an initialized LoRa radio for LoRaWAN public or private network.
+    ///
+    /// In order to configure radio to use non-LoRaWAN networks, use
+    /// [`Self::with_syncword()`] which has `sync_word` argument.
     pub async fn new(radio_kind: RK, enable_public_network: bool, delay: DLY) -> Result<Self, RadioError> {
         let sync_word = if enable_public_network {
             LORAWAN_PUBLIC_SYNCWORD

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -57,8 +57,8 @@ where
     RK: RadioKind,
     DLY: DelayNs,
 {
-    /// Build and return a new instance of the LoRa physical layer API to control an initialized LoRa radio
-    pub async fn new(radio_kind: RK, sync_word: u8, delay: DLY) -> Result<Self, RadioError> {
+    /// Build and return a new instance of the LoRa physical layer API with a specified sync word
+    pub async fn with_syncword(radio_kind: RK, sync_word: u8, delay: DLY) -> Result<Self, RadioError> {
         let mut lora = Self {
             radio_kind,
             delay,
@@ -70,6 +70,16 @@ where
         lora.init().await?;
 
         Ok(lora)
+    }
+
+    /// Build and return a new instance of the LoRa physical layer API to control an initialized LoRa radio
+    pub async fn new(radio_kind: RK, enable_public_network: bool, delay: DLY) -> Result<Self, RadioError> {
+        let sync_word = if enable_public_network {
+            LORAWAN_PUBLIC_SYNCWORD
+        } else {
+            LORAWAN_PRIVATE_SYNCWORD
+        };
+        Self::with_syncword(radio_kind, sync_word, delay).await
     }
 
     /// Wait for an IRQ event to occur

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -12,12 +12,6 @@
 /// Provides an implementation of the async LoRaWAN device trait.
 pub mod lorawan_radio;
 
-/// Sync word for public LoRaWAN networks
-pub const LORAWAN_PUBLIC_SYNCWORD: u8 = 0x34;
-
-/// Sync word for private LoRaWAN networks
-pub const LORAWAN_PRIVATE_SYNCWORD: u8 = 0x12;
-
 /// The read/write interface between an embedded framework/MCU combination and a LoRa chip
 pub(crate) mod interface;
 /// InterfaceVariant implementations using `embedded-hal`.
@@ -37,6 +31,12 @@ pub use embedded_hal_async::delay::DelayNs;
 use interface::*;
 use mod_params::*;
 use mod_traits::*;
+
+/// Sync word for public LoRaWAN networks
+const LORAWAN_PUBLIC_SYNCWORD: u8 = 0x34;
+
+/// Sync word for private LoRaWAN networks
+const LORAWAN_PRIVATE_SYNCWORD: u8 = 0x12;
 
 /// Provides the physical layer API to support LoRa chips
 pub struct LoRa<RK, DLY>

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -34,7 +34,7 @@ pub enum IrqState {
 #[allow(async_fn_in_trait)]
 pub trait RadioKind {
     /// Initialize lora radio
-    async fn init_lora(&mut self, is_public_network: bool) -> Result<(), RadioError>;
+    async fn init_lora(&mut self, sync_word: u8) -> Result<(), RadioError>;
     /// Create modulation parameters specific to the LoRa chip kind and type
     fn create_modulation_params(
         &self,

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -177,6 +177,11 @@ where
     }
 }
 
+// Convert u8 sync word to two byte value expected by sx126x
+fn convert_sync_word(sync_word: u8) -> [u8; 2] {
+    [(sync_word & 0xF0) | 0x04, ((sync_word & 0x0F) << 4) | 0x04]
+}
+
 impl<SPI, IV, C> RadioKind for Sx126x<SPI, IV, C>
 where
     SPI: SpiDevice<u8>,
@@ -232,12 +237,13 @@ where
             .write(&[OpCode::SetPacketType.value(), PacketType::LoRa.value()], false)
             .await?;
         // ...and network syncword
+        let word = convert_sync_word(sync_word);
         let lora_syncword_set = [
             OpCode::WriteRegister.value(),
             Register::LoRaSyncword.addr1(),
             Register::LoRaSyncword.addr2(),
-            (sync_word & 0xF0) | 0x04,
-            ((sync_word & 0x0F) << 4) | 0x04,
+            word[0],
+            word[1],
         ];
         self.intf.write(&lora_syncword_set, false).await?;
 
@@ -946,7 +952,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    // use super::*;
+    use super::*;
 
     #[test]
     // -17 (0xEF) to +14 (0x0E) dBm by step of 1 dB if low power PA is selected
@@ -956,5 +962,14 @@ mod tests {
         assert_eq!(i32_val as u8, 0xefu8);
         i32_val = -9;
         assert_eq!(i32_val as u8, 0xf7u8);
+    }
+
+    #[test]
+    fn test_convert_sync_word() {
+        // sx126x 0x3444 corresponds to sx127 0x34
+        assert_eq!(convert_sync_word(0x34), [0x34, 0x44]);
+
+        // sx126x 0x1424 corresponds to sx127 0x12
+        assert_eq!(convert_sync_word(0x12), [0x14, 0x24]);
     }
 }

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -13,10 +13,6 @@ use crate::mod_params::*;
 use crate::mod_traits::IrqState;
 use crate::{InterfaceVariant, RadioKind, SpiInterface};
 
-// Syncwords for public and private networks
-const LORA_MAC_PUBLIC_SYNCWORD: u8 = 0x34; // corresponds to sx126x 0x3444
-const LORA_MAC_PRIVATE_SYNCWORD: u8 = 0x12; // corresponds to sx126x 0x1424
-
 // TCXO flag
 const TCXO_FOR_OSCILLATOR: u8 = 0x10u8;
 
@@ -122,17 +118,12 @@ where
     IV: InterfaceVariant,
     C: Sx127xVariant,
 {
-    async fn init_lora(&mut self, is_public_network: bool) -> Result<(), RadioError> {
+    async fn init_lora(&mut self, sync_word: u8) -> Result<(), RadioError> {
         if self.config.tcxo_used {
             self.write_register(C::reg_txco(), TCXO_FOR_OSCILLATOR).await?;
         }
 
-        let syncword = if is_public_network {
-            LORA_MAC_PUBLIC_SYNCWORD
-        } else {
-            LORA_MAC_PRIVATE_SYNCWORD
-        };
-        self.write_register(Register::RegSyncWord, syncword).await?;
+        self.write_register(Register::RegSyncWord, sync_word).await?;
 
         self.set_tx_rx_buffer_base_address(0, 0).await?;
         Ok(())


### PR DESCRIPTION
This is manually rebased version of #288.