### PR TITLE
Cleanup JoinAcceptCreator, JoinRequestCreator and DataPayloadCreator.

### DIFF
--- a/lorawan-device/src/mac/otaa.rs
+++ b/lorawan-device/src/mac/otaa.rs
@@ -37,12 +37,12 @@ impl Otaa {
     ) -> u16 {
         self.dev_nonce = DevNonce::from(rng.next_u32() as u16);
         buf.clear();
-        let mut phy: JoinRequestCreator<[u8; 23], C> = JoinRequestCreator::default();
+        let mut phy = JoinRequestCreator::with_options(buf.as_mut(), C::default()).unwrap();
         phy.set_app_eui(self.network_credentials.appeui)
             .set_dev_eui(self.network_credentials.deveui)
             .set_dev_nonce(self.dev_nonce);
-        let vec = phy.build(&self.network_credentials.appkey);
-        buf.extend_from_slice(vec).unwrap();
+        let len = phy.build(&self.network_credentials.appkey).len();
+        buf.set_pos(len);
         u16::from(self.dev_nonce)
     }
 

--- a/lorawan-device/src/mac/otaa.rs
+++ b/lorawan-device/src/mac/otaa.rs
@@ -37,11 +37,12 @@ impl Otaa {
     ) -> u16 {
         self.dev_nonce = DevNonce::from(rng.next_u32() as u16);
         buf.clear();
-        let mut phy = JoinRequestCreator::with_options(buf.as_mut(), C::default()).unwrap();
+        let mut phy = JoinRequestCreator::new(buf.as_mut()).unwrap();
         phy.set_app_eui(self.network_credentials.appeui)
             .set_dev_eui(self.network_credentials.deveui)
             .set_dev_nonce(self.dev_nonce);
-        let len = phy.build(&self.network_credentials.appkey).len();
+        let crypto_factory = C::default();
+        let len = phy.build(&self.network_credentials.appkey, &crypto_factory).len();
         buf.set_pos(len);
         u16::from(self.dev_nonce)
     }

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -190,7 +190,7 @@ impl Session {
         tx_buffer.clear();
         let fcnt = self.fcnt_up;
         let mut buf = [0u8; 256];
-        let mut phy = DataPayloadCreator::with_options(&mut buf, C::default()).unwrap();
+        let mut phy = DataPayloadCreator::new(&mut buf).unwrap();
 
         let mut fctrl = FCtrl(0x0, true);
         if self.uplink.confirms_downlink() {
@@ -216,7 +216,14 @@ impl Session {
             }
         }
 
-        match phy.build(data.data, dyn_cmds.as_slice(), &self.nwkskey, &self.appskey) {
+        let crypto_factory = C::default();
+        match phy.build(
+            data.data,
+            dyn_cmds.as_slice(),
+            &self.nwkskey,
+            &self.appskey,
+            &crypto_factory,
+        ) {
             Ok(packet) => {
                 tx_buffer.clear();
                 tx_buffer.extend_from_slice(packet).unwrap();

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -89,8 +89,7 @@ pub fn handle_join_request<const I: usize>(
             phy.set_app_nonce(&app_nonce_bytes);
             phy.set_net_id(&[1; 3]);
             phy.set_dev_addr(get_dev_addr());
-            let crypto_factory = DefaultFactory::default();
-            let finished = phy.build(&get_key().into(), &crypto_factory).unwrap();
+            let finished = phy.build(&get_key().into(), &DefaultFactory).unwrap();
             rx_buffer[..finished.len()].copy_from_slice(finished);
 
             let mut copy = rx_buffer[..finished.len()].to_vec();
@@ -153,9 +152,8 @@ pub fn handle_data_uplink_with_link_adr_req<const FCNT_UP: u16, const FCNT_DOWN:
             phy.set_dev_addr(&[0; 4]);
             phy.set_uplink(false);
             phy.set_fcnt(FCNT_DOWN);
-            let crypto_factory = DefaultFactory::default();
             let finished = phy
-                .build(&[3, 2, 1], &cmd, &get_key().into(), &get_key().into(), &crypto_factory)
+                .build(&[3, 2, 1], &cmd, &get_key().into(), &get_key().into(), &DefaultFactory)
                 .unwrap();
             finished.len()
         } else {
@@ -188,9 +186,8 @@ pub fn handle_class_c_uplink_after_join(
             phy.set_uplink(false);
             phy.set_fctrl(&fctrl);
             // set ack bit
-            let crypto_factory = DefaultFactory::default();
             let finished =
-                phy.build(&[], &[], &get_key().into(), &get_key().into(), &crypto_factory).unwrap();
+                phy.build(&[], &[], &get_key().into(), &get_key().into(), &DefaultFactory).unwrap();
             finished.len()
         } else {
             panic!("Did not decode PhyPayload::Data!");
@@ -243,9 +240,8 @@ pub fn handle_data_uplink_with_link_adr_ans(
             //phy.set_f_port(3);
             phy.set_fcnt(1);
             // zero out rx_buffer
-            let crypto_factory = DefaultFactory::default();
             let finished =
-                phy.build(&[], &[], &get_key().into(), &get_key().into(), &crypto_factory).unwrap();
+                phy.build(&[], &[], &get_key().into(), &get_key().into(), &DefaultFactory).unwrap();
             finished.len()
         } else {
             panic!("Unable to parse PhyPayload::Data from uplink in handle_data_uplink_with_link_adr_ans")
@@ -267,8 +263,7 @@ pub fn class_c_downlink<const FCNT_DOWN: u32>(
     phy.set_uplink(false);
     phy.set_fcnt(FCNT_DOWN);
 
-    let crypto_factory = DefaultFactory::default();
     let finished =
-        phy.build(&[1, 2, 3], &[], &get_key().into(), &get_key().into(), &crypto_factory).unwrap();
+        phy.build(&[1, 2, 3], &[], &get_key().into(), &get_key().into(), &DefaultFactory).unwrap();
     finished.len()
 }

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -84,14 +84,13 @@ pub fn handle_join_request<const I: usize>(
             let devnonce = join_request.dev_nonce().to_owned();
             assert!(join_request.validate_mic(&get_key().into()));
             let mut buffer: [u8; 17] = [0; 17];
-            let mut phy =
-                lorawan::creator::JoinAcceptCreator::with_options(&mut buffer, DefaultFactory)
-                    .unwrap();
+            let mut phy = lorawan::creator::JoinAcceptCreator::new(&mut buffer[..]).unwrap();
             let app_nonce_bytes = [1; 3];
             phy.set_app_nonce(&app_nonce_bytes);
             phy.set_net_id(&[1; 3]);
             phy.set_dev_addr(get_dev_addr());
-            let finished = phy.build(&get_key().into()).unwrap();
+            let crypto_factory = DefaultFactory::default();
+            let finished = phy.build(&get_key().into(), &crypto_factory).unwrap();
             rx_buffer[..finished.len()].copy_from_slice(finished);
 
             let mut copy = rx_buffer[..finished.len()].to_vec();
@@ -148,16 +147,16 @@ pub fn handle_data_uplink_with_link_adr_req<const FCNT_UP: u16, const FCNT_DOWN:
                 ),
             ];
             let cmd: Vec<&dyn SerializableMacCommand> = vec![&mac_cmds[0], &mac_cmds[1]];
-            let mut phy =
-                lorawan::creator::DataPayloadCreator::with_options(rx_buffer, DefaultFactory)
-                    .unwrap();
+            let mut phy = lorawan::creator::DataPayloadCreator::new(rx_buffer).unwrap();
             phy.set_confirmed(uplink.is_confirmed());
             phy.set_f_port(4);
             phy.set_dev_addr(&[0; 4]);
             phy.set_uplink(false);
             phy.set_fcnt(FCNT_DOWN);
-            let finished =
-                phy.build(&[3, 2, 1], &cmd, &get_key().into(), &get_key().into()).unwrap();
+            let crypto_factory = DefaultFactory::default();
+            let finished = phy
+                .build(&[3, 2, 1], &cmd, &get_key().into(), &get_key().into(), &crypto_factory)
+                .unwrap();
             finished.len()
         } else {
             panic!("Did not decode PhyPayload::Data!");
@@ -181,9 +180,7 @@ pub fn handle_class_c_uplink_after_join(
             let uplink =
                 data.decrypt(Some(&get_key().into()), Some(&get_key().into()), fcnt).unwrap();
             assert_eq!(uplink.fhdr().fcnt(), 0);
-            let mut phy =
-                lorawan::creator::DataPayloadCreator::with_options(rx_buffer, DefaultFactory)
-                    .unwrap();
+            let mut phy = lorawan::creator::DataPayloadCreator::new(rx_buffer).unwrap();
             let mut fctrl = parser::FCtrl::new(0, false);
             fctrl.set_ack();
             phy.set_confirmed(false);
@@ -191,7 +188,9 @@ pub fn handle_class_c_uplink_after_join(
             phy.set_uplink(false);
             phy.set_fctrl(&fctrl);
             // set ack bit
-            let finished = phy.build(&[], &[], &get_key().into(), &get_key().into()).unwrap();
+            let crypto_factory = DefaultFactory::default();
+            let finished =
+                phy.build(&[], &[], &get_key().into(), &get_key().into(), &crypto_factory).unwrap();
             finished.len()
         } else {
             panic!("Did not decode PhyPayload::Data!");
@@ -237,16 +236,16 @@ pub fn handle_data_uplink_with_link_adr_ans(
 
             // Build the actual data payload with FPort 0 which allows MAC Commands in payload
             rx_buffer.iter_mut().for_each(|x| *x = 0);
-            let mut phy =
-                lorawan::creator::DataPayloadCreator::with_options(rx_buffer, DefaultFactory)
-                    .unwrap();
+            let mut phy = lorawan::creator::DataPayloadCreator::new(rx_buffer).unwrap();
             phy.set_confirmed(uplink.is_confirmed());
             phy.set_dev_addr(&[0; 4]);
             phy.set_uplink(false);
             //phy.set_f_port(3);
             phy.set_fcnt(1);
             // zero out rx_buffer
-            let finished = phy.build(&[], &[], &get_key().into(), &get_key().into()).unwrap();
+            let crypto_factory = DefaultFactory::default();
+            let finished =
+                phy.build(&[], &[], &get_key().into(), &get_key().into(), &crypto_factory).unwrap();
             finished.len()
         } else {
             panic!("Unable to parse PhyPayload::Data from uplink in handle_data_uplink_with_link_adr_ans")
@@ -262,12 +261,14 @@ pub fn class_c_downlink<const FCNT_DOWN: u32>(
     _config: RfConfig,
     rx_buffer: &mut [u8],
 ) -> usize {
-    let mut phy =
-        lorawan::creator::DataPayloadCreator::with_options(rx_buffer, DefaultFactory).unwrap();
+    let mut phy = lorawan::creator::DataPayloadCreator::new(rx_buffer).unwrap();
     phy.set_f_port(3);
     phy.set_dev_addr(&[0; 4]);
     phy.set_uplink(false);
     phy.set_fcnt(FCNT_DOWN);
-    let finished = phy.build(&[1, 2, 3], &[], &get_key().into(), &get_key().into()).unwrap();
+
+    let crypto_factory = DefaultFactory::default();
+    let finished =
+        phy.build(&[1, 2, 3], &[], &get_key().into(), &get_key().into(), &crypto_factory).unwrap();
     finished.len()
 }

--- a/lorawan-encoding/README.md
+++ b/lorawan-encoding/README.md
@@ -30,7 +30,7 @@ use lorawan::types::Frequency;
 
 fn main() {
     let mut data = [0; 33];
-    let mut phy = JoinAcceptCreator::with_options(&mut data, DefaultFactory).unwrap();
+    let mut phy = JoinAcceptCreator::new(&mut data).unwrap();
     let key = keys::AES128([1; 16]);
     let app_nonce_bytes = [1; 3];
     phy.set_app_nonce(&app_nonce_bytes);
@@ -43,7 +43,8 @@ fn main() {
         Frequency::new(&[0x88, 0x66, 0x84,]).unwrap()
     ];
     phy.set_c_f_list(freqs).unwrap();
-    let payload = phy.build(&key).unwrap();
+    let crypto_factory = DefaultFactory::default();
+    let payload = phy.build(&key,&crypto_factory).unwrap();
     println!("Payload: {:x?}", payload);
 }
 ```

--- a/lorawan-encoding/README.md
+++ b/lorawan-encoding/README.md
@@ -43,8 +43,7 @@ fn main() {
         Frequency::new(&[0x88, 0x66, 0x84,]).unwrap()
     ];
     phy.set_c_f_list(freqs).unwrap();
-    let crypto_factory = DefaultFactory::default();
-    let payload = phy.build(&key,&crypto_factory).unwrap();
+    let payload = phy.build(&key,&DefaultFactory).unwrap();
     println!("Payload: {:x?}", payload);
 }
 ```

--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -166,14 +166,14 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> JoinAcceptCreator<D, F> {
         if !self.encrypted {
             self.encrypt_payload(key);
         }
-        Ok(&self.data.as_mut()[0..required_len])
+        Ok(&self.data.as_mut()[..required_len])
     }
 
     fn encrypt_payload(&mut self, key: &AES128) {
         let d = if self.with_c_f_list {
-            self.data.as_mut()
+            &mut self.data.as_mut()[..JOIN_ACCEPT_WITH_CFLIST_LEN]
         } else {
-            &mut self.data.as_mut()[..17]
+            &mut self.data.as_mut()[..JOIN_ACCEPT_LEN]
         };
         set_mic(d, key, &self.factory);
         let aes_enc = self.factory.new_dec(key);
@@ -265,8 +265,8 @@ impl<D: AsMut<[u8]>, F: CryptoFactory> JoinRequestCreator<D, F> {
     /// * key - the key to be used for setting the MIC.
     pub fn build(&mut self, key: &AppKey) -> &[u8] {
         let d = self.data.as_mut();
-        set_mic(d, &key.0, &self.factory);
-        d
+        set_mic(&mut d[..JOIN_REQUEST_LEN], &key.0, &self.factory);
+        &d[..JOIN_REQUEST_LEN]
     }
 }
 

--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -280,8 +280,7 @@ impl<D: AsMut<[u8]>> JoinRequestCreator<D> {
 ///     .set_dev_addr(&[4, 3, 2, 1])
 ///     .set_fctrl(&lorawan::parser::FCtrl::new(0x80, true)) // ADR: true, all others: false
 ///     .set_fcnt(76543);
-///    let crypto_factory = lorawan::default_crypto::DefaultFactory::default();
-/// phy.build(b"hello lora", &[], &nwk_skey, &app_skey,&crypto_factory).unwrap();
+/// phy.build(b"hello lora", &[], &nwk_skey, &app_skey,&lorawan::default_crypto::DefaultFactory).unwrap();
 /// ```
 #[derive(Default)]
 pub struct DataPayloadCreator<D> {
@@ -422,8 +421,7 @@ impl<D: AsMut<[u8]>> DataPayloadCreator<D> {
     /// cmds.push(&mac_cmd2);
     /// let nwk_skey = lorawan::keys::NwkSKey::from([2; 16]);
     /// let app_skey = lorawan::keys::AppSKey::from([1; 16]);
-    /// let crypto_factory = lorawan::default_crypto::DefaultFactory::default();
-    /// phy.build(&[], &cmds, &nwk_skey, &app_skey, &crypto_factory).unwrap();
+    /// phy.build(&[], &cmds, &nwk_skey, &app_skey, &lorawan::default_crypto::DefaultFactory).unwrap();
     /// ```
     pub fn build<F: CryptoFactory>(
         &mut self,

--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -27,6 +27,25 @@ const PIGGYBACK_MAC_COMMANDS_MAX_LEN: usize = 15;
 
 /// JoinAcceptCreator serves for creating binary representation of Physical
 /// Payload of JoinAccept.
+///
+/// # Examples
+///
+/// ```
+/// let mut buf = [0u8; 100];
+/// let mut phy = lorawan::creator::JoinAcceptCreator::new(&mut buf).unwrap();
+/// let key = lorawan::keys::AES128([1; 16]);
+/// let app_nonce_bytes = [1; 3];
+/// phy.set_app_nonce(&app_nonce_bytes);
+/// phy.set_net_id(&[1; 3]);
+/// phy.set_dev_addr(&[1; 4]);
+/// phy.set_dl_settings(2);
+/// phy.set_rx_delay(1);
+/// let mut freqs: Vec<lorawan::types::Frequency> = Vec::new();
+/// freqs.push(lorawan::types::Frequency::new(&[0x58, 0x6e, 0x84,]).unwrap());
+/// freqs.push(lorawan::types::Frequency::new(&[0x88, 0x66, 0x84,]).unwrap());
+/// phy.set_c_f_list(freqs);
+/// let payload = phy.build(&key, &lorawan::default_crypto::DefaultFactory).unwrap();
+/// ```
 #[derive(Default)]
 pub struct JoinAcceptCreator<D> {
     data: D,
@@ -189,6 +208,17 @@ fn set_mic<F: CryptoFactory>(data: &mut [u8], key: &AES128, factory: &F) {
 
 /// JoinRequestCreator serves for creating binary representation of Physical
 /// Payload of JoinRequest.
+/// # Examples
+///
+/// ```
+/// let mut buf = [0u8;100];
+/// let mut phy = lorawan::creator::JoinRequestCreator::new(&mut buf).unwrap();
+/// let key = lorawan::keys::AppKey::from([7; 16]);
+/// phy.set_app_eui(&[1; 8]);
+/// phy.set_dev_eui(&[2; 8]);
+/// phy.set_dev_nonce(&[3; 2]);
+/// let payload = phy.build(&key, &lorawan::default_crypto::DefaultFactory);
+/// ```
 #[derive(Default)]
 pub struct JoinRequestCreator<D> {
     data: D,

--- a/lorawan-encoding/src/default_crypto.rs
+++ b/lorawan-encoding/src/default_crypto.rs
@@ -1,11 +1,9 @@
 //! Provides a default software implementation for LoRaWAN's cryptographic functions.
-use super::creator::JoinRequestCreator;
 use super::keys::*;
 use super::parser::{
     DecryptedDataPayload, DecryptedJoinAcceptPayload, EncryptedDataPayload,
     EncryptedJoinAcceptPayload, JoinRequestPayload,
 };
-use crate::creator::{DataPayloadCreator, JoinAcceptCreator};
 use crate::parser::Error;
 use aes::cipher::generic_array::GenericArray;
 use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
@@ -59,77 +57,6 @@ impl Mac for Cmac {
 
     fn result(self) -> [u8; 16] {
         cmac::Mac::finalize(self).into_bytes().into()
-    }
-}
-
-impl<D: AsMut<[u8]>> DataPayloadCreator<D, DefaultFactory> {
-    /// Creates a well initialized DataPayloadCreator.
-    ///
-    /// By default the packet is unconfirmed data up packet.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let mut buf = [0u8; 255];
-    /// let mut phy = lorawan::creator::DataPayloadCreator::new(&mut buf).unwrap();
-    /// let nwk_skey = lorawan::keys::NwkSKey::from([2; 16]);
-    /// let app_skey = lorawan::keys::AppSKey::from([1; 16]);
-    /// let fctrl = lorawan::parser::FCtrl::new(0x80, true);
-    /// phy.set_confirmed(false).
-    ///     set_uplink(true).
-    ///     set_f_port(1).
-    ///     set_dev_addr(&[4, 3, 2, 1]).
-    ///     set_fctrl(&fctrl). // ADR: true, all others: false
-    ///     set_fcnt(1);
-    /// let payload = phy.build(b"hello", &[], &nwk_skey, &app_skey).unwrap();
-    /// ```
-    pub fn new(buf: D) -> Result<Self, super::creator::Error> {
-        Self::with_options(buf, DefaultFactory)
-    }
-}
-
-impl<D: AsMut<[u8]>> JoinRequestCreator<D, DefaultFactory> {
-    /// Creates a well initialized JoinRequestCreator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let mut buf = [0u8; 23];
-    /// let mut phy = lorawan::creator::JoinRequestCreator::new(&mut buf[..]).unwrap();
-    /// let key = lorawan::keys::AppKey::from([7; 16]);
-    /// phy.set_app_eui(&[1; 8]);
-    /// phy.set_dev_eui(&[2; 8]);
-    /// phy.set_dev_nonce(&[3; 2]);
-    /// let payload = phy.build(&key);
-    /// ```
-    pub fn new(buf: D) -> Result<Self, super::creator::Error> {
-        Self::with_options(buf, DefaultFactory)
-    }
-}
-
-impl<D: AsMut<[u8]>> JoinAcceptCreator<D, DefaultFactory> {
-    /// Creates a well initialized JoinAcceptCreator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let mut buf = [0u8; 17];
-    /// let mut phy = lorawan::creator::JoinAcceptCreator::new(&mut buf[..]).unwrap();
-    /// let key = lorawan::keys::AES128([1; 16]);
-    /// let app_nonce_bytes = [1; 3];
-    /// phy.set_app_nonce(&app_nonce_bytes);
-    /// phy.set_net_id(&[1; 3]);
-    /// phy.set_dev_addr(&[1; 4]);
-    /// phy.set_dl_settings(2);
-    /// phy.set_rx_delay(1);
-    /// let mut freqs: Vec<lorawan::types::Frequency> = Vec::new();
-    /// freqs.push(lorawan::types::Frequency::new(&[0x58, 0x6e, 0x84,]).unwrap());
-    /// freqs.push(lorawan::types::Frequency::new(&[0x88, 0x66, 0x84,]).unwrap());
-    /// phy.set_c_f_list(freqs);
-    /// let payload = phy.build(&key).unwrap();
-    /// ```
-    pub fn new(buf: D) -> Result<Self, super::creator::Error> {
-        Self::with_options(buf, DefaultFactory)
     }
 }
 

--- a/lorawan-encoding/tests/lorawan.rs
+++ b/lorawan-encoding/tests/lorawan.rs
@@ -447,9 +447,8 @@ fn test_data_payload_uplink_creator() {
         .set_fctrl(&fctrl) // ADR: true, all others: false
         .set_fcnt(1);
 
-    let crypto_factory = DefaultFactory::default();
     assert_eq!(
-        phy.build(b"hello", &[], &nwk_skey, &app_skey, &crypto_factory).unwrap(),
+        phy.build(b"hello", &[], &nwk_skey, &app_skey, &DefaultFactory).unwrap(),
         &phy_dataup_payload()[..]
     );
 }
@@ -468,14 +467,13 @@ fn test_long_data_payload_uplink_creator() {
         .set_fctrl(&fctrl) // all flags set to false
         .set_fcnt(0);
 
-    let crypto_factory = DefaultFactory::default();
     assert_eq!(
         phy.build(
             &long_data_payload().into_bytes()[..],
             &[],
             &nwk_skey,
             &app_skey,
-            &crypto_factory
+            &DefaultFactory
         )
         .unwrap(),
         &phy_long_dataup_payload()[..]
@@ -496,9 +494,8 @@ fn test_data_payload_downlink_creator() {
         .set_fctrl(&fctrl) // ADR: true, all others: false
         .set_fcnt(76543);
 
-    let crypto_factory = DefaultFactory::default();
     assert_eq!(
-        phy.build(b"hello lora", &[], &nwk_skey, &app_skey, &crypto_factory).unwrap(),
+        phy.build(b"hello lora", &[], &nwk_skey, &app_skey, &DefaultFactory).unwrap(),
         &phy_datadown_payload()[..]
     );
 }
@@ -510,8 +507,7 @@ fn test_data_payload_creator_when_payload_and_fport_0() {
     let nwk_skey = [2; 16].into();
     let app_skey = [1; 16].into();
     phy.set_f_port(0);
-    let crypto_factory = DefaultFactory::default();
-    assert!(phy.build(b"hello", &[], &nwk_skey, &app_skey, &crypto_factory).is_err());
+    assert!(phy.build(b"hello", &[], &nwk_skey, &app_skey, &DefaultFactory).is_err());
 }
 
 #[test]
@@ -526,8 +522,7 @@ fn test_data_payload_creator_when_encrypt_but_not_fport_0() {
     let mut cmds: Vec<&dyn SerializableMacCommand> = Vec::new();
     cmds.extend_from_slice(&[&new_channel_req, &new_channel_req, &new_channel_req]);
     phy.set_f_port(1);
-    let crypto_factory = DefaultFactory::default();
-    assert!(phy.build(b"", &cmds[..], &nwk_skey, &app_skey, &crypto_factory).is_err());
+    assert!(phy.build(b"", &cmds[..], &nwk_skey, &app_skey, &DefaultFactory).is_err());
 }
 
 #[test]
@@ -536,8 +531,7 @@ fn test_data_payload_creator_when_payload_no_fport() {
     let mut phy = DataPayloadCreator::new(&mut buf).unwrap();
     let nwk_skey = [2; 16].into();
     let app_skey = [1; 16].into();
-    let crypto_factory = DefaultFactory::default();
-    assert!(phy.build(b"hello", &[], &nwk_skey, &app_skey, &crypto_factory).is_err());
+    assert!(phy.build(b"hello", &[], &nwk_skey, &app_skey, &DefaultFactory).is_err());
 }
 
 #[test]
@@ -552,9 +546,8 @@ fn test_data_payload_creator_when_mac_commands_in_payload() {
     let mut cmds: Vec<&dyn SerializableMacCommand> = Vec::new();
     cmds.extend_from_slice(&[&mac_cmd1, &mac_cmd2]);
     phy.set_confirmed(false).set_uplink(true).set_f_port(0).set_dev_addr(&[4, 3, 2, 1]).set_fcnt(0);
-    let crypto_factory = DefaultFactory::default();
     assert_eq!(
-        phy.build(b"", &cmds[..], &nwk_skey, &app_skey, &crypto_factory).unwrap(),
+        phy.build(b"", &cmds[..], &nwk_skey, &app_skey, &DefaultFactory).unwrap(),
         &data_payload_with_fport_zero()[..]
     );
 }
@@ -562,7 +555,6 @@ fn test_data_payload_creator_when_mac_commands_in_payload() {
 #[test]
 fn test_data_payload_creator_when_mac_commands_in_f_opts() {
     let mut buf = [0u8; 256];
-    let crypto_factory = DefaultFactory::default();
     let mut phy = DataPayloadCreator::new(&mut buf).unwrap();
     let nwk_skey = [1; 16].into();
     let app_skey = [0; 16].into();
@@ -574,7 +566,7 @@ fn test_data_payload_creator_when_mac_commands_in_f_opts() {
     phy.set_confirmed(false).set_uplink(true).set_dev_addr(&[4, 3, 2, 1]).set_fcnt(0);
 
     assert_eq!(
-        phy.build(b"", &cmds[..], &nwk_skey, &app_skey, &crypto_factory).unwrap(),
+        phy.build(b"", &cmds[..], &nwk_skey, &app_skey, &DefaultFactory).unwrap(),
         &data_payload_with_f_opts()[..]
     );
 }
@@ -630,8 +622,7 @@ fn test_join_accept_creator() {
         .set_dl_settings(0)
         .set_rx_delay(0);
 
-    let crypto_factory = DefaultFactory::default();
-    assert_eq!(phy.build(&key, &crypto_factory), Ok(&phy_join_accept_payload()[..]));
+    assert_eq!(phy.build(&key, &DefaultFactory), Ok(&phy_join_accept_payload()[..]));
 }
 #[test]
 #[cfg(feature = "default-crypto")]
@@ -661,8 +652,7 @@ fn test_join_accept_creator_with_cflist() {
         .set_rx_delay(0)
         .set_c_f_list(&freqs)
         .unwrap();
-    let crypto_factory = DefaultFactory::default();
-    phy.build(key.inner(), &crypto_factory).unwrap();
+    phy.build(key.inner(), &DefaultFactory).unwrap();
     let encrypted = EncryptedJoinAcceptPayload::new(buf).unwrap();
     let decrypted = encrypted.decrypt(&key);
     assert!(decrypted.validate_mic(&key));
@@ -678,8 +668,7 @@ fn test_join_request_creator() {
         .set_dev_eui(&[0x05, 0x04, 0x03, 0x02, 0x05, 0x04, 0x03, 0x02])
         .set_dev_nonce(&[0x2du8, 0x10]);
 
-    let crypto_factory = DefaultFactory::default();
-    assert_eq!(phy.build(&key, &crypto_factory), &phy_join_request_payload()[..]);
+    assert_eq!(phy.build(&key, &DefaultFactory), &phy_join_request_payload()[..]);
 }
 #[test]
 fn test_join_request_creator_short_buffer() {

--- a/lorawan-encoding/tests/lorawan.rs
+++ b/lorawan-encoding/tests/lorawan.rs
@@ -626,6 +626,21 @@ fn test_join_accept_creator() {
 }
 #[test]
 #[cfg(feature = "default-crypto")]
+fn test_join_accept_creator_long_buffer() {
+    let mut buf = [0u8; 255];
+    let mut phy = JoinAcceptCreator::new(&mut buf[..]).unwrap();
+    let key = AES128(app_key());
+    let app_nonce_bytes = [0xc7, 0x0b, 0x57];
+    phy.set_app_nonce(&app_nonce_bytes)
+        .set_net_id(&[0x01, 0x11, 0x22])
+        .set_dev_addr(&[0x80, 0x19, 0x03, 0x02])
+        .set_dl_settings(0)
+        .set_rx_delay(0);
+
+    assert_eq!(phy.build(&key, &DefaultFactory), Ok(&phy_join_accept_payload()[..]));
+}
+#[test]
+#[cfg(feature = "default-crypto")]
 fn test_join_accept_creator_short_buffer() {
     let mut buf = [0u8; 16];
     let phy_res = JoinAcceptCreator::new(&mut buf[..]);
@@ -662,6 +677,17 @@ fn test_join_accept_creator_with_cflist() {
 #[test]
 fn test_join_request_creator() {
     let buf = [0u8; 23];
+    let mut phy = JoinRequestCreator::new(buf).unwrap();
+    let key = [1; 16].into();
+    phy.set_app_eui(&[0x04, 0x03, 0x02, 0x01, 0x04, 0x03, 0x02, 0x01])
+        .set_dev_eui(&[0x05, 0x04, 0x03, 0x02, 0x05, 0x04, 0x03, 0x02])
+        .set_dev_nonce(&[0x2du8, 0x10]);
+
+    assert_eq!(phy.build(&key, &DefaultFactory), &phy_join_request_payload()[..]);
+}
+#[test]
+fn test_join_request_creator_long_buffer() {
+    let buf = [0u8; 255];
     let mut phy = JoinRequestCreator::new(buf).unwrap();
     let key = [1; 16].into();
     phy.set_app_eui(&[0x04, 0x03, 0x02, 0x01, 0x04, 0x03, 0x02, 0x01])

--- a/lorawan-encoding/tests/lorawan.rs
+++ b/lorawan-encoding/tests/lorawan.rs
@@ -602,7 +602,8 @@ fn test_validate_join_request_mic_when_not_ok() {
 #[test]
 #[cfg(feature = "default-crypto")]
 fn test_join_accept_creator() {
-    let mut phy = JoinAcceptCreator::new();
+    let mut buf = [0u8; 17];
+    let mut phy = JoinAcceptCreator::new(&mut buf[..]).unwrap();
     let key = AES128(app_key());
     let app_nonce_bytes = [0xc7, 0x0b, 0x57];
     phy.set_app_nonce(&app_nonce_bytes)

--- a/lorawan-encoding/tests/lorawan.rs
+++ b/lorawan-encoding/tests/lorawan.rs
@@ -683,7 +683,7 @@ fn test_join_request_creator() {
         .set_dev_eui(&[0x05, 0x04, 0x03, 0x02, 0x05, 0x04, 0x03, 0x02])
         .set_dev_nonce(&[0x2du8, 0x10]);
 
-    assert_eq!(phy.build(&key, &DefaultFactory), &phy_join_request_payload()[..]);
+    assert_eq!(phy.build(&key, &DefaultFactory), &phy_join_request_payload());
 }
 #[test]
 fn test_join_request_creator_long_buffer() {


### PR DESCRIPTION
This change makes the creator apis more uniform for JoinAcceptCreator, JoinRequestCreator and DataPayloadCreator.
The ::new api changes to accept a buffer instead of creating its own. This returns a result as the buffer might be too short.

This change also makes the `new` api a wrapper for `with_options`. lora-rs code uses the with_options directly as we want to pass in the generic CryptoFactory

I also moved JoinAcceptCreator new impl to default crypto so it stays with the others.