### PR TITLE
Update to embassy-time-0.4

### DIFF
--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -5,9 +5,9 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.3.1", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-nrf = { version = "0.1.0", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
+embassy-executor = { version = "0.7", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.4", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-nrf = { version = "0.3", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio", "defmt-03"] }
 lorawan-device = { path = "../../lorawan-device", default-features = false, features = ["embassy-time", "default-crypto", "defmt-03"] }

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -18,7 +18,7 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 
 cortex-m = { version = "0.7.7", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
-embedded-hal-bus = { version = "0.1.0", features = ["async"]}
+embedded-hal-bus = { version = "0.2", features = ["async"]}
 
 [profile.release]
 debug = 2

--- a/examples/nrf52840/src/bin/lora_cad.rs
+++ b/examples/nrf52840/src/bin/lora_cad.rs
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;
     let spim = spim::Spim::new(p.TWISPI1, Irqs, p.P1_11, p.P1_13, p.P1_12, spi_config);
-    let spi = ExclusiveDevice::new(spim, nss, Delay);
+    let spi = ExclusiveDevice::new(spim, nss, Delay).unwrap();
 
     let config = sx126x::Config {
         chip: Sx1262,

--- a/examples/nrf52840/src/bin/lora_cad.rs
+++ b/examples/nrf52840/src/bin/lora_cad.rs
@@ -19,7 +19,7 @@ use {defmt_rtt as _, panic_probe as _};
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
 
 bind_interrupts!(struct Irqs {
-    SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1 => spim::InterruptHandler<peripherals::TWISPI1>;
+    TWISPI1 => spim::InterruptHandler<peripherals::TWISPI1>;
 });
 
 #[embassy_executor::main]

--- a/examples/nrf52840/src/bin/lora_get_rssi.rs
+++ b/examples/nrf52840/src/bin/lora_get_rssi.rs
@@ -37,7 +37,7 @@ async fn main(_spawner: Spawner) {
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;
     let spim = spim::Spim::new(p.TWISPI1, Irqs, p.P1_11, p.P1_13, p.P1_12, spi_config);
-    let spi = ExclusiveDevice::new(spim, nss, Delay);
+    let spi = ExclusiveDevice::new(spim, nss, Delay).unwrap();
 
     let config = sx126x::Config {
         chip: Sx1262,

--- a/examples/nrf52840/src/bin/lora_get_rssi.rs
+++ b/examples/nrf52840/src/bin/lora_get_rssi.rs
@@ -20,7 +20,7 @@ const LORA_FREQUENCY_IN_HZ: u32 = 869_400_000; // warning: set this appropriatel
 const RSSI_THRESHOLD: i16 = -100;
 
 bind_interrupts!(struct Irqs {
-    SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1 => spim::InterruptHandler<peripherals::TWISPI1>;
+    TWISPI1 => spim::InterruptHandler<peripherals::TWISPI1>;
 });
 
 #[embassy_executor::main]

--- a/examples/nrf52840/src/bin/lora_get_rssi.rs
+++ b/examples/nrf52840/src/bin/lora_get_rssi.rs
@@ -13,7 +13,7 @@ use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
 use lora_phy::sx126x::{Sx1262, Sx126x, TcxoCtrlVoltage};
 use lora_phy::{mod_params::*, sx126x};
-use lora_phy::{LoRa, RxMode};
+use lora_phy::LoRa;
 use {defmt_rtt as _, panic_probe as _};
 
 const LORA_FREQUENCY_IN_HZ: u32 = 869_400_000; // warning: set this appropriately for the region
@@ -31,8 +31,8 @@ async fn main(_spawner: Spawner) {
     let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
     let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
     let busy = Input::new(p.P1_14.degrade(), Pull::None);
-    let rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
-    let rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
+    let _rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
+    let _rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
 
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;
@@ -60,8 +60,6 @@ async fn main(_spawner: Spawner) {
             return;
         }
     };
-
-    let mut counter = 0;
 
     loop {
         let rssi = match lora.get_rssi().await {

--- a/examples/nrf52840/src/bin/lora_lorawan.rs
+++ b/examples/nrf52840/src/bin/lora_lorawan.rs
@@ -52,7 +52,7 @@ async fn main(_spawner: Spawner) {
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;
     let spim = spim::Spim::new(p.TWISPI1, Irqs, p.P1_11, p.P1_13, p.P1_12, spi_config);
-    let spi = ExclusiveDevice::new(spim, nss, Delay);
+    let spi = ExclusiveDevice::new(spim, nss, Delay).unwrap();
 
     let config = sx126x::Config {
         chip: Sx1262,

--- a/examples/nrf52840/src/bin/lora_lorawan.rs
+++ b/examples/nrf52840/src/bin/lora_lorawan.rs
@@ -34,7 +34,7 @@ const DEFAULT_APPEUI: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
 const DEFAULT_APPKEY: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
 bind_interrupts!(struct Irqs {
-    SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1 => spim::InterruptHandler<peripherals::TWISPI1>;
+    TWISPI1 => spim::InterruptHandler<peripherals::TWISPI1>;
     RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 

--- a/examples/nrf52840/src/bin/lora_p2p_receive.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive.rs
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;
     let spim = spim::Spim::new(p.TWISPI1, Irqs, p.P1_11, p.P1_13, p.P1_12, spi_config);
-    let spi = ExclusiveDevice::new(spim, nss, Delay);
+    let spi = ExclusiveDevice::new(spim, nss, Delay).unwrap();
 
     let config = sx126x::Config {
         chip: Sx1262,

--- a/examples/nrf52840/src/bin/lora_p2p_receive.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive.rs
@@ -19,7 +19,7 @@ use {defmt_rtt as _, panic_probe as _};
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
 
 bind_interrupts!(struct Irqs {
-    SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1 => spim::InterruptHandler<peripherals::TWISPI1>;
+    TWISPI1 => spim::InterruptHandler<peripherals::TWISPI1>;
 });
 
 #[embassy_executor::main]

--- a/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;
     let spim = spim::Spim::new(p.TWISPI1, Irqs, p.P1_11, p.P1_13, p.P1_12, spi_config);
-    let spi = ExclusiveDevice::new(spim, nss, Delay);
+    let spi = ExclusiveDevice::new(spim, nss, Delay).unwrap();
 
     let config = sx126x::Config {
         chip: Sx1262,

--- a/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
@@ -19,7 +19,7 @@ use {defmt_rtt as _, panic_probe as _};
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
 
 bind_interrupts!(struct Irqs {
-    SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1 => spim::InterruptHandler<peripherals::TWISPI1>;
+    TWISPI1 => spim::InterruptHandler<peripherals::TWISPI1>;
 });
 
 #[embassy_executor::main]

--- a/examples/nrf52840/src/bin/lora_p2p_send.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_send.rs
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;
     let spim = spim::Spim::new(p.TWISPI1, Irqs, p.P1_11, p.P1_13, p.P1_12, spi_config);
-    let spi = ExclusiveDevice::new(spim, nss, Delay);
+    let spi = ExclusiveDevice::new(spim, nss, Delay).unwrap();
 
     let config = sx126x::Config {
         chip: Sx1262,

--- a/examples/nrf52840/src/bin/lora_p2p_send.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_send.rs
@@ -19,7 +19,7 @@ use {defmt_rtt as _, panic_probe as _};
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
 
 bind_interrupts!(struct Irqs {
-    SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1 => spim::InterruptHandler<peripherals::TWISPI1>;
+    TWISPI1 => spim::InterruptHandler<peripherals::TWISPI1>;
 });
 
 #[embassy_executor::main]

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -5,10 +5,10 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-sync = { version = "0.5.0", features = ["defmt"] }
-embassy-rp = { version = "0.1.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
+embassy-executor = { version = "0.7", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.4", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-sync = { version = "0.6", features = ["defmt"] }
+embassy-rp = { version = "0.3", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio", "defmt-03"] }
 lorawan-device = { path = "../../lorawan-device", features = ["embassy-time", "default-crypto", "defmt-03"] }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -17,9 +17,9 @@ defmt = "0.3"
 defmt-rtt = "0.4"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
-cortex-m = { version = "0.7.6", features = ["inline-asm"] }
-cortex-m-rt = "0.7.0"
-embedded-hal-bus = { version = "0.1.0", features = ["async"]}
+cortex-m = { version = "0.7", features = ["inline-asm"] }
+cortex-m-rt = "0.7"
+embedded-hal-bus = { version = "0.2", features = ["async"]}
 
 static_cell = { version = "2.0.0" }
 portable-atomic = { version = "1.5", features = ["critical-section"] } # needed for static_cell on thumbv6

--- a/examples/rp/src/bin/lora_lorawan.rs
+++ b/examples/rp/src/bin/lora_lorawan.rs
@@ -41,7 +41,7 @@ async fn main(_spawner: Spawner) {
         p.DMA_CH1,
         Config::default(),
     );
-    let spi = ExclusiveDevice::new(spi, nss, Delay);
+    let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx126x::Config {
         chip: Sx1262,

--- a/examples/rp/src/bin/lora_p2p_receive.rs
+++ b/examples/rp/src/bin/lora_p2p_receive.rs
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
         p.DMA_CH1,
         Config::default(),
     );
-    let spi = ExclusiveDevice::new(spi, nss, Delay);
+    let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx126x::Config {
         chip: Sx1262,

--- a/examples/rp/src/bin/lora_p2p_send.rs
+++ b/examples/rp/src/bin/lora_p2p_send.rs
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
         p.DMA_CH1,
         Config::default(),
     );
-    let spi = ExclusiveDevice::new(spi, nss, Delay);
+    let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx126x::Config {
         chip: Sx1262,

--- a/examples/rp/src/bin/lora_p2p_send_multicore.rs
+++ b/examples/rp/src/bin/lora_p2p_send_multicore.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
         p.DMA_CH1,
         Config::default(),
     );
-    let spi = ExclusiveDevice::new(spi, nss, Delay);
+    let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let iv = GenericSx126xInterfaceVariant::new(reset, dio1, busy, None, None).unwrap();
 

--- a/examples/stm32l0/.cargo/config.toml
+++ b/examples/stm32l0/.cargo/config.toml
@@ -1,6 +1,7 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # replace your chip as listed in `probe-rs chip list`
-runner = "probe-rs run --chip STM32L053R8Tx"
+runner = "probe-rs run --chip STM32L072CZTx"
+#runner = "probe-rs run --chip STM32L053R8Tx"
 
 [build]
 target = "thumbv6m-none-eabi"

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -19,7 +19,8 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
-embedded-hal-bus = { version = "0.1.0", features = ["async"]}
+portable-atomic = { version = "1.10.0", features = ["unsafe-assume-single-core"] }
+embedded-hal-bus = { version = "0.2.0", features = ["async"]}
 
 [profile.release]
 debug = 2

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32l072cz to your chip name, if necessary. Also change it in .cargo/config.toml
 embassy-stm32 = { version = "0.1.0", features = ["defmt", "stm32l072cz", "time-driver-any", "exti", "memory-x"]  }
-embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio", "defmt-03"] }
 lorawan-device = { path = "../../lorawan-device", features = ["embassy-time", "default-crypto", "defmt-03"] }
@@ -24,3 +24,13 @@ embedded-hal-bus = { version = "0.1.0", features = ["async"]}
 [profile.release]
 debug = 2
 
+[patch.crates-io]
+# Unfortunately embassy-stm32 hasn't had proper releases for a while,
+# therefore update to a somewhat newer version to handle API changes
+# between 0.1.0 -> 0.2.0
+embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
+embassy-sync= { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
+embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
+embassy-time-queue-utils = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Change stm32l072cz to your chip name, if necessary. Also change it in .cargo/config.toml
-embassy-stm32 = { version = "0.1.0", features = ["defmt", "stm32l072cz", "time-driver-any", "exti", "memory-x"]  }
+embassy-stm32 = { version = "0.2.0", features = ["defmt", "stm32l072cz", "time-driver-any", "exti", "memory-x"]  }
 embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime"] }
 
@@ -24,14 +24,3 @@ embedded-hal-bus = { version = "0.2.0", features = ["async"]}
 
 [profile.release]
 debug = 2
-
-[patch.crates-io]
-# Unfortunately embassy-stm32 hasn't had proper releases for a while,
-# therefore update to a somewhat newer version to handle API changes
-# between 0.1.0 -> 0.2.0
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
-embassy-sync= { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
-embassy-time-queue-utils = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }

--- a/examples/stm32l0/src/bin/lora_cad.rs
+++ b/examples/stm32l0/src/bin/lora_cad.rs
@@ -33,7 +33,7 @@ async fn main(_spawner: Spawner) {
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);
     let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
-    let spi = ExclusiveDevice::new(spi, nss, Delay);
+    let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx127x::Config {
         chip: Sx1276,

--- a/examples/stm32l0/src/bin/lora_cad.rs
+++ b/examples/stm32l0/src/bin/lora_cad.rs
@@ -5,8 +5,8 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::exti::{Channel, ExtiInput};
-use embassy_stm32::gpio::{Input, Level, Output, Pin, Pull, Speed};
+use embassy_stm32::exti::ExtiInput;
+use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
 use embassy_stm32::spi;
 use embassy_stm32::time::khz;
 use embassy_time::{Delay, Timer};
@@ -23,13 +23,12 @@ const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriatel
 async fn main(_spawner: Spawner) {
     let mut config = embassy_stm32::Config::default();
     config.rcc.hsi = true;
-    config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSI;
+    config.rcc.sys = embassy_stm32::rcc::Sysclk::HSI;
     let p = embassy_stm32::init(config);
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
     let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);
-    let irq_pin = Input::new(p.PB4.degrade(), Pull::Up);
-    let irq = ExtiInput::new(irq_pin, p.EXTI4.degrade());
+    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up);
 
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);

--- a/examples/stm32l0/src/bin/lora_get_rssi.rs
+++ b/examples/stm32l0/src/bin/lora_get_rssi.rs
@@ -5,14 +5,14 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::exti::{Channel, ExtiInput};
-use embassy_stm32::gpio::{Input, Level, Output, Pin, Pull, Speed};
+use embassy_stm32::exti::ExtiInput;
+use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
 use embassy_stm32::spi;
 use embassy_stm32::time::khz;
 use embassy_time::{Delay, Duration, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
-use lora_phy::sx127x::{Sx127x, Sx1276};
+use lora_phy::sx127x::{Sx1276, Sx127x};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx127x};
 use {defmt_rtt as _, panic_probe as _};
@@ -23,13 +23,12 @@ const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriatel
 async fn main(_spawner: Spawner) {
     let mut config = embassy_stm32::Config::default();
     config.rcc.hsi = true;
-    config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSI;
+    config.rcc.sys = embassy_stm32::rcc::Sysclk::HSI;
     let p = embassy_stm32::init(config);
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
     let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);
-    let irq_pin = Input::new(p.PB4.degrade(), Pull::Up);
-    let irq = ExtiInput::new(irq_pin, p.EXTI4.degrade());
+    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up);
 
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);

--- a/examples/stm32l0/src/bin/lora_get_rssi.rs
+++ b/examples/stm32l0/src/bin/lora_get_rssi.rs
@@ -33,7 +33,7 @@ async fn main(_spawner: Spawner) {
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);
     let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
-    let spi = ExclusiveDevice::new(spi, nss, Delay);
+    let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx127x::Config {
         chip: Sx1276,

--- a/examples/stm32l0/src/bin/lora_lorawan.rs
+++ b/examples/stm32l0/src/bin/lora_lorawan.rs
@@ -5,8 +5,8 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::exti::{Channel, ExtiInput};
-use embassy_stm32::gpio::{Input, Level, Output, Pin, Pull, Speed};
+use embassy_stm32::exti::ExtiInput;
+use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
 use embassy_stm32::rng::Rng;
 use embassy_stm32::time::khz;
 use embassy_stm32::{bind_interrupts, peripherals, rng, spi};
@@ -14,7 +14,7 @@ use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
 use lora_phy::lorawan_radio::LorawanRadio;
-use lora_phy::sx127x::{self, Sx127x, Sx1276};
+use lora_phy::sx127x::{self, Sx1276, Sx127x};
 use lora_phy::LoRa;
 use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::default_crypto::DefaultFactory as Crypto;
@@ -33,13 +33,12 @@ const MAX_TX_POWER: u8 = 14;
 async fn main(_spawner: Spawner) {
     let mut config = embassy_stm32::Config::default();
     config.rcc.hsi = true;
-    config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSI;
+    config.rcc.sys = embassy_stm32::rcc::Sysclk::HSI;
     let p = embassy_stm32::init(config);
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
     let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);
-    let irq_pin = Input::new(p.PB4.degrade(), Pull::Up);
-    let irq = ExtiInput::new(irq_pin, p.EXTI4.degrade());
+    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up);
 
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);

--- a/examples/stm32l0/src/bin/lora_lorawan.rs
+++ b/examples/stm32l0/src/bin/lora_lorawan.rs
@@ -43,7 +43,7 @@ async fn main(_spawner: Spawner) {
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);
     let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
-    let spi = ExclusiveDevice::new(spi, nss, Delay);
+    let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx127x::Config {
         chip: Sx1276,

--- a/examples/stm32l0/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_receive.rs
@@ -5,14 +5,14 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::exti::{Channel, ExtiInput};
-use embassy_stm32::gpio::{Input, Level, Output, Pin, Pull, Speed};
+use embassy_stm32::exti::ExtiInput;
+use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
 use embassy_stm32::spi;
 use embassy_stm32::time::khz;
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
-use lora_phy::sx127x::{Sx127x, Sx1276};
+use lora_phy::sx127x::{Sx1276, Sx127x};
 use lora_phy::{mod_params::*, sx127x};
 use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
@@ -23,13 +23,12 @@ const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriatel
 async fn main(_spawner: Spawner) {
     let mut config = embassy_stm32::Config::default();
     config.rcc.hsi = true;
-    config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSI;
+    config.rcc.sys = embassy_stm32::rcc::Sysclk::HSI;
     let p = embassy_stm32::init(config);
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
     let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);
-    let irq_pin = Input::new(p.PB4.degrade(), Pull::Up);
-    let irq = ExtiInput::new(irq_pin, p.EXTI4.degrade());
+    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up);
 
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);

--- a/examples/stm32l0/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_receive.rs
@@ -33,7 +33,7 @@ async fn main(_spawner: Spawner) {
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);
     let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
-    let spi = ExclusiveDevice::new(spi, nss, Delay);
+    let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx127x::Config {
         chip: Sx1276,

--- a/examples/stm32l0/src/bin/lora_p2p_send.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_send.rs
@@ -33,7 +33,7 @@ async fn main(_spawner: Spawner) {
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);
     let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
-    let spi = ExclusiveDevice::new(spi, nss, Delay);
+    let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx127x::Config {
         chip: Sx1276,

--- a/examples/stm32l0/src/bin/lora_p2p_send.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_send.rs
@@ -5,14 +5,14 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::exti::{Channel, ExtiInput};
-use embassy_stm32::gpio::{Input, Level, Output, Pin, Pull, Speed};
+use embassy_stm32::exti::ExtiInput;
+use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
 use embassy_stm32::spi;
 use embassy_stm32::time::khz;
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
-use lora_phy::sx127x::{Sx127x, Sx1276};
+use lora_phy::sx127x::{Sx1276, Sx127x};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx127x};
 use {defmt_rtt as _, panic_probe as _};
@@ -23,13 +23,12 @@ const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriatel
 async fn main(_spawner: Spawner) {
     let mut config = embassy_stm32::Config::default();
     config.rcc.hsi = true;
-    config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSI;
+    config.rcc.sys = embassy_stm32::rcc::Sysclk::HSI;
     let p = embassy_stm32::init(config);
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
     let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);
-    let irq_pin = Input::new(p.PB4.degrade(), Pull::Up);
-    let irq = ExtiInput::new(irq_pin, p.EXTI4.degrade());
+    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up);
 
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -7,9 +7,9 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32wle5jc to your chip name, if necessary. Also update .cargo/config.toml
 embassy-stm32 = { version = "0.1.0", features = ["defmt", "stm32wle5jc", "time-driver-any", "memory-x", "unstable-pac", "exti", "chrono"] }
-embassy-executor = { version = "0.5.0", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-sync = { version = "0.5.0", features = ["defmt"] }
+embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-sync = { version = "0.6", features = ["defmt"] }
 embassy-futures = { version = "0", features = ["defmt"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio", "defmt-03"] }
@@ -23,14 +23,18 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = { version = "1.0.0" }
 embedded-hal-async = { version = "1.0.0" }
-embedded-hal-bus = { version = "0.1.0", features = ["async"]}
+embedded-hal-bus = { version = "0.2.0", features = ["async"]}
 
 [profile.release]
 debug = 2
 
 [patch.crates-io]
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "ca2eef5387b521a0ea95f26bae530d9bdfbba4d7" }
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "ca2eef5387b521a0ea95f26bae530d9bdfbba4d7" }
-embassy-sync= { git = "https://github.com/embassy-rs/embassy.git", rev = "ca2eef5387b521a0ea95f26bae530d9bdfbba4d7" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "ca2eef5387b521a0ea95f26bae530d9bdfbba4d7" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "ca2eef5387b521a0ea95f26bae530d9bdfbba4d7" }
+# Unfortunately embassy-stm32 hasn't had proper releases for a while,
+# therefore update to a somewhat newer version to handle API changes
+# between 0.1.0 -> 0.2.0
+embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
+embassy-sync= { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
+embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
+embassy-time-queue-utils = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -28,3 +28,9 @@ embedded-hal-bus = { version = "0.1.0", features = ["async"]}
 [profile.release]
 debug = 2
 
+[patch.crates-io]
+embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "3387ee7238f1c9c4eeccb732ba543cbe38ab7ccd" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "3387ee7238f1c9c4eeccb732ba543cbe38ab7ccd" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "3387ee7238f1c9c4eeccb732ba543cbe38ab7ccd" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "3387ee7238f1c9c4eeccb732ba543cbe38ab7ccd" }
+#embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "3387ee7238f1c9c4eeccb732ba543cbe38ab7ccd" }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -29,8 +29,8 @@ embedded-hal-bus = { version = "0.1.0", features = ["async"]}
 debug = 2
 
 [patch.crates-io]
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "489d0be2a2971cfae7d6413b601bbd044d42e351" }
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "489d0be2a2971cfae7d6413b601bbd044d42e351" }
-embassy-sync= { git = "https://github.com/embassy-rs/embassy.git", rev = "489d0be2a2971cfae7d6413b601bbd044d42e351" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "489d0be2a2971cfae7d6413b601bbd044d42e351" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "489d0be2a2971cfae7d6413b601bbd044d42e351" }
+embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "be087e5d43326178878878bebae96f3b51a3b184" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "be087e5d43326178878878bebae96f3b51a3b184" }
+embassy-sync= { git = "https://github.com/embassy-rs/embassy.git", rev = "be087e5d43326178878878bebae96f3b51a3b184" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "be087e5d43326178878878bebae96f3b51a3b184" }
+embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "be087e5d43326178878878bebae96f3b51a3b184" }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -29,8 +29,8 @@ embedded-hal-bus = { version = "0.1.0", features = ["async"]}
 debug = 2
 
 [patch.crates-io]
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "be087e5d43326178878878bebae96f3b51a3b184" }
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "be087e5d43326178878878bebae96f3b51a3b184" }
-embassy-sync= { git = "https://github.com/embassy-rs/embassy.git", rev = "be087e5d43326178878878bebae96f3b51a3b184" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "be087e5d43326178878878bebae96f3b51a3b184" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "be087e5d43326178878878bebae96f3b51a3b184" }
+embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "ca2eef5387b521a0ea95f26bae530d9bdfbba4d7" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "ca2eef5387b521a0ea95f26bae530d9bdfbba4d7" }
+embassy-sync= { git = "https://github.com/embassy-rs/embassy.git", rev = "ca2eef5387b521a0ea95f26bae530d9bdfbba4d7" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "ca2eef5387b521a0ea95f26bae530d9bdfbba4d7" }
+embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "ca2eef5387b521a0ea95f26bae530d9bdfbba4d7" }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -29,8 +29,8 @@ embedded-hal-bus = { version = "0.1.0", features = ["async"]}
 debug = 2
 
 [patch.crates-io]
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "3387ee7238f1c9c4eeccb732ba543cbe38ab7ccd" }
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "3387ee7238f1c9c4eeccb732ba543cbe38ab7ccd" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "3387ee7238f1c9c4eeccb732ba543cbe38ab7ccd" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "3387ee7238f1c9c4eeccb732ba543cbe38ab7ccd" }
-#embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "3387ee7238f1c9c4eeccb732ba543cbe38ab7ccd" }
+embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "489d0be2a2971cfae7d6413b601bbd044d42e351" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "489d0be2a2971cfae7d6413b601bbd044d42e351" }
+embassy-sync= { git = "https://github.com/embassy-rs/embassy.git", rev = "489d0be2a2971cfae7d6413b601bbd044d42e351" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "489d0be2a2971cfae7d6413b601bbd044d42e351" }
+embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "489d0be2a2971cfae7d6413b601bbd044d42e351" }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Change stm32wle5jc to your chip name, if necessary. Also update .cargo/config.toml
-embassy-stm32 = { version = "0.1.0", features = ["defmt", "stm32wle5jc", "time-driver-any", "memory-x", "unstable-pac", "exti", "chrono"] }
+embassy-stm32 = { version = "0.2.0", features = ["defmt", "stm32wle5jc", "time-driver-any", "memory-x", "unstable-pac", "exti", "chrono"] }
 embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-sync = { version = "0.6", features = ["defmt"] }
@@ -27,14 +27,3 @@ embedded-hal-bus = { version = "0.2.0", features = ["async"]}
 
 [profile.release]
 debug = 2
-
-[patch.crates-io]
-# Unfortunately embassy-stm32 hasn't had proper releases for a while,
-# therefore update to a somewhat newer version to handle API changes
-# between 0.1.0 -> 0.2.0
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
-embassy-sync= { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }
-embassy-time-queue-utils = { git = "https://github.com/embassy-rs/embassy.git", rev = "06869e2e85695f4528d1148dfd81700c905771c5" }

--- a/examples/stm32wl/src/bin/lora_lorawan.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan.rs
@@ -43,7 +43,7 @@ async fn main(_spawner: Spawner) {
             mode: HseMode::Bypass,
             prescaler: HsePrescaler::DIV1,
         });
-        config.rcc.mux = ClockSrc::PLL1_R;
+        config.rcc.sys = Sysclk::PLL1_R;
         config.rcc.pll = Some(Pll {
             source: PllSource::HSE,
             prediv: PllPreDiv::DIV2,

--- a/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
@@ -12,6 +12,7 @@ use embassy_executor::Spawner;
 use embassy_futures::select::{select, Either};
 use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
+use embassy_stm32::mode::Async;
 use embassy_stm32::rng::{self, Rng};
 use embassy_stm32::spi::Spi;
 use embassy_stm32::time::Hertz;
@@ -93,11 +94,7 @@ async fn main(spawner: Spawner) {
 }
 
 type Stm32wlLoRa<'d> = LoRa<
-    Sx126x<
-        iv::SubghzSpiDevice<Spi<'d, peripherals::SUBGHZSPI, peripherals::DMA1_CH1, peripherals::DMA1_CH2>>,
-        Stm32wlInterfaceVariant<Output<'d>>,
-        Stm32wl,
-    >,
+    Sx126x<iv::SubghzSpiDevice<Spi<'d, peripherals::SUBGHZSPI, Async>>, Stm32wlInterfaceVariant<Output<'d>>, Stm32wl>,
     Delay,
 >;
 
@@ -183,10 +180,7 @@ enum ButtonState {
 }
 
 #[embassy_executor::task]
-async fn button_task(
-    mut button: ExtiInput<'static>,
-    tx: Sender<'static, ThreadModeRawMutex, ButtonState, 3>,
-) {
+async fn button_task(mut button: ExtiInput<'static>, tx: Sender<'static, ThreadModeRawMutex, ButtonState, 3>) {
     info!("Press the USER button...");
     loop {
         button.wait_for_falling_edge().await;

--- a/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
@@ -93,10 +93,8 @@ async fn main(spawner: Spawner) {
     let _button_task = spawner.spawn(button_task(button, CHANNEL.sender()));
 }
 
-type Stm32wlLoRa<'d> = LoRa<
-    Sx126x<iv::SubghzSpiDevice<Spi<'d, peripherals::SUBGHZSPI, Async>>, Stm32wlInterfaceVariant<Output<'d>>, Stm32wl>,
-    Delay,
->;
+type Stm32wlLoRa<'d> =
+    LoRa<Sx126x<iv::SubghzSpiDevice<Spi<'d, Async>>, Stm32wlInterfaceVariant<Output<'d>>, Stm32wl>, Delay>;
 
 #[embassy_executor::task]
 async fn lora_task(

--- a/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
@@ -55,7 +55,7 @@ async fn main(spawner: Spawner) {
             mode: HseMode::Bypass,
             prescaler: HsePrescaler::DIV1,
         });
-        config.rcc.mux = ClockSrc::PLL1_R;
+        config.rcc.sys = Sysclk::PLL1_R;
         config.rcc.pll = Some(Pll {
             source: PllSource::HSE,
             prediv: PllPreDiv::DIV2,

--- a/examples/stm32wl/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_receive.rs
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
             mode: HseMode::Bypass,
             prescaler: HsePrescaler::DIV1,
         });
-        config.rcc.mux = ClockSrc::PLL1_R;
+        config.rcc.sys = Sysclk::PLL1_R;
         config.rcc.pll = Some(Pll {
             source: PllSource::HSE,
             prediv: PllPreDiv::DIV2,

--- a/examples/stm32wl/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_send.rs
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
             mode: HseMode::Bypass,
             prescaler: HsePrescaler::DIV1,
         });
-        config.rcc.mux = ClockSrc::PLL1_R;
+        config.rcc.sys = Sysclk::PLL1_R;
         config.rcc.pll = Some(Pll {
             source: PllSource::HSE,
             prediv: PllPreDiv::DIV2,

--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1", default-features = false, features = [
 ], optional = true }
 seq-macro = "0.3.5"
 document-features = "0.2.8"
-embassy-time = { version = "0.3.0", optional = true }
+embassy-time = { version = "0.4", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }

--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1", default-features = false, features = [
 ], optional = true }
 seq-macro = "0.3.5"
 document-features = "0.2.8"
-embassy-time = { version = "0.4", optional = true }
+embassy-time = { version = ">=0.3, <0.5", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }


### PR DESCRIPTION
Unfortunately we need to update everything in one go...

Looks like stm32 examples haven't been updated in a while and there are bunch of API changes in embassy-stm32

* [x] lorawan-device
* [x] examples/nrf52840
* [x] examples/rp
* [x] stm32l0
* [x] stm32wl