### PR TITLE
500kHz Sensitivity optimization

### DIFF
--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -58,6 +58,7 @@ pub struct Config<C: Sx127xVariant> {
 pub struct Sx127x<SPI, IV, C: Sx127xVariant + Sized> {
     intf: SpiInterface<SPI, IV>,
     config: Config<C>,
+    data: C::Data,
 }
 
 impl<SPI, IV, C> Sx127x<SPI, IV, C>
@@ -69,7 +70,11 @@ where
     /// Create an instance of the RadioKind implementation for the LoRa chip kind and board type
     pub fn new(spi: SPI, iv: IV, config: Config<C>) -> Self {
         let intf = SpiInterface::new(spi, iv);
-        Self { intf, config }
+        Self {
+            intf,
+            config,
+            data: Default::default(),
+        }
     }
 
     // Utility functions
@@ -125,6 +130,9 @@ where
         self.write_register(Register::RegSyncWord, sync_word).await?;
 
         self.set_tx_rx_buffer_base_address(0, 0).await?;
+
+        C::init_lora(self, sync_word).await?;
+
         Ok(())
     }
 

--- a/lora-phy/src/sx127x/radio_kind_params.rs
+++ b/lora-phy/src/sx127x/radio_kind_params.rs
@@ -5,6 +5,15 @@ use embedded_hal_async::spi::SpiDevice;
 
 #[allow(async_fn_in_trait)]
 pub trait Sx127xVariant {
+    type Data: Default;
+
+    async fn init_lora<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        radio: &mut Sx127x<SPI, IV, Self>,
+        sync_word: u8,
+    ) -> Result<(), RadioError>
+    where
+        Self: Sized;
+
     fn bandwidth_value(bw: Bandwidth) -> Result<u8, RadioError>;
     fn reg_txco() -> Register;
     async fn set_tx_power<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
@@ -175,8 +184,10 @@ pub enum Register {
     RegRssiWideband = 0x2c,
     RegDetectionOptimize = 0x31,
     RegInvertiq = 0x33,
+    RegHighBwOptimize1 = 0x36,
     RegDetectionThreshold = 0x37,
     RegSyncWord = 0x39,
+    RegHighBwOptimize2 = 0x3a,
     RegInvertiq2 = 0x3b,
     RegDioMapping1 = 0x40,
     RegVersion = 0x42,

--- a/lora-phy/src/sx127x/sx1272.rs
+++ b/lora-phy/src/sx127x/sx1272.rs
@@ -9,6 +9,15 @@ use lora_modulation::Bandwidth;
 pub struct Sx1272;
 
 impl Sx127xVariant for Sx1272 {
+    type Data = ();
+
+    async fn init_lora<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
+        _radio: &mut Sx127x<SPI, IV, Self>,
+        _sync_word: u8,
+    ) -> Result<(), RadioError> {
+        Ok(())
+    }
+
     fn bandwidth_value(bw: Bandwidth) -> Result<u8, RadioError> {
         match bw {
             Bandwidth::_125KHz => Ok(0x00),


### PR DESCRIPTION
Support optimizations for 500kHz bandwidth as described in Errata 2.1.

The Errata indicates that this only applies to chips that have 0x12 in RegVersion, but I believe that is the case for all production chips.

See: https://github.com/sparkfun/SparkFun_LoRaSerial/blob/main/Documents/SX1276_77_8_ErrataNote_1.1_STD.pdf