### PR TITLE
Fix DioMapping1Dio1 Shifts

### DIFF
--- a/lora-phy/src/sx127x/radio_kind_params.rs
+++ b/lora-phy/src/sx127x/radio_kind_params.rs
@@ -78,10 +78,10 @@ impl LoRaMode {
 
 #[allow(dead_code)]
 pub enum DioMapping1Dio0 {
-    RxDone = 0x00,
-    TxDone = 0x40,
-    CadDone = 0x80,
-    Other = 0xc0,
+    RxDone = 0b00 << 6,
+    TxDone = 0b01 << 6,
+    CadDone = 0b10 << 6,
+    Other = 0b11 << 6,
     Mask = 0x3f,
 }
 
@@ -93,11 +93,11 @@ impl DioMapping1Dio0 {
 
 #[allow(dead_code)]
 pub enum DioMapping1Dio1 {
-    RxTimeOut = 0b00 << 2,
-    FhssChangeChannel = 0b01 << 2,
-    CadDetected = 0b10 << 2,
-    Other = 0b11 << 2,
-    Mask = 0xf3,
+    RxTimeOut = 0b00 << 4,
+    FhssChangeChannel = 0b01 << 4,
+    CadDetected = 0b10 << 4,
+    Other = 0b11 << 4,
+    Mask = 0xcf,
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
According to the datasheet, Dio1 occupies bits 5-4 (zero indexed) of the register. This requires a left shift of 4 to skip over Dio3 and Dio2

![image](https://github.com/user-attachments/assets/23b0e597-d1d2-49c3-a896-daafca80c05d)
