### PR TITLE
Bunch of small documentation fixes for lorawan-device

### DIFF
--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -35,7 +35,6 @@ embassy-time = { version = ">=0.3, <0.5", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }
 rand = { version = "0", features = ["getrandom"] }
-lazy_static = "1"
 # Pull in lorawan/default-crypto which is required for tests
 lorawan = { path = "../lorawan-encoding", default-features = false, features = [
     "default-crypto",

--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", default-features = false, features = [
     "derive",
 ], optional = true }
 seq-macro = "0.3.5"
-document-features = "0.2.8"
+document-features = "0.2.10"
 embassy-time = { version = ">=0.3, <0.5", optional = true }
 
 [dev-dependencies]

--- a/lorawan-device/src/lib.rs
+++ b/lorawan-device/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! ## Feature flags
-#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![doc = document_features::document_features!()]
 #![doc = include_str!("../README.md")]
 
 // This must go FIRST so that all the other modules see its macros.

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -17,7 +17,8 @@ pub use us915::US915;
 
 seq_macro::seq!(
     N in 1..=8 {
-        /// Subband definitions used to bias the join process of a fixed channel plan (ie: US915, AU915).
+        /// Subband definitions used to bias the join process for regions with fixed channel plans (ie: [`US915`], [`AU915`]).
+        ///
         /// Each Subband holds 8 channels. eg: subband 1 contains: channels 0-7, subband 2: channels 8-15, etc.
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -77,7 +77,9 @@ pub(crate) trait ChannelRegion<const D: usize> {
 
 #[derive(Clone)]
 /// Contains LoRaWAN region-specific configuration; is required for creating a LoRaWAN Device.
-/// Generally constructed using the `Region` enum, unless you need to fine-tune US915 or AU915.
+///
+/// Generally constructed using the [`Region`] enum, unless You need to do region-specific
+/// fine-tuning, like for example [`US915`] or [`AU915`].
 pub struct Configuration {
     state: State,
 }
@@ -88,7 +90,9 @@ seq_macro::seq!(
         #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
         #[repr(u8)]
         /// A restricted data rate type that exposes the number of variants to only what _may_ be
-        /// potentially be possible. Note that not all data rates are valid in all regions.
+        /// potentially be possible.
+        ///
+        /// Note that not all data rates are valid in all regions.
         pub enum DR {
             #(
                 _~N = N,
@@ -99,6 +103,7 @@ seq_macro::seq!(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Regions supported by this crate: AS923_1, AS923_2, AS923_3, AS923_4, AU915, EU868, EU433, IN865, US915.
+///
 /// Each region is individually feature-gated (eg: `region-eu868`), however, by default, all regions are enabled.
 ///
 pub enum Region {
@@ -193,7 +198,8 @@ impl State {
     }
 }
 
-/// This datarate type is used internally for defining bandwidth/sf per region
+/// This datarate type is used internally for defining [`Bandwidth`]/[`SpreadingFactor`] per
+/// region.
 #[derive(Debug, Clone)]
 pub(crate) struct Datarate {
     bandwidth: Bandwidth,

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -12,7 +12,11 @@ use lorawan::{
 use mac::Session;
 
 use radio::{RfConfig, TxConfig};
-use std::{collections::HashMap, sync::Mutex, vec::Vec};
+use std::{
+    collections::HashMap,
+    sync::{LazyLock, Mutex},
+    vec::Vec,
+};
 
 /// This module contains some functions for both async device and state machine driven devices
 /// to operate unit tests.
@@ -68,10 +72,8 @@ pub fn get_abp_credentials() -> JoinMode {
 
 pub type RxTxHandler = fn(Option<Uplink>, RfConfig, &mut [u8]) -> usize;
 
-lazy_static::lazy_static! {
-    static ref SESSION: Mutex<HashMap<usize, Session>> = Mutex::new(HashMap::new());
-
-}
+static SESSION: LazyLock<Mutex<HashMap<usize, Session>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Handle join request and pack a JoinAccept into RxBuffer
 pub fn handle_join_request<const I: usize>(


### PR DESCRIPTION
Also drop lazy_static dev-dependency in favor of [`std::sync::LazyLock`](https://doc.rust-lang.org/std/sync/struct.LazyLock.html)