### PR TITLE
lora-phy: Errata cleanup

### DIFF
--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -58,7 +58,6 @@ pub struct Config<C: Sx127xVariant> {
 pub struct Sx127x<SPI, IV, C: Sx127xVariant + Sized> {
     intf: SpiInterface<SPI, IV>,
     config: Config<C>,
-    data: C::Data,
 }
 
 impl<SPI, IV, C> Sx127x<SPI, IV, C>
@@ -70,11 +69,7 @@ where
     /// Create an instance of the RadioKind implementation for the LoRa chip kind and board type
     pub fn new(spi: SPI, iv: IV, config: Config<C>) -> Self {
         let intf = SpiInterface::new(spi, iv);
-        Self {
-            intf,
-            config,
-            data: Default::default(),
-        }
+        Self { intf, config }
     }
 
     // Utility functions

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -19,12 +19,6 @@ const TCXO_FOR_OSCILLATOR: u8 = 0x10u8;
 const SX127X_MIN_LORA_SYMB_NUM_TIMEOUT: u16 = 4;
 const SX127X_MAX_LORA_SYMB_NUM_TIMEOUT: u16 = 1023;
 
-// Constant values need to compute the RSSI value
-const SX1272_RSSI_OFFSET: i16 = -139;
-const SX1276_RSSI_OFFSET_LF: i16 = -164;
-const SX1276_RSSI_OFFSET_HF: i16 = -157;
-const SX1276_RF_MID_BAND_THRESH: u32 = 525_000_000;
-
 // Frequency synthesizer step for frequency calculation (Hz)
 // FXOSC (32 MHz) * 1000000 (Hz/MHz) / 524288 (2^19)
 const SCALE: u32 = 8;

--- a/lora-phy/src/sx127x/radio_kind_params.rs
+++ b/lora-phy/src/sx127x/radio_kind_params.rs
@@ -5,8 +5,6 @@ use embedded_hal_async::spi::SpiDevice;
 
 #[allow(async_fn_in_trait)]
 pub trait Sx127xVariant {
-    type Data: Default;
-
     async fn init_lora<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
         radio: &mut Sx127x<SPI, IV, Self>,
         sync_word: u8,

--- a/lora-phy/src/sx127x/sx1272.rs
+++ b/lora-phy/src/sx127x/sx1272.rs
@@ -1,9 +1,11 @@
 use crate::mod_params::{ModulationParams, PacketParams, RadioError};
 use crate::mod_traits::InterfaceVariant;
 use crate::sx127x::radio_kind_params::{coding_rate_value, spreading_factor_value, RampTime, Register, Sx127xVariant};
-use crate::sx127x::{Sx127x, SX1272_RSSI_OFFSET};
+use crate::sx127x::Sx127x;
 use embedded_hal_async::spi::SpiDevice;
 use lora_modulation::Bandwidth;
+
+const SX1272_RSSI_OFFSET: i16 = -139;
 
 /// Sx1272 implements the Sx127xVariant trait
 pub struct Sx1272;

--- a/lora-phy/src/sx127x/sx1272.rs
+++ b/lora-phy/src/sx127x/sx1272.rs
@@ -9,8 +9,6 @@ use lora_modulation::Bandwidth;
 pub struct Sx1272;
 
 impl Sx127xVariant for Sx1272 {
-    type Data = ();
-
     async fn init_lora<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
         _radio: &mut Sx127x<SPI, IV, Self>,
         _sync_word: u8,

--- a/lora-phy/src/sx127x/sx1276.rs
+++ b/lora-phy/src/sx127x/sx1276.rs
@@ -3,11 +3,13 @@ use crate::mod_traits::InterfaceVariant;
 use crate::sx127x::radio_kind_params::{
     coding_rate_denominator_value, spreading_factor_value, OcpTrim, PaConfig, PaDac, RampTime, Register, Sx127xVariant,
 };
-use crate::sx127x::{
-    pll_step_to_freq, Sx127x, SX1276_RF_MID_BAND_THRESH, SX1276_RSSI_OFFSET_HF, SX1276_RSSI_OFFSET_LF,
-};
+use crate::sx127x::{pll_step_to_freq, Sx127x};
 use embedded_hal_async::spi::SpiDevice;
 use lora_modulation::Bandwidth;
+
+const SX1276_RSSI_OFFSET_LF: i16 = -164;
+const SX1276_RSSI_OFFSET_HF: i16 = -157;
+const SX1276_RF_MID_BAND_THRESH: u32 = 525_000_000;
 
 /// Sx1276 implements the Sx127xVariant trait
 pub struct Sx1276 {


### PR DESCRIPTION
After merging #324 I noticed that we can actually utilize the chip struct itself for keeping the chip-specific data.

cc: @powturns 