### PR TITLE
update to heapless 0.8

### DIFF
--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 lora-modulation = { path = "../lora-modulation", version = ">=0.1.2", default-features = false }
 lorawan = { path = "../lorawan-encoding", version = "0.9", default-features = false }
-heapless = "0.7"
+heapless = "0.8"
 defmt = { version = "0.3", optional = true }
 fastrand = { version = "2", default-features = false }
 futures = { version = "0.3", default-features = false }
@@ -39,7 +39,7 @@ lazy_static = "1"
 # Pull in lorawan/default-crypto which is required for tests
 lorawan = { path = "../lorawan-encoding", default-features = false, features = [
     "default-crypto",
-    "defmt-03"
+    "defmt-03",
 ] }
 
 [features]

--- a/lorawan-encoding/Cargo.toml
+++ b/lorawan-encoding/Cargo.toml
@@ -18,12 +18,13 @@ aes = { version = "0.8", optional = true }
 cmac = { version = "0.7", optional = true }
 hex = { version = "0", default-features = false }
 defmt = { version = "0.3", optional = true }
-serde = { version = "1", default-features = false, features = ["derive"], optional = true}
+serde = { version = "1", default-features = false, features = [
+    "derive",
+], optional = true }
 lorawan-macros = { path = "../lorawan-macros", version = "0.1.0" }
 
 [dev-dependencies]
 criterion = "0"
-heapless = "0"
 trallocator = "0.2.1"
 
 [[bench]]

--- a/lorawan-encoding/README.md
+++ b/lorawan-encoding/README.md
@@ -27,7 +27,6 @@ lorawan = "0.9"
 use lorawan::{creator::JoinAcceptCreator, keys};
 use lorawan::default_crypto::DefaultFactory;
 use lorawan::types::Frequency;
-use heapless;
 
 fn main() {
     let mut data = [0; 33];
@@ -39,9 +38,10 @@ fn main() {
     phy.set_dev_addr(&[1; 4]);
     phy.set_dl_settings(2);
     phy.set_rx_delay(1);
-    let mut freqs: heapless::Vec<Frequency, 2> = heapless::Vec::new();
-    freqs.push(Frequency::new(&[0x58, 0x6e, 0x84,]).unwrap()).unwrap();
-    freqs.push(Frequency::new(&[0x88, 0x66, 0x84,]).unwrap()).unwrap();
+    let mut freqs = [
+        Frequency::new(&[0x58, 0x6e, 0x84,]).unwrap(),
+        Frequency::new(&[0x88, 0x66, 0x84,]).unwrap()
+    ];
     phy.set_c_f_list(freqs).unwrap();
     let payload = phy.build(&key).unwrap();
     println!("Payload: {:x?}", payload);


### PR DESCRIPTION
update to heapless 0.8 and remove heapless from lorawan-encoding

heapless was only used in the lorawan-encoding readme and could be substituted for a simple array