### PR TITLE
lorawan-device: NwkSKey migration

### DIFF
--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -239,8 +239,8 @@ where
                 self.timer.reset();
                 Ok(self.rx_downlink(&Frame::Join, ms).await?.try_into()?)
             }
-            JoinMode::ABP { newskey, appskey, devaddr } => {
-                self.mac.join_abp(*newskey, *appskey, *devaddr);
+            JoinMode::ABP { nwkskey, appskey, devaddr } => {
+                self.mac.join_abp(*nwkskey, *appskey, *devaddr);
                 Ok(JoinResponse::JoinSuccess)
             }
         }

--- a/lorawan-device/src/async_device/test/util.rs
+++ b/lorawan-device/src/async_device/test/util.rs
@@ -1,7 +1,7 @@
 use super::{get_dev_addr, get_key, radio::*, region, timer::*, Device};
 
 use crate::mac::Session;
-use crate::{AppSKey, NewSKey};
+use crate::{AppSKey, NwkSKey};
 
 fn setup_internal(session_data: Option<Session>) -> (RadioChannel, TimerChannel, Device) {
     let (radio_channel, mock_radio) = TestRadio::new();
@@ -19,7 +19,7 @@ fn setup_internal(session_data: Option<Session>) -> (RadioChannel, TimerChannel,
 
 pub fn setup_with_session() -> (RadioChannel, TimerChannel, Device) {
     setup_internal(Some(Session {
-        newskey: NewSKey::from(get_key()),
+        nwkskey: NwkSKey::from(get_key()),
         appskey: AppSKey::from(get_key()),
         devaddr: get_dev_addr(),
         fcnt_up: 0,

--- a/lorawan-device/src/lib.rs
+++ b/lorawan-device/src/lib.rs
@@ -78,5 +78,5 @@ pub trait Timings {
 /// Join the network using either OTAA or ABP.
 pub enum JoinMode {
     OTAA { deveui: DevEui, appeui: AppEui, appkey: AppKey },
-    ABP { newskey: NwkSKey, appskey: AppSKey, devaddr: DevAddr<[u8; 4]> },
+    ABP { nwkskey: NwkSKey, appskey: AppSKey, devaddr: DevAddr<[u8; 4]> },
 }

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -145,11 +145,11 @@ impl Mac {
     /// Join via ABP. This does not transmit a join request frame, but instead sets the session.
     pub(crate) fn join_abp(
         &mut self,
-        newskey: NwkSKey,
+        nwkskey: NwkSKey,
         appskey: AppSKey,
         devaddr: DevAddr<[u8; 4]>,
     ) {
-        self.state = State::Joined(Session::new(newskey, appskey, devaddr));
+        self.state = State::Joined(Session::new(nwkskey, appskey, devaddr));
     }
 
     /// Join via ABP. This does not transmit a join request frame, but instead sets the session.

--- a/lorawan-device/src/nb_device/mod.rs
+++ b/lorawan-device/src/nb_device/mod.rs
@@ -50,8 +50,8 @@ where
             JoinMode::OTAA { deveui, appeui, appkey } => {
                 self.handle_event(Event::Join(NetworkCredentials::new(appeui, deveui, appkey)))
             }
-            JoinMode::ABP { devaddr, appskey, newskey } => {
-                self.shared.mac.join_abp(newskey, appskey, devaddr);
+            JoinMode::ABP { devaddr, appskey, nwkskey } => {
+                self.shared.mac.join_abp(nwkskey, appskey, devaddr);
                 Ok(Response::JoinSuccess)
             }
         }

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -62,7 +62,7 @@ pub fn get_abp_credentials() -> JoinMode {
     JoinMode::ABP {
         devaddr: get_dev_addr(),
         appskey: AppSKey::from(get_key()),
-        newskey: NewSKey::from(get_key()),
+        nwkskey: NwkSKey::from(get_key()),
     }
 }
 


### PR DESCRIPTION
A bit controversial patch to replace `newskey` with `nwkskey` in public structs to migrate to commonly used LoRaWAN definitions.