### PR TITLE
lora-phy: fix Sx126x::process_irq_event

### DIFF
--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -944,7 +944,7 @@ where
             RadioMode::ChannelActivityDetection => {
                 if IrqMask::CADDone.is_set(irq_flags) {
                     if let Some(detected) = cad_activity_detected {
-                        *detected = IrqMask::CADDone.is_set(irq_flags);
+                        *detected = IrqMask::CADActivityDetected.is_set(irq_flags);
                     }
                     return Ok(Some(IrqState::Done));
                 }


### PR DESCRIPTION
The `LoRa::cad` always returns true because the `Sx126x::process_irq_event` doesn't check the IrqMask::CADActivityDetected flag when the IrqMask::CADDone flag is set. This fixes the issue.