### PR TITLE
lorawan-encoding: Rename NewSKey to NwkSKey

### DIFF
--- a/lorawan-device/CHANGELOG.md
+++ b/lorawan-device/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## Unreleased
 
+- Deprecate NewSKey in favor of more commonly used NwkSKey
 - Rename the defmt feature to defmt-03
 
 ## [v0.12.1]

--- a/lorawan-device/src/lib.rs
+++ b/lorawan-device/src/lib.rs
@@ -33,9 +33,12 @@ use core::marker::PhantomData;
 #[cfg_attr(docsrs, doc(cfg(feature = "default-crypto")))]
 pub use lorawan::default_crypto;
 pub use lorawan::{
-    keys::{AppEui, AppKey, AppSKey, CryptoFactory, DevEui, NewSKey},
+    keys::{AppEui, AppKey, AppSKey, CryptoFactory, DevEui, NwkSKey},
     parser::DevAddr,
 };
+
+#[deprecated(since = "0.12.2", note = "Please use `NwkSKey` instead")]
+pub use lorawan::keys::NwkSKey as NewSKey;
 
 pub use rand_core::RngCore;
 mod rng;
@@ -75,5 +78,5 @@ pub trait Timings {
 /// Join the network using either OTAA or ABP.
 pub enum JoinMode {
     OTAA { deveui: DevEui, appeui: AppEui, appkey: AppKey },
-    ABP { newskey: NewSKey, appskey: AppSKey, devaddr: DevAddr<[u8; 4]> },
+    ABP { newskey: NwkSKey, appskey: AppSKey, devaddr: DevAddr<[u8; 4]> },
 }

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     radio::{self, RadioBuffer, RfConfig, RxConfig, RxMode},
-    region, AppSKey, Downlink, NewSKey,
+    region, AppSKey, Downlink, NwkSKey,
 };
 use heapless::Vec;
 use lorawan::{self, keys::CryptoFactory};
@@ -145,7 +145,7 @@ impl Mac {
     /// Join via ABP. This does not transmit a join request frame, but instead sets the session.
     pub(crate) fn join_abp(
         &mut self,
-        newskey: NewSKey,
+        newskey: NwkSKey,
         appskey: AppSKey,
         devaddr: DevAddr<[u8; 4]>,
     ) {

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -1,4 +1,4 @@
-use crate::{region, AppSKey, Downlink, NewSKey};
+use crate::{region, AppSKey, Downlink, NwkSKey};
 use heapless::Vec;
 use lorawan::keys::CryptoFactory;
 use lorawan::maccommands::{DownlinkMacCommand, MacCommandIterator};
@@ -24,7 +24,7 @@ use super::{
 pub struct Session {
     pub uplink: uplink::Uplink,
     pub confirmed: bool,
-    pub newskey: NewSKey,
+    pub newskey: NwkSKey,
     pub appskey: AppSKey,
     pub devaddr: DevAddr<[u8; 4]>,
     pub fcnt_up: u32,
@@ -34,7 +34,7 @@ pub struct Session {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct SessionKeys {
-    pub newskey: NewSKey,
+    pub newskey: NwkSKey,
     pub appskey: AppSKey,
     pub devaddr: DevAddr<[u8; 4]>,
 }
@@ -52,7 +52,7 @@ impl Session {
         credentials: &NetworkCredentials,
     ) -> Self {
         Self::new(
-            decrypt.derive_newskey(&devnonce, credentials.appkey()),
+            decrypt.derive_nwkskey(&devnonce, credentials.appkey()),
             decrypt.derive_appskey(&devnonce, credentials.appkey()),
             DevAddr::new([
                 decrypt.dev_addr().as_ref()[0],
@@ -64,7 +64,7 @@ impl Session {
         )
     }
 
-    pub fn new(newskey: NewSKey, appskey: AppSKey, devaddr: DevAddr<[u8; 4]>) -> Self {
+    pub fn new(newskey: NwkSKey, appskey: AppSKey, devaddr: DevAddr<[u8; 4]>) -> Self {
         Self {
             newskey,
             appskey,
@@ -82,7 +82,7 @@ impl Session {
     pub fn appskey(&self) -> &AppSKey {
         &self.appskey
     }
-    pub fn newskey(&self) -> &NewSKey {
+    pub fn newskey(&self) -> &NwkSKey {
         &self.newskey
     }
 

--- a/lorawan-encoding/CHANGELOG.md
+++ b/lorawan-encoding/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## Unreleased
 
 - Remove defmt feature from defaults, rename to defmt-03
+- Mark `NewSKey` deprecated in favor of `NwkSkey` which is used in most LoRaWAN documentation.
 
 ## [v0.9.0]
 - for AppEui, DevEui, AppKey: implement `core::str::FromStr`  (#[nostd] compatible) and

--- a/lorawan-encoding/Cargo.toml
+++ b/lorawan-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorawan"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Ivaylo Petrov <ivajloip@gmail.com>"]
 description = "Crate lorawan provides structures and tools for reading and writing LoRaWAN messages from and to a slice of bytes."

--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -2,7 +2,7 @@
 //!
 //! See [JoinAcceptCreator.new](struct.JoinAcceptCreator.html#method.new) for an example.
 
-use super::keys::{AppKey, AppSKey, CryptoFactory, Decrypter, NewSKey, AES128};
+use super::keys::{AppKey, AppSKey, CryptoFactory, Decrypter, NwkSKey, AES128};
 use super::maccommandcreator;
 use super::maccommands::{mac_commands_len, DLSettings, Frequency, SerializableMacCommand};
 use super::parser;
@@ -301,7 +301,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory> JoinRequestCreator<D, F> {
 ///
 /// ```
 /// let mut phy = lorawan::creator::DataPayloadCreator::new();
-/// let nwk_skey = lorawan::keys::NewSKey::from([2; 16]);
+/// let nwk_skey = lorawan::keys::NwkSKey::from([2; 16]);
 /// let app_skey = lorawan::keys::AppSKey::from([1; 16]);
 /// phy.set_confirmed(true)
 ///     .set_uplink(true)
@@ -448,7 +448,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> DataPayloadCreator<D, F> {
     /// let mut cmds: Vec<&dyn lorawan::maccommands::SerializableMacCommand> = Vec::new();
     /// cmds.push(&mac_cmd1);
     /// cmds.push(&mac_cmd2);
-    /// let nwk_skey = lorawan::keys::NewSKey::from([2; 16]);
+    /// let nwk_skey = lorawan::keys::NwkSKey::from([2; 16]);
     /// let app_skey = lorawan::keys::AppSKey::from([1; 16]);
     /// phy.build(&[], &cmds, &nwk_skey, &app_skey).unwrap();
     /// ```
@@ -456,7 +456,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> DataPayloadCreator<D, F> {
         &mut self,
         payload: &[u8],
         cmds: &[&dyn SerializableMacCommand],
-        nwk_skey: &NewSKey,
+        nwk_skey: &NwkSKey,
         app_skey: &AppSKey,
     ) -> Result<&[u8], Error> {
         let d = self.data.as_mut();
@@ -539,7 +539,7 @@ impl DataPayloadCreator<GenericArray<u8, U256>, DefaultFactory> {
     ///
     /// ```
     /// let mut phy = lorawan::creator::DataPayloadCreator::new();
-    /// let nwk_skey = lorawan::keys::NewSKey::from([2; 16]);
+    /// let nwk_skey = lorawan::keys::NwkSKey::from([2; 16]);
     /// let app_skey = lorawan::keys::AppSKey::from([1; 16]);
     /// let fctrl = lorawan::parser::FCtrl::new(0x80, true);
     /// phy.set_confirmed(false).

--- a/lorawan-encoding/src/keys.rs
+++ b/lorawan-encoding/src/keys.rs
@@ -52,25 +52,6 @@ lorawan_key!(
     pub struct AppKey(AES128);
 );
 lorawan_key!(
-    /// You can construct NewSKey from a hex-encoded MSB string or bytes in MSB format.
-    ///
-    /// Typically, a LNS will provide a hex-encoded MSB string such as: `00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF`.
-    ///
-    /// To create from a string:
-    /// ```
-    /// use lorawan::keys::NewSKey;
-    /// use core::str::FromStr;
-    /// let newskey = NewSKey::from_str("00112233445566778899aabbccddeeff").unwrap();
-    /// ```
-    ///
-    /// To create from a byte array, you should enter the bytes in MSB format:
-    /// ```
-    /// use lorawan::keys::NewSKey;
-    /// let newskey = NewSKey::from([0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
-    /// ```
-    pub struct NewSKey(AES128);
-);
-lorawan_key!(
     /// You can construct AppSKey from a hex-encoded MSB string or bytes in MSB format.
     ///
     /// Typically, a LNS will provide a hex-encoded MSB string format such as: `00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF`.
@@ -89,6 +70,29 @@ lorawan_key!(
     /// ```
     pub struct AppSKey(AES128);
 );
+
+lorawan_key!(
+    /// You can construct NwkSKey from a hex-encoded MSB string or bytes in MSB format.
+    ///
+    /// Typically, a LNS will provide a hex-encoded MSB string such as: `00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF`.
+    ///
+    /// To create from a string:
+    /// ```
+    /// use lorawan::keys::NwkSKey;
+    /// use core::str::FromStr;
+    /// let nwkskey = NwkSKey::from_str("00112233445566778899aabbccddeeff").unwrap();
+    /// ```
+    ///
+    /// To create from a byte array, you should enter the bytes in MSB format:
+    /// ```
+    /// use lorawan::keys::NwkSKey;
+    /// let nwkskey = NwkSKey::from([0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+    /// ```
+    pub struct NwkSKey(AES128);
+);
+
+#[deprecated(since = "0.9.1", note = "Please use `NwkSKey` instead")]
+pub type NewSKey = NwkSKey;
 
 macro_rules! lorawan_eui {
     (

--- a/lorawan-encoding/src/parser.rs
+++ b/lorawan-encoding/src/parser.rs
@@ -20,9 +20,7 @@
 //! }
 //! ```
 
-use crate::keys::NewSKey;
-
-use super::keys::{AppKey, AppSKey, CryptoFactory, Encrypter, AES128, MIC};
+use super::keys::{AppKey, AppSKey, CryptoFactory, Encrypter, NwkSKey, AES128, MIC};
 use super::maccommands::{ChannelMask, DLSettings, Frequency};
 
 use super::securityhelpers;
@@ -427,17 +425,26 @@ impl<T: AsRef<[u8]>, F: CryptoFactory> DecryptedJoinAcceptPayload<T, F> {
     ///     0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
     /// let join_accept = lorawan::parser::DecryptedJoinAcceptPayload::new(data, &app_key).unwrap();
     ///
-    /// let nwk_skey = join_accept.derive_newskey(
+    /// let nwk_skey = join_accept.derive_nwkskey(
     ///     &lorawan::parser::DevNonce::new(&dev_nonce[..]).unwrap(),
     ///     &app_key,
     /// );
     /// ```
+    pub fn derive_nwkskey<TT: AsRef<[u8]>>(
+        &self,
+        dev_nonce: &DevNonce<TT>,
+        key: &AppKey,
+    ) -> NwkSKey {
+        NwkSKey(self.derive_session_key(0x1, dev_nonce, &key.0))
+    }
+
+    #[deprecated(since = "0.9.1", note = "Please use `derive_nwkskey` instead")]
     pub fn derive_newskey<TT: AsRef<[u8]>>(
         &self,
         dev_nonce: &DevNonce<TT>,
         key: &AppKey,
-    ) -> NewSKey {
-        NewSKey(self.derive_session_key(0x1, dev_nonce, &key.0))
+    ) -> NwkSKey {
+        NwkSKey(self.derive_session_key(0x1, dev_nonce, &key.0))
     }
 
     /// Computes the application session key for a given device.

--- a/lorawan-encoding/src/string.rs
+++ b/lorawan-encoding/src/string.rs
@@ -115,7 +115,7 @@ fixed_len_struct_impl_to_string_msb! {
 }
 
 fixed_len_struct_impl_to_string_msb! {
-    NewSKey, 16;
+    NwkSKey, 16;
 }
 
 fixed_len_struct_impl_to_string_msb! {

--- a/lorawan-encoding/tests/lorawan.rs
+++ b/lorawan-encoding/tests/lorawan.rs
@@ -632,18 +632,18 @@ fn test_join_request_creator_with_options() {
 }
 
 #[test]
-fn test_derive_newskey() {
+fn test_derive_nwkskey() {
     let key = AppKey::from(app_key());
     let join_request = JoinRequestPayload::new(phy_join_request_payload()).unwrap();
     let join_accept = DecryptedJoinAcceptPayload::new(phy_join_accept_payload(), &key).unwrap();
 
-    let newskey = join_accept.derive_newskey(&join_request.dev_nonce(), &key);
+    let nwkskey = join_accept.derive_nwkskey(&join_request.dev_nonce(), &key);
     //AppNonce([49, 3e, eb]), NwkAddr([51, fb, a2]), DevNonce([2d, 10])
-    let expect = NewSKey::from([
+    let expect = NwkSKey::from([
         0x7b, 0xb2, 0x5f, 0x89, 0xe0, 0xd1, 0x37, 0x1e, 0x1f, 0xbf, 0x4d, 0x99, 0x7e, 0x14, 0x68,
         0xa3,
     ]);
-    assert_eq!(newskey, expect);
+    assert_eq!(nwkskey, expect);
 }
 
 #[test]


### PR DESCRIPTION
Should be mostly backwards compatible.