### PR TITLE
Move common internal data types (frequency, dlsettings, etc) from maccomands to `lorawan::types`

### DIFF
--- a/lorawan-encoding/README.md
+++ b/lorawan-encoding/README.md
@@ -24,8 +24,9 @@ lorawan = "0.9"
 ### Packet generation
 
 ```rust
-use lorawan::{creator::JoinAcceptCreator, keys, maccommands};
+use lorawan::{creator::JoinAcceptCreator, keys};
 use lorawan::default_crypto::DefaultFactory;
+use lorawan::types::Frequency;
 use heapless;
 
 fn main() {
@@ -38,9 +39,9 @@ fn main() {
     phy.set_dev_addr(&[1; 4]);
     phy.set_dl_settings(2);
     phy.set_rx_delay(1);
-    let mut freqs: heapless::Vec<lorawan::maccommands::Frequency, 2> = heapless::Vec::new();
-    freqs.push(maccommands::Frequency::new(&[0x58, 0x6e, 0x84,]).unwrap()).unwrap();
-    freqs.push(maccommands::Frequency::new(&[0x88, 0x66, 0x84,]).unwrap()).unwrap();
+    let mut freqs: heapless::Vec<Frequency, 2> = heapless::Vec::new();
+    freqs.push(Frequency::new(&[0x58, 0x6e, 0x84,]).unwrap()).unwrap();
+    freqs.push(Frequency::new(&[0x88, 0x66, 0x84,]).unwrap()).unwrap();
     phy.set_c_f_list(freqs).unwrap();
     let payload = phy.build(&key).unwrap();
     println!("Payload: {:x?}", payload);

--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -4,10 +4,10 @@
 
 use super::keys::{AppKey, AppSKey, CryptoFactory, Decrypter, NwkSKey, AES128};
 use super::maccommandcreator;
-use super::maccommands::{mac_commands_len, DLSettings, SerializableMacCommand};
-use crate::types::Frequency;
+use super::maccommands::{mac_commands_len, SerializableMacCommand};
 use super::parser;
 use super::securityhelpers;
+use crate::types::{DLSettings, Frequency};
 
 #[cfg(feature = "default-crypto")]
 use super::default_crypto::DefaultFactory;

--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -4,7 +4,8 @@
 
 use super::keys::{AppKey, AppSKey, CryptoFactory, Decrypter, NwkSKey, AES128};
 use super::maccommandcreator;
-use super::maccommands::{mac_commands_len, DLSettings, Frequency, SerializableMacCommand};
+use super::maccommands::{mac_commands_len, DLSettings, SerializableMacCommand};
+use crate::types::Frequency;
 use super::parser;
 use super::securityhelpers;
 
@@ -196,9 +197,9 @@ impl JoinAcceptCreator<[u8; 33], DefaultFactory> {
     /// phy.set_dev_addr(&[1; 4]);
     /// phy.set_dl_settings(2);
     /// phy.set_rx_delay(1);
-    /// let mut freqs: Vec<lorawan::maccommands::Frequency> = Vec::new();
-    /// freqs.push(lorawan::maccommands::Frequency::new(&[0x58, 0x6e, 0x84,]).unwrap());
-    /// freqs.push(lorawan::maccommands::Frequency::new(&[0x88, 0x66, 0x84,]).unwrap());
+    /// let mut freqs: Vec<lorawan::types::Frequency> = Vec::new();
+    /// freqs.push(lorawan::types::Frequency::new(&[0x58, 0x6e, 0x84,]).unwrap());
+    /// freqs.push(lorawan::types::Frequency::new(&[0x88, 0x66, 0x84,]).unwrap());
     /// phy.set_c_f_list(freqs);
     /// let payload = phy.build(&key).unwrap();
     /// ```

--- a/lorawan-encoding/src/lib.rs
+++ b/lorawan-encoding/src/lib.rs
@@ -13,6 +13,7 @@ mod macros;
 pub mod packet_length;
 pub mod parser;
 pub mod string;
+pub mod types;
 
 #[cfg(feature = "full")]
 pub mod extra;

--- a/lorawan-encoding/src/maccommandcreator.rs
+++ b/lorawan-encoding/src/maccommandcreator.rs
@@ -1,7 +1,5 @@
-use super::maccommands::{
-    mac_commands_len, DLSettings, DataRateRange, Redundancy, SerializableMacCommand,
-};
-use crate::types::{ChannelMask, Frequency};
+use super::maccommands::{mac_commands_len, DataRateRange, Redundancy, SerializableMacCommand};
+use crate::types::{ChannelMask, DLSettings, Frequency};
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]

--- a/lorawan-encoding/src/maccommandcreator.rs
+++ b/lorawan-encoding/src/maccommandcreator.rs
@@ -1,7 +1,7 @@
 use super::maccommands::{
-    mac_commands_len, ChannelMask, DLSettings, DataRateRange, Frequency, Redundancy,
-    SerializableMacCommand,
+    mac_commands_len, DLSettings, DataRateRange, Frequency, Redundancy, SerializableMacCommand,
 };
+use crate::types::ChannelMask;
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]

--- a/lorawan-encoding/src/maccommandcreator.rs
+++ b/lorawan-encoding/src/maccommandcreator.rs
@@ -1,5 +1,5 @@
-use super::maccommands::{mac_commands_len, DataRateRange, Redundancy, SerializableMacCommand};
-use crate::types::{ChannelMask, DLSettings, Frequency};
+use super::maccommands::{mac_commands_len, DataRateRange, SerializableMacCommand};
+use crate::types::{ChannelMask, DLSettings, Frequency, Redundancy};
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
@@ -233,7 +233,7 @@ impl LinkADRReqCreator {
     ///
     /// # Argument
     ///
-    /// * redundancy - instance of maccommands::Redundancy or anything that can
+    /// * redundancy - instance of types::Redundancy or anything that can
     ///   be converted into it.
     pub fn set_redundancy<T: Into<Redundancy>>(&mut self, redundancy: T) -> &mut Self {
         let converted = redundancy.into();

--- a/lorawan-encoding/src/maccommandcreator.rs
+++ b/lorawan-encoding/src/maccommandcreator.rs
@@ -1,7 +1,7 @@
 use super::maccommands::{
-    mac_commands_len, DLSettings, DataRateRange, Frequency, Redundancy, SerializableMacCommand,
+    mac_commands_len, DLSettings, DataRateRange, Redundancy, SerializableMacCommand,
 };
-use crate::types::ChannelMask;
+use crate::types::{ChannelMask, Frequency};
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]

--- a/lorawan-encoding/src/maccommandcreator.rs
+++ b/lorawan-encoding/src/maccommandcreator.rs
@@ -1,4 +1,7 @@
-use super::maccommands::*;
+use super::maccommands::{
+    mac_commands_len, ChannelMask, DLSettings, DataRateRange, Frequency, Redundancy,
+    SerializableMacCommand,
+};
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]

--- a/lorawan-encoding/src/maccommandcreator.rs
+++ b/lorawan-encoding/src/maccommandcreator.rs
@@ -1,5 +1,5 @@
-use super::maccommands::{mac_commands_len, DataRateRange, SerializableMacCommand};
-use crate::types::{ChannelMask, DLSettings, Frequency, Redundancy};
+use super::maccommands::{mac_commands_len, SerializableMacCommand};
+use crate::types::{ChannelMask, DataRateRange, DLSettings, Frequency, Redundancy};
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]

--- a/lorawan-encoding/src/maccommandcreator.rs
+++ b/lorawan-encoding/src/maccommandcreator.rs
@@ -1,5 +1,5 @@
 use super::maccommands::{mac_commands_len, SerializableMacCommand};
-use crate::types::{ChannelMask, DataRateRange, DLSettings, Frequency, Redundancy};
+use crate::types::{ChannelMask, DLSettings, DataRateRange, Frequency, Redundancy};
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]

--- a/lorawan-encoding/src/maccommands.rs
+++ b/lorawan-encoding/src/maccommands.rs
@@ -1,6 +1,9 @@
 use crate::macros::{mac_cmd_zero_len, mac_cmds, mac_cmds_enum};
 use core::marker::PhantomData;
 
+#[deprecated(note = "Use lorawan::types::ChannelMask")]
+pub use crate::types::ChannelMask;
+
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Error {
@@ -283,147 +286,6 @@ impl LinkADRReqPayload<'_> {
 impl<'a> From<&'a [u8; 4]> for LinkADRReqPayload<'a> {
     fn from(v: &'a [u8; 4]) -> Self {
         LinkADRReqPayload(v)
-    }
-}
-
-/// ChannelMask represents the ChannelMask from LoRaWAN.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ChannelMask<const N: usize>([u8; N]);
-
-impl<const N: usize> Default for ChannelMask<N> {
-    fn default() -> Self {
-        ChannelMask([0xFF; N])
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<const N: usize> serde::Serialize for ChannelMask<N> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeSeq;
-        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-        for e in &self.0 {
-            seq.serialize_element(e)?;
-        }
-        seq.end()
-    }
-}
-
-#[cfg(feature = "serde")]
-struct ChannelMaskDeserializer<const N: usize>;
-
-#[cfg(feature = "serde")]
-impl<'de, const N: usize> serde::de::Visitor<'de> for ChannelMaskDeserializer<N> {
-    type Value = ChannelMask<N>;
-
-    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        formatter.write_str("ChannelMask byte.")
-    }
-
-    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-    where
-        A: serde::de::SeqAccess<'de>,
-    {
-        let mut arr = [0; N];
-        let mut index = 0;
-        while let Some(el) = seq.next_element()? {
-            if index >= N {
-                return Err(serde::de::Error::custom("ChannelMask has too many elements"));
-            } else {
-                arr[index] = el;
-                index += 1;
-            }
-        }
-        Ok(ChannelMask(arr))
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de, const N: usize> serde::Deserialize<'de> for ChannelMask<N> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(ChannelMaskDeserializer {})
-    }
-}
-
-impl<const N: usize> ChannelMask<N> {
-    /// Constructs a new ChannelMask from the provided data.
-    pub fn new(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < N {
-            return Err(Error::BufferTooShort);
-        }
-        Ok(Self::new_from_raw(data))
-    }
-
-    pub fn set_bank(&mut self, index: usize, value: u8) {
-        self.0[index] = value;
-    }
-
-    /// Enable or disable a specific channel. Recall that LoRaWAN channel numbers start indexing
-    /// at zero.
-    ///
-    /// Improper use of this method could lead to out of bounds panic during runtime!
-    pub fn set_channel(&mut self, channel: usize, set: bool) {
-        let index = channel >> 3;
-        let mut flag = 0b1 << (channel & 0x07);
-        if set {
-            self.0[index] |= flag;
-        } else {
-            flag = !flag;
-            self.0[index] &= flag;
-        }
-    }
-
-    pub fn get_index(&self, index: usize) -> u8 {
-        self.0[index]
-    }
-
-    /// Constructs a new ChannelMask from the provided data, without verifying if they are
-    /// admissible.
-    ///
-    /// Improper use of this method could lead to panic during runtime!
-    pub fn new_from_raw(data: &[u8]) -> Self {
-        let mut payload = [0; N];
-        payload[..N].copy_from_slice(&data[..N]);
-        ChannelMask(payload)
-    }
-
-    fn channel_enabled(&self, index: usize) -> bool {
-        self.0[index >> 3] & (1 << (index & 0x07)) != 0
-    }
-
-    /// Verifies if a given channel is enabled.
-    pub fn is_enabled(&self, index: usize) -> Result<bool, Error> {
-        let index_limit = N * 8 - 1;
-        if index > index_limit {
-            return Err(Error::InvalidIndex);
-        }
-        Ok(self.channel_enabled(index))
-    }
-
-    /// Provides information for each of the 16 channels if they are enabled.
-    pub fn statuses<const M: usize>(&self) -> [bool; M] {
-        let mut res = [false; M];
-        for (i, c) in res.iter_mut().enumerate() {
-            *c = self.channel_enabled(i);
-        }
-        res
-    }
-}
-
-impl<const N: usize> From<[u8; N]> for ChannelMask<N> {
-    fn from(v: [u8; N]) -> Self {
-        ChannelMask(v)
-    }
-}
-
-impl<const N: usize> AsRef<[u8]> for ChannelMask<N> {
-    fn as_ref(&self) -> &[u8] {
-        &self.0[..]
     }
 }
 

--- a/lorawan-encoding/src/maccommands.rs
+++ b/lorawan-encoding/src/maccommands.rs
@@ -2,18 +2,23 @@ use crate::macros::{mac_cmd_zero_len, mac_cmds, mac_cmds_enum};
 use core::marker::PhantomData;
 
 #[deprecated(note = "Use lorawan::types::ChannelMask")]
+#[doc(hidden)]
 pub use crate::types::ChannelMask;
 
 #[deprecated(note = "Use lorawan::types::DataRateRange")]
+#[doc(hidden)]
 use crate::types::DataRateRange;
 
 #[deprecated(note = "Use lorawan::types::DLSettings")]
+#[doc(hidden)]
 pub use crate::types::DLSettings;
 
 #[deprecated(note = "Use lorawan::types::Frequency")]
+#[doc(hidden)]
 pub use crate::types::Frequency;
 
 #[deprecated(note = "Use lorawan::types::Redundancy")]
+#[doc(hidden)]
 pub use crate::types::Redundancy;
 
 #[derive(Debug, PartialEq)]

--- a/lorawan-encoding/src/maccommands.rs
+++ b/lorawan-encoding/src/maccommands.rs
@@ -10,6 +10,9 @@ pub use crate::types::DLSettings;
 #[deprecated(note = "Use lorawan::types::Frequency")]
 pub use crate::types::Frequency;
 
+#[deprecated(note = "Use lorawan::types::Redundancy")]
+pub use crate::types::Redundancy;
+
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Error {
@@ -292,38 +295,6 @@ impl LinkADRReqPayload<'_> {
 impl<'a> From<&'a [u8; 4]> for LinkADRReqPayload<'a> {
     fn from(v: &'a [u8; 4]) -> Self {
         LinkADRReqPayload(v)
-    }
-}
-
-/// Redundancy represents the LinkADRReq Redundancy from LoRaWAN.
-#[derive(Debug, PartialEq, Eq)]
-pub struct Redundancy(u8);
-
-impl Redundancy {
-    /// Constructs a new Redundancy from the provided data.
-    pub fn new(data: u8) -> Self {
-        Redundancy(data)
-    }
-
-    /// Controls the interpretation of the previously defined ChannelMask bit mask.
-    pub fn channel_mask_control(&self) -> u8 {
-        (self.0 >> 4) & 0x07
-    }
-
-    /// How many times each message should be repeated.
-    pub fn number_of_transmissions(&self) -> u8 {
-        self.0 & 0x0f
-    }
-
-    /// The integer value of the Redundancy.
-    pub fn raw_value(&self) -> u8 {
-        self.0
-    }
-}
-
-impl From<u8> for Redundancy {
-    fn from(v: u8) -> Self {
-        Redundancy(v)
     }
 }
 

--- a/lorawan-encoding/src/maccommands.rs
+++ b/lorawan-encoding/src/maccommands.rs
@@ -4,6 +4,9 @@ use core::marker::PhantomData;
 #[deprecated(note = "Use lorawan::types::ChannelMask")]
 pub use crate::types::ChannelMask;
 
+#[deprecated(note = "Use lorawan::types::DLSettings")]
+pub use crate::types::DLSettings;
+
 #[deprecated(note = "Use lorawan::types::Frequency")]
 pub use crate::types::Frequency;
 
@@ -371,39 +374,6 @@ impl RXParamSetupReqPayload<'_> {
     /// RX2 frequency.
     pub fn frequency(&self) -> Frequency<'_> {
         Frequency::new_from_raw(&self.0[1..])
-    }
-}
-
-/// DLSettings represents LoRaWAN DLSettings.
-#[derive(Debug, PartialEq, Eq)]
-pub struct DLSettings(u8);
-
-impl DLSettings {
-    /// Constructs a new DLSettings from the provided data.
-    pub fn new(byte: u8) -> DLSettings {
-        DLSettings(byte)
-    }
-
-    /// The offset between the uplink data rate and the downlink data rate used to communicate with
-    /// the end-device on the first reception slot (RX1).
-    pub fn rx1_dr_offset(&self) -> u8 {
-        self.0 >> 4 & 0x07
-    }
-
-    /// The data rate of a downlink using the second receive window.
-    pub fn rx2_data_rate(&self) -> u8 {
-        self.0 & 0x0f
-    }
-
-    /// The integer value of the DL Settings.
-    pub fn raw_value(&self) -> u8 {
-        self.0
-    }
-}
-
-impl From<u8> for DLSettings {
-    fn from(v: u8) -> Self {
-        DLSettings(v)
     }
 }
 

--- a/lorawan-encoding/src/maccommands.rs
+++ b/lorawan-encoding/src/maccommands.rs
@@ -4,6 +4,9 @@ use core::marker::PhantomData;
 #[deprecated(note = "Use lorawan::types::ChannelMask")]
 pub use crate::types::ChannelMask;
 
+#[deprecated(note = "Use lorawan::types::Frequency")]
+pub use crate::types::Frequency;
+
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Error {
@@ -401,46 +404,6 @@ impl DLSettings {
 impl From<u8> for DLSettings {
     fn from(v: u8) -> Self {
         DLSettings(v)
-    }
-}
-
-/// Frequency represents a channel's central frequency.
-#[derive(Debug, PartialEq, Eq)]
-pub struct Frequency<'a>(&'a [u8]);
-
-impl<'a> Frequency<'a> {
-    /// Constructs a new Frequency from the provided bytes, without verifying if they are
-    /// admissible.
-    ///
-    /// Improper use of this method could lead to panic during runtime!
-    pub fn new_from_raw(bytes: &'a [u8]) -> Self {
-        Frequency(bytes)
-    }
-
-    /// Constructs a new Frequency from the provided bytes.
-    pub fn new(bytes: &'a [u8]) -> Option<Self> {
-        if bytes.len() != 3 {
-            return None;
-        }
-
-        Some(Frequency(bytes))
-    }
-
-    /// Provides the decimal value in Hz of the frequency.
-    pub fn value(&self) -> u32 {
-        ((u32::from(self.0[2]) << 16) + (u32::from(self.0[1]) << 8) + u32::from(self.0[0])) * 100
-    }
-}
-
-impl<'a> From<&'a [u8; 3]> for Frequency<'a> {
-    fn from(v: &'a [u8; 3]) -> Self {
-        Frequency(&v[..])
-    }
-}
-
-impl AsRef<[u8]> for Frequency<'_> {
-    fn as_ref(&self) -> &[u8] {
-        self.0
     }
 }
 

--- a/lorawan-encoding/src/maccommands.rs
+++ b/lorawan-encoding/src/maccommands.rs
@@ -4,6 +4,9 @@ use core::marker::PhantomData;
 #[deprecated(note = "Use lorawan::types::ChannelMask")]
 pub use crate::types::ChannelMask;
 
+#[deprecated(note = "Use lorawan::types::DataRateRange")]
+use crate::types::DataRateRange;
+
 #[deprecated(note = "Use lorawan::types::DLSettings")]
 pub use crate::types::DLSettings;
 
@@ -406,53 +409,6 @@ impl NewChannelReqPayload<'_> {
     /// The data rate range specifies allowed data rates for the new or modified channel.
     pub fn data_rate_range(&self) -> DataRateRange {
         DataRateRange::new_from_raw(self.0[4])
-    }
-}
-
-/// DataRateRange represents LoRaWAN DataRateRange.
-#[derive(Debug, PartialEq, Eq)]
-pub struct DataRateRange(u8);
-
-impl DataRateRange {
-    /// Constructs a new DataRateRange from the provided byte, without checking for correctness.
-    pub fn new_from_raw(byte: u8) -> DataRateRange {
-        DataRateRange(byte)
-    }
-
-    /// Constructs a new DataRateRange from the provided byte.
-    pub fn new(byte: u8) -> Result<DataRateRange, Error> {
-        Self::can_build_from(byte)?;
-
-        Ok(Self::new_from_raw(byte))
-    }
-
-    /// Check if the byte can be used to create DataRateRange.
-    pub fn can_build_from(byte: u8) -> Result<(), Error> {
-        if (byte >> 4) < (byte & 0x0f) {
-            return Err(Error::InvalidDataRateRange);
-        }
-        Ok(())
-    }
-
-    /// The highest data rate allowed on this channel.
-    pub fn max_data_rate(&self) -> u8 {
-        self.0 >> 4
-    }
-
-    /// The lowest data rate allowed on this channel.
-    pub fn min_data_rate(&self) -> u8 {
-        self.0 & 0x0f
-    }
-
-    /// The integer value of the DataRateRange.
-    pub fn raw_value(&self) -> u8 {
-        self.0
-    }
-}
-
-impl From<u8> for DataRateRange {
-    fn from(v: u8) -> Self {
-        DataRateRange(v)
     }
 }
 

--- a/lorawan-encoding/src/parser.rs
+++ b/lorawan-encoding/src/parser.rs
@@ -21,8 +21,7 @@
 //! ```
 
 use super::keys::{AppKey, AppSKey, CryptoFactory, Encrypter, NwkSKey, AES128, MIC};
-use super::maccommands::DLSettings;
-use crate::types::{ChannelMask, Frequency};
+use crate::types::{ChannelMask, DLSettings, Frequency};
 
 use super::securityhelpers;
 use super::securityhelpers::generic_array::GenericArray;

--- a/lorawan-encoding/src/parser.rs
+++ b/lorawan-encoding/src/parser.rs
@@ -21,7 +21,8 @@
 //! ```
 
 use super::keys::{AppKey, AppSKey, CryptoFactory, Encrypter, NwkSKey, AES128, MIC};
-use super::maccommands::{ChannelMask, DLSettings, Frequency};
+use super::maccommands::{DLSettings, Frequency};
+use crate::types::ChannelMask;
 
 use super::securityhelpers;
 use super::securityhelpers::generic_array::GenericArray;

--- a/lorawan-encoding/src/parser.rs
+++ b/lorawan-encoding/src/parser.rs
@@ -21,8 +21,8 @@
 //! ```
 
 use super::keys::{AppKey, AppSKey, CryptoFactory, Encrypter, NwkSKey, AES128, MIC};
-use super::maccommands::{DLSettings, Frequency};
-use crate::types::ChannelMask;
+use super::maccommands::DLSettings;
+use crate::types::{ChannelMask, Frequency};
 
 use super::securityhelpers;
 use super::securityhelpers::generic_array::GenericArray;

--- a/lorawan-encoding/src/types.rs
+++ b/lorawan-encoding/src/types.rs
@@ -1,3 +1,5 @@
+//! LoRaWAN type primitives (frequency, channelmask, etc)
+//! commonly used in payloads.
 use crate::maccommands::Error;
 
 /// ChannelMask represents the ChannelMask from LoRaWAN.

--- a/lorawan-encoding/src/types.rs
+++ b/lorawan-encoding/src/types.rs
@@ -141,6 +141,53 @@ impl<const N: usize> AsRef<[u8]> for ChannelMask<N> {
     }
 }
 
+/// DataRateRange represents LoRaWAN DataRateRange.
+#[derive(Debug, PartialEq, Eq)]
+pub struct DataRateRange(u8);
+
+impl DataRateRange {
+    /// Constructs a new DataRateRange from the provided byte, without checking for correctness.
+    pub fn new_from_raw(byte: u8) -> DataRateRange {
+        DataRateRange(byte)
+    }
+
+    /// Constructs a new DataRateRange from the provided byte.
+    pub fn new(byte: u8) -> Result<DataRateRange, Error> {
+        Self::can_build_from(byte)?;
+
+        Ok(Self::new_from_raw(byte))
+    }
+
+    /// Check if the byte can be used to create DataRateRange.
+    pub fn can_build_from(byte: u8) -> Result<(), Error> {
+        if (byte >> 4) < (byte & 0x0f) {
+            return Err(Error::InvalidDataRateRange);
+        }
+        Ok(())
+    }
+
+    /// The highest data rate allowed on this channel.
+    pub fn max_data_rate(&self) -> u8 {
+        self.0 >> 4
+    }
+
+    /// The lowest data rate allowed on this channel.
+    pub fn min_data_rate(&self) -> u8 {
+        self.0 & 0x0f
+    }
+
+    /// The integer value of the DataRateRange.
+    pub fn raw_value(&self) -> u8 {
+        self.0
+    }
+}
+
+impl From<u8> for DataRateRange {
+    fn from(v: u8) -> Self {
+        DataRateRange(v)
+    }
+}
+
 /// DLSettings represents LoRaWAN DLSettings.
 #[derive(Debug, PartialEq, Eq)]
 pub struct DLSettings(u8);

--- a/lorawan-encoding/src/types.rs
+++ b/lorawan-encoding/src/types.rs
@@ -213,3 +213,35 @@ impl AsRef<[u8]> for Frequency<'_> {
         self.0
     }
 }
+
+/// Redundancy represents the LinkADRReq Redundancy from LoRaWAN.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Redundancy(u8);
+
+impl Redundancy {
+    /// Constructs a new Redundancy from the provided data.
+    pub fn new(data: u8) -> Self {
+        Redundancy(data)
+    }
+
+    /// Controls the interpretation of the previously defined ChannelMask bit mask.
+    pub fn channel_mask_control(&self) -> u8 {
+        (self.0 >> 4) & 0x07
+    }
+
+    /// How many times each message should be repeated.
+    pub fn number_of_transmissions(&self) -> u8 {
+        self.0 & 0x0f
+    }
+
+    /// The integer value of the Redundancy.
+    pub fn raw_value(&self) -> u8 {
+        self.0
+    }
+}
+
+impl From<u8> for Redundancy {
+    fn from(v: u8) -> Self {
+        Redundancy(v)
+    }
+}

--- a/lorawan-encoding/src/types.rs
+++ b/lorawan-encoding/src/types.rs
@@ -140,3 +140,43 @@ impl<const N: usize> AsRef<[u8]> for ChannelMask<N> {
         &self.0[..]
     }
 }
+
+/// Frequency represents a channel's central frequency.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Frequency<'a>(&'a [u8]);
+
+impl<'a> Frequency<'a> {
+    /// Constructs a new Frequency from the provided bytes, without verifying if they are
+    /// admissible.
+    ///
+    /// Improper use of this method could lead to panic during runtime!
+    pub fn new_from_raw(bytes: &'a [u8]) -> Self {
+        Frequency(bytes)
+    }
+
+    /// Constructs a new Frequency from the provided bytes.
+    pub fn new(bytes: &'a [u8]) -> Option<Self> {
+        if bytes.len() != 3 {
+            return None;
+        }
+
+        Some(Frequency(bytes))
+    }
+
+    /// Provides the decimal value in Hz of the frequency.
+    pub fn value(&self) -> u32 {
+        ((u32::from(self.0[2]) << 16) + (u32::from(self.0[1]) << 8) + u32::from(self.0[0])) * 100
+    }
+}
+
+impl<'a> From<&'a [u8; 3]> for Frequency<'a> {
+    fn from(v: &'a [u8; 3]) -> Self {
+        Frequency(&v[..])
+    }
+}
+
+impl AsRef<[u8]> for Frequency<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}

--- a/lorawan-encoding/src/types.rs
+++ b/lorawan-encoding/src/types.rs
@@ -141,6 +141,39 @@ impl<const N: usize> AsRef<[u8]> for ChannelMask<N> {
     }
 }
 
+/// DLSettings represents LoRaWAN DLSettings.
+#[derive(Debug, PartialEq, Eq)]
+pub struct DLSettings(u8);
+
+impl DLSettings {
+    /// Constructs a new DLSettings from the provided data.
+    pub fn new(byte: u8) -> DLSettings {
+        DLSettings(byte)
+    }
+
+    /// The offset between the uplink data rate and the downlink data rate used to communicate with
+    /// the end-device on the first reception slot (RX1).
+    pub fn rx1_dr_offset(&self) -> u8 {
+        self.0 >> 4 & 0x07
+    }
+
+    /// The data rate of a downlink using the second receive window.
+    pub fn rx2_data_rate(&self) -> u8 {
+        self.0 & 0x0f
+    }
+
+    /// The integer value of the DL Settings.
+    pub fn raw_value(&self) -> u8 {
+        self.0
+    }
+}
+
+impl From<u8> for DLSettings {
+    fn from(v: u8) -> Self {
+        DLSettings(v)
+    }
+}
+
 /// Frequency represents a channel's central frequency.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Frequency<'a>(&'a [u8]);

--- a/lorawan-encoding/src/types.rs
+++ b/lorawan-encoding/src/types.rs
@@ -1,0 +1,142 @@
+use crate::maccommands::Error;
+
+/// ChannelMask represents the ChannelMask from LoRaWAN.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelMask<const N: usize>([u8; N]);
+
+impl<const N: usize> Default for ChannelMask<N> {
+    fn default() -> Self {
+        ChannelMask([0xFF; N])
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<const N: usize> serde::Serialize for ChannelMask<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for e in &self.0 {
+            seq.serialize_element(e)?;
+        }
+        seq.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+struct ChannelMaskDeserializer<const N: usize>;
+
+#[cfg(feature = "serde")]
+impl<'de, const N: usize> serde::de::Visitor<'de> for ChannelMaskDeserializer<N> {
+    type Value = ChannelMask<N>;
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str("ChannelMask byte.")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let mut arr = [0; N];
+        let mut index = 0;
+        while let Some(el) = seq.next_element()? {
+            if index >= N {
+                return Err(serde::de::Error::custom("ChannelMask has too many elements"));
+            } else {
+                arr[index] = el;
+                index += 1;
+            }
+        }
+        Ok(ChannelMask(arr))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, const N: usize> serde::Deserialize<'de> for ChannelMask<N> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(ChannelMaskDeserializer {})
+    }
+}
+
+impl<const N: usize> ChannelMask<N> {
+    /// Constructs a new ChannelMask from the provided data.
+    pub fn new(data: &[u8]) -> Result<Self, Error> {
+        if data.len() < N {
+            return Err(Error::BufferTooShort);
+        }
+        Ok(Self::new_from_raw(data))
+    }
+
+    pub fn set_bank(&mut self, index: usize, value: u8) {
+        self.0[index] = value;
+    }
+
+    /// Enable or disable a specific channel. Recall that LoRaWAN channel numbers start indexing
+    /// at zero.
+    ///
+    /// Improper use of this method could lead to out of bounds panic during runtime!
+    pub fn set_channel(&mut self, channel: usize, set: bool) {
+        let index = channel >> 3;
+        let mut flag = 0b1 << (channel & 0x07);
+        if set {
+            self.0[index] |= flag;
+        } else {
+            flag = !flag;
+            self.0[index] &= flag;
+        }
+    }
+
+    pub fn get_index(&self, index: usize) -> u8 {
+        self.0[index]
+    }
+
+    /// Constructs a new ChannelMask from the provided data, without verifying if they are
+    /// admissible.
+    ///
+    /// Improper use of this method could lead to panic during runtime!
+    pub fn new_from_raw(data: &[u8]) -> Self {
+        let mut payload = [0; N];
+        payload[..N].copy_from_slice(&data[..N]);
+        ChannelMask(payload)
+    }
+
+    fn channel_enabled(&self, index: usize) -> bool {
+        self.0[index >> 3] & (1 << (index & 0x07)) != 0
+    }
+
+    /// Verifies if a given channel is enabled.
+    pub fn is_enabled(&self, index: usize) -> Result<bool, Error> {
+        let index_limit = N * 8 - 1;
+        if index > index_limit {
+            return Err(Error::InvalidIndex);
+        }
+        Ok(self.channel_enabled(index))
+    }
+
+    /// Provides information for each of the 16 channels if they are enabled.
+    pub fn statuses<const M: usize>(&self) -> [bool; M] {
+        let mut res = [false; M];
+        for (i, c) in res.iter_mut().enumerate() {
+            *c = self.channel_enabled(i);
+        }
+        res
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for ChannelMask<N> {
+    fn from(v: [u8; N]) -> Self {
+        ChannelMask(v)
+    }
+}
+
+impl<const N: usize> AsRef<[u8]> for ChannelMask<N> {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}

--- a/lorawan-encoding/tests/lorawan.rs
+++ b/lorawan-encoding/tests/lorawan.rs
@@ -4,7 +4,7 @@ use lorawan::keys::*;
 use lorawan::maccommandcreator::*;
 use lorawan::maccommands::*;
 use lorawan::parser::*;
-use lorawan::types::Frequency;
+use lorawan::types::{DLSettings, Frequency};
 
 fn phy_join_request_payload() -> Vec<u8> {
     let mut res = Vec::new();

--- a/lorawan-encoding/tests/lorawan.rs
+++ b/lorawan-encoding/tests/lorawan.rs
@@ -4,6 +4,7 @@ use lorawan::keys::*;
 use lorawan::maccommandcreator::*;
 use lorawan::maccommands::*;
 use lorawan::parser::*;
+use lorawan::types::Frequency;
 
 fn phy_join_request_payload() -> Vec<u8> {
     let mut res = Vec::new();

--- a/lorawan-encoding/tests/maccommands.rs
+++ b/lorawan-encoding/tests/maccommands.rs
@@ -1,6 +1,6 @@
 use lorawan::maccommandcreator::*;
 use lorawan::maccommands::*;
-use lorawan::types::{DLSettings, Frequency};
+use lorawan::types::{DLSettings, Frequency, Redundancy};
 
 macro_rules! test_helper {
     ( $cmd:ident, $data:ident, $name:ident, $type:ident, $size:expr, $( ( $method:ident, $val:expr ) ,)*) => {{

--- a/lorawan-encoding/tests/maccommands.rs
+++ b/lorawan-encoding/tests/maccommands.rs
@@ -1,6 +1,6 @@
 use lorawan::maccommandcreator::*;
 use lorawan::maccommands::*;
-use lorawan::types::Frequency;
+use lorawan::types::{DLSettings, Frequency};
 
 macro_rules! test_helper {
     ( $cmd:ident, $data:ident, $name:ident, $type:ident, $size:expr, $( ( $method:ident, $val:expr ) ,)*) => {{

--- a/lorawan-encoding/tests/maccommands.rs
+++ b/lorawan-encoding/tests/maccommands.rs
@@ -1,5 +1,6 @@
 use lorawan::maccommandcreator::*;
 use lorawan::maccommands::*;
+use lorawan::types::Frequency;
 
 macro_rules! test_helper {
     ( $cmd:ident, $data:ident, $name:ident, $type:ident, $size:expr, $( ( $method:ident, $val:expr ) ,)*) => {{

--- a/lorawan-encoding/tests/maccommands.rs
+++ b/lorawan-encoding/tests/maccommands.rs
@@ -1,6 +1,6 @@
 use lorawan::maccommandcreator::*;
 use lorawan::maccommands::*;
-use lorawan::types::{DLSettings, Frequency, Redundancy};
+use lorawan::types::{DLSettings, DataRateRange, Frequency, Redundancy};
 
 macro_rules! test_helper {
     ( $cmd:ident, $data:ident, $name:ident, $type:ident, $size:expr, $( ( $method:ident, $val:expr ) ,)*) => {{


### PR DESCRIPTION
This PR moves most internal types used inside payloads from `maccommands` module to common `types` module.
No functional changes, and moves are made in a backwards compatible way to preserve API. (Unfortunately deprecated attribute doesn't really work when re-exporting).
This is also a preparation PR for #305 