### PR TITLE
encoding: Update README to mention that LoRaWAN 1.0.4 is implemented

### DIFF
--- a/lorawan-encoding/README.md
+++ b/lorawan-encoding/README.md
@@ -4,7 +4,7 @@
 [![Docs]][doc.rs]
 
 The lorawan library provides structures and tools for reading and writing
-LoRaWAN 1.0.2 messages from and to slices of bytes.
+LoRaWAN 1.0.4 messages from and to slices of bytes.
 
 ## Sample Packet manipulation
 


### PR DESCRIPTION
README still mentions 1.0.2, though 1.0.4 commands were implemented some time ago in commit e486447:

- TXParamSetupReq/TXParamSetupAns
- DeviceTimeReq/DeviceTimeAns
- DlChannelReq/DlChannelAns

Need to validate fully though...