### PR TITLE
Implement Multicast Messages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,8 @@
-/Cargo.toml @ivajloip @lthiery @lulf
-/README.md @ivajloip @lthiery @lulf
+/Cargo.toml @ivajloip @lthiery @lulf @plaes
+/README.md @ivajloip @lthiery @lulf @plaes
 
 /lora-modulation/ @lthiery @lulf @ivajloip
 /lora-phy/ @lucasgranberg @plaes @CBJamo @Dirbaio @lthiery
-/lorawan-device/ @ivajloip @lthiery @lulf
-/lorawan-encoding/ @ivajloip @lthiery @lulf
+/lorawan-device/ @ivajloip @lthiery @lulf @plaes
+/lorawan-encoding/ @ivajloip @lthiery @lulf @plaes
+/lorawan-macros/ @plaes

--- a/lorawan-encoding/src/lib.rs
+++ b/lorawan-encoding/src/lib.rs
@@ -3,12 +3,14 @@
 #![deny(rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::len_without_is_empty)]
 #![doc = include_str!("../README.md")]
 
 pub mod creator;
 pub mod keys;
 pub mod maccommandcreator;
 pub mod maccommands;
+pub mod multicast;
 pub mod packet_length;
 pub mod parser;
 pub mod string;

--- a/lorawan-encoding/src/multicast.rs
+++ b/lorawan-encoding/src/multicast.rs
@@ -1,0 +1,73 @@
+use crate::maccommands::{Error, MacCommandIterator, SerializableMacCommand};
+use lorawan_macros::CommandHandler;
+
+const MAX_GROUPS: usize = 4;
+
+#[derive(Debug, PartialEq, CommandHandler)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+/// Downlink Multicast Messages
+pub enum DownlinkMulticastMsg<'a> {
+    #[cmd(cid = 0x00, len = 0)]
+    PackageVersionReq(PackageVersionReqPayload),
+    #[cmd(cid = 0x01, len = 1)]
+    McGroupStatusReq(McGroupStatusReqPayload<'a>),
+    #[cmd(cid = 0x02, len = 24)]
+    McGroupSetupReq(McGroupSetupReqPayload<'a>),
+    #[cmd(cid = 0x03, len = 1)]
+    McGroupDeleteReq(McGroupDeleteReqPayload<'a>),
+    #[cmd(cid = 0x04, len = 10)]
+    McClassCSessionReq(McClassCSessionReqPayload<'a>),
+    #[cmd(cid = 0x05, len = 10)]
+    McClassBSessionReq(McClassBSessionReqPayload<'a>),
+}
+
+#[derive(Debug, PartialEq, CommandHandler)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+/// Uplink Multicast Messages
+pub enum UplinkMulticastMsg<'a> {
+    #[cmd(cid = 0x00, len = 2)]
+    PackageVersionAns(PackageVersionAnsPayload<'a>),
+    #[cmd(cid = 0x01)]
+    McGroupStatusAns(McGroupStatusAnsPayload<'a>),
+    #[cmd(cid = 0x02, len = 1)]
+    McGroupSetupAns(McGroupSetupAnsPayload<'a>),
+    #[cmd(cid = 0x03, len = 1)]
+    McGroupDeleteAns(McGroupDeleteAnsPayload<'a>),
+    #[cmd(cid = 0x04, len = 4)]
+    McClassCSessionAns(McClassCSessionAnsPayload<'a>),
+    #[cmd(cid = 0x05, len = 4)]
+    McClassBSessionAns(McClassBSessionAnsPayload<'a>),
+}
+
+impl<'a> McGroupStatusAnsPayload<'a> {
+    const ITEM_LEN: usize = 5;
+    pub fn new(data: &'a [u8]) -> Result<McGroupStatusAnsPayload<'a>, Error> {
+        if data.is_empty() {
+            return Err(Error::BufferTooShort);
+        }
+        let status = data[0];
+        let required_len = Self::required_len(status);
+        if data.len() < required_len {
+            return Err(Error::BufferTooShort);
+        }
+        Ok(McGroupStatusAnsPayload(&data[0..required_len]))
+    }
+
+    pub fn required_len(status: u8) -> usize {
+        // |  RFU  | NbTotalGroups | AnsGroupMask |
+        // | 1 bit |    3 bits     |    4 bits    |
+        // Table 5: McGroupStatusAns
+        let nb_total_groups = (status >> 4) & 0x07;
+        nb_total_groups as usize * Self::ITEM_LEN
+    }
+
+    /// Maximum possible length of the payload
+    pub const fn max_len() -> usize {
+        MAX_GROUPS * Self::ITEM_LEN
+    }
+
+    /// Actual length of this specific payload
+    pub fn len(&self) -> usize {
+        Self::required_len(self.0[0])
+    }
+}

--- a/lorawan-encoding/tests/maccommands.rs
+++ b/lorawan-encoding/tests/maccommands.rs
@@ -7,7 +7,7 @@ macro_rules! test_helper {
         {
             assert!($type::new(&[]).is_err());
             let res = $type::new(&$data[..]).unwrap();
-            assert_eq!($type::len(), $size);
+            assert_eq!(res.len(), $size);
             $(
                 assert_eq!(res.$method(), $val);
             )*
@@ -71,7 +71,7 @@ fn test_link_adr_ans_new() {
     assert!(LinkADRReqPayload::new(&[]).is_err());
     for (v, e_power, e_dr, e_cm, e_ack) in &examples {
         let laa = LinkADRAnsPayload::new(&v[..]).unwrap();
-        assert_eq!(LinkADRAnsPayload::len(), 1);
+        assert_eq!(laa.len(), 1);
         assert_eq!(laa.channel_mask_ack(), *e_power);
         assert_eq!(laa.data_rate_ack(), *e_dr);
         assert_eq!(laa.powert_ack(), *e_cm);
@@ -125,7 +125,7 @@ fn test_rx_param_setup_ans_new() {
     assert!(RXParamSetupAnsPayload::new(&[]).is_err());
     for (v, e_ch, e_rx2_dr, e_rx1_dr_offset, e_ack) in &examples {
         let psa = RXParamSetupAnsPayload::new(&v[..]).unwrap();
-        assert_eq!(RXParamSetupAnsPayload::len(), 1);
+        assert_eq!(psa.len(), 1);
         assert_eq!(psa.channel_ack(), *e_ch);
         assert_eq!(psa.rx2_data_rate_ack(), *e_rx2_dr);
         assert_eq!(psa.rx1_dr_offset_ack(), *e_rx1_dr_offset);
@@ -178,7 +178,7 @@ fn test_new_channel_ans() {
     assert!(NewChannelAnsPayload::new(&[]).is_err());
     for (v, e_ch_freq, e_drr, e_ack) in &examples {
         let nca = NewChannelAnsPayload::new(&v[..]).unwrap();
-        assert_eq!(NewChannelAnsPayload::len(), 1);
+        assert_eq!(nca.len(), 1);
         assert_eq!(nca.data_rate_range_ack(), *e_drr);
         assert_eq!(nca.channel_freq_ack(), *e_ch_freq);
         assert_eq!(nca.ack(), *e_ack);


### PR DESCRIPTION
I've re-implemented the multicast messages from an old branch of mine using the attribute macro.

There is one tricky command that I forced me to make some changes to the attribute macro: `McGroupStatusAnsPayload`. It is a **variable length message**, therefore, I needed to make the fixed-length concept optional in the attribute macro.

To make this work right, I renamed `const fn len()` to become `const fn max_len()`, so that it could be used for payload creation in the case of variable length mac commands. `fn len(&self)` takes the old name, but also a reference to self so that it would be appropriate for variable length commands in the case the parsing.