### PR TITLE
Certification protocol implementation

### DIFF
--- a/lorawan-encoding/src/certification.rs
+++ b/lorawan-encoding/src/certification.rs
@@ -17,6 +17,10 @@ pub enum DownlinkDUTCommand<'a> {
     #[cmd(cid = 0x02, len = 0)]
     DutJoinReq(DutJoinReqPayload),
 
+    /// Request to activate/deactivate Adaptive Data Rate (ADR)
+    #[cmd(cid = 0x04, len = 1)]
+    AdrBitChangeReq(AdrBitChangeReqPayload<'a>),
+
     /// Change uplink periodicity to the provided value
     #[cmd(cid = 0x06, len = 1)]
     TxPeriodicityChangeReq(TxPeriodicityChangeReqPayload<'a>),
@@ -31,6 +35,17 @@ pub fn parse_downlink_certification_messages(
     data: &[u8],
 ) -> MacCommandIterator<'_, DownlinkDUTCommand<'_>> {
     MacCommandIterator::new(data)
+}
+
+impl AdrBitChangeReqPayload<'_> {
+    /// Enable/disable ADR
+    pub fn adr_enable(&self) -> Result<bool, Error> {
+        match self.0[0] {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(Error::RFU),
+        }
+    }
 }
 
 impl TxPeriodicityChangeReqPayload<'_> {

--- a/lorawan-encoding/src/certification.rs
+++ b/lorawan-encoding/src/certification.rs
@@ -1,6 +1,7 @@
 //! LoRaWAN Certification Protocol (TS009) command and payload handling
 use lorawan_macros::CommandHandler;
 
+use crate::creator::UnimplementedCreator;
 use crate::maccommands::MacCommandIterator;
 use crate::maccommands::SerializableMacCommand;
 
@@ -92,6 +93,11 @@ impl TxPeriodicityChangeReqPayload<'_> {
         }
     }
 }
+
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+pub struct TxFramesCtrlReqCreator {}
+impl UnimplementedCreator for TxFramesCtrlReqCreator {}
 
 impl<'a> TxFramesCtrlReqPayload<'a> {
     pub fn new(data: &'a [u8]) -> Result<Self, Error> {

--- a/lorawan-encoding/src/certification.rs
+++ b/lorawan-encoding/src/certification.rs
@@ -10,6 +10,10 @@ pub enum DownlinkDUTCommand {
     /// Request to reset the Microcontroller Unit
     #[cmd(cid = 0x01, len = 0)]
     DutResetReq(DutResetReqPayload),
+
+    /// Request to reset the LoRaWAN MAC layer and start issuing Join-Request messages
+    #[cmd(cid = 0x02, len = 0)]
+    DutJoinReq(DutJoinReqPayload),
 }
 
 pub fn parse_downlink_certification_messages(

--- a/lorawan-encoding/src/certification.rs
+++ b/lorawan-encoding/src/certification.rs
@@ -1,0 +1,19 @@
+//! LoRaWAN Certification Protocol (TS009) command and payload handling
+use lorawan_macros::CommandHandler;
+
+use crate::maccommands::MacCommandIterator;
+use crate::maccommands::SerializableMacCommand;
+
+#[derive(Debug, PartialEq, CommandHandler)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+pub enum DownlinkDUTCommand {
+    /// Request to reset the Microcontroller Unit
+    #[cmd(cid = 0x01, len = 0)]
+    DutResetReq(DutResetReqPayload),
+}
+
+pub fn parse_downlink_certification_messages(
+    data: &[u8],
+) -> MacCommandIterator<'_, DownlinkDUTCommand> {
+    MacCommandIterator::new(data)
+}

--- a/lorawan-encoding/src/certification.rs
+++ b/lorawan-encoding/src/certification.rs
@@ -29,6 +29,17 @@ pub enum DownlinkDUTCommand<'a> {
     // NB! Variable length payload without any size indication
     #[cmd(cid = 0x07)]
     TxFramesCtrlReq(TxFramesCtrlReqPayload<'a>),
+
+    /// Request to send firmware version, LoRaWAN version, and regional parameters version
+    #[cmd(cid = 0x7f, len = 0)]
+    DutVersionsReq(DutVersionsReqPayload),
+}
+
+#[derive(Debug, PartialEq, CommandHandler)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+pub enum UplinkDUTCommand<'a> {
+    #[cmd(cid = 0x7f, len = 12)]
+    DutVersionsAns(DutVersionsAnsPayload<'a>),
 }
 
 pub fn parse_downlink_certification_messages(
@@ -45,6 +56,13 @@ impl AdrBitChangeReqPayload<'_> {
             1 => Ok(true),
             _ => Err(Error::RFU),
         }
+    }
+}
+
+impl DutVersionsAnsCreator {
+    pub fn set_versions_raw(&mut self, data: [u8; 12]) -> &mut Self {
+        self.data[1..=12].copy_from_slice(&data);
+        self
     }
 }
 

--- a/lorawan-encoding/src/certification.rs
+++ b/lorawan-encoding/src/certification.rs
@@ -4,9 +4,11 @@ use lorawan_macros::CommandHandler;
 use crate::maccommands::MacCommandIterator;
 use crate::maccommands::SerializableMacCommand;
 
+use crate::maccommands::Error;
+
 #[derive(Debug, PartialEq, CommandHandler)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
-pub enum DownlinkDUTCommand {
+pub enum DownlinkDUTCommand<'a> {
     /// Request to reset the Microcontroller Unit
     #[cmd(cid = 0x01, len = 0)]
     DutResetReq(DutResetReqPayload),
@@ -14,10 +16,41 @@ pub enum DownlinkDUTCommand {
     /// Request to reset the LoRaWAN MAC layer and start issuing Join-Request messages
     #[cmd(cid = 0x02, len = 0)]
     DutJoinReq(DutJoinReqPayload),
+
+    /// Change uplink periodicity to the provided value
+    #[cmd(cid = 0x06, len = 1)]
+    TxPeriodicityChangeReq(TxPeriodicityChangeReqPayload<'a>),
 }
 
 pub fn parse_downlink_certification_messages(
     data: &[u8],
-) -> MacCommandIterator<'_, DownlinkDUTCommand> {
+) -> MacCommandIterator<'_, DownlinkDUTCommand<'_>> {
     MacCommandIterator::new(data)
+}
+
+impl TxPeriodicityChangeReqPayload<'_> {
+    pub fn periodicity(&self) -> Result<Option<u16>, Error> {
+        let v = self.0[0];
+        if v > 10 {
+            Err(Error::RFU)
+        } else if v == 0 {
+            // DUT should switch back to default behaviour
+            Ok(None)
+        } else {
+            let seconds = match v {
+                1 => 5,
+                2 => 10,
+                3 => 20,
+                4 => 30,
+                5 => 40,
+                6 => 50,
+                7 => 60,
+                8 => 120,
+                9 => 240,
+                10 => 480,
+                0_u8 | 11_u8..=u8::MAX => unreachable!(),
+            };
+            Ok(Some(seconds))
+        }
+    }
 }

--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -23,6 +23,26 @@ pub enum Error {
     FRMPayloadWithFportZero,
 }
 
+/// Helper trait to provide dummy Creator implementation for
+/// variable length commands.
+#[allow(clippy::len_without_is_empty)]
+pub trait UnimplementedCreator {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        unimplemented!()
+    }
+
+    fn build(&self) -> &[u8] {
+        unimplemented!()
+    }
+
+    fn len(&self) -> usize {
+        unimplemented!()
+    }
+}
+
 const PIGGYBACK_MAC_COMMANDS_MAX_LEN: usize = 15;
 
 /// JoinAcceptCreator serves for creating binary representation of Physical

--- a/lorawan-encoding/src/lib.rs
+++ b/lorawan-encoding/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 
+pub mod certification;
 pub mod creator;
 pub mod keys;
 pub mod maccommandcreator;

--- a/lorawan-encoding/src/maccommands.rs
+++ b/lorawan-encoding/src/maccommands.rs
@@ -32,6 +32,7 @@ pub enum Error {
     BufferTooShort,
     InvalidIndex,
     InvalidDataRateRange,
+    RFU,
 }
 
 pub trait SerializableMacCommand {

--- a/lorawan-encoding/src/multicast/mod.rs
+++ b/lorawan-encoding/src/multicast/mod.rs
@@ -1,4 +1,5 @@
 mod group_setup;
+use crate::creator::UnimplementedCreator;
 use crate::maccommands::{Error, MacCommandIterator, SerializableMacCommand};
 pub use group_setup::Session;
 use lorawan_macros::CommandHandler;
@@ -73,6 +74,11 @@ impl<'a> McGroupStatusAnsPayload<'a> {
         Self::required_len(self.0[0])
     }
 }
+
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+pub struct McGroupStatusAnsCreator {}
+impl UnimplementedCreator for McGroupStatusAnsCreator {}
 
 pub fn parse_downlink_multicast_messages(
     data: &[u8],

--- a/lorawan-encoding/tests/certification.rs
+++ b/lorawan-encoding/tests/certification.rs
@@ -53,6 +53,20 @@ fn test_echopayload() {
     // Check that internal payload data actually matches
     let payload = EchoPayloadReqPayload::new(&data[1..]).unwrap();
     assert_eq!(&data[1..], payload.payload());
+
+    let mut cmd = EchoPayloadAnsCreator::new();
+    assert_eq!(cmd.build(), [EchoPayloadAnsPayload::cid()]);
+
+    // Push in data...
+    cmd.payload(&data[1..]);
+
+    // ...and check whether this has been properly mutated
+    let out = cmd.build();
+    assert_eq!(out.len(), 4);
+    assert_eq!(out[1..], [2, 6, 0]);
+
+    cmd.payload(&[]);
+    assert_eq!(cmd.build().len(), 1);
 }
 
 #[test]

--- a/lorawan-encoding/tests/certification.rs
+++ b/lorawan-encoding/tests/certification.rs
@@ -23,3 +23,16 @@ fn test_parse_variable_txframectrlreq() {
     // ..end there's nothing left
     assert_eq!(c.next(), None);
 }
+
+#[test]
+fn test_dutversionsans() {
+    let mut cmd = DutVersionsAnsCreator::new();
+    let cid = DutVersionsAnsPayload::cid();
+    cmd.set_versions_raw([
+        0, 0, 0, 1, // Firmware version
+        1, 0, 4, 0, // Lorawan version - 1.0.4
+        2, 1, 0, 4, // region version, RP002-1.0.4 == 2.1.0.4
+    ]);
+
+    assert_eq!(cmd.build(), [cid, 0, 0, 0, 1, 1, 0, 4, 0, 2, 1, 0, 4]);
+}

--- a/lorawan-encoding/tests/certification.rs
+++ b/lorawan-encoding/tests/certification.rs
@@ -1,0 +1,25 @@
+use lorawan::certification::parse_downlink_certification_messages;
+use lorawan::certification::DownlinkDUTCommand::*;
+use lorawan::certification::*;
+
+#[test]
+fn test_parse_empty_downlink() {
+    assert_eq!(parse_downlink_certification_messages(&[]).count(), 0);
+}
+
+#[test]
+fn test_parse_variable_txframectrlreq() {
+    assert_eq!(parse_downlink_certification_messages(&[0x07]).count(), 0);
+    assert_eq!(parse_downlink_certification_messages(&[0x07, 0x02]).count(), 1);
+    assert_eq!(parse_downlink_certification_messages(&[0x07, 0x02, 0x02, 0x04]).count(), 1);
+
+    let mut c = parse_downlink_certification_messages(&[0x07, 0x02, 0x03]);
+    assert_eq!(c.next(), Some(TxFramesCtrlReq(TxFramesCtrlReqPayload::new(&[2, 3]).unwrap())));
+
+    let data = [0x07, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+    let mut c = parse_downlink_certification_messages(&data);
+    // Make sure whole buffer is consumed as single payload...
+    assert_eq!(c.next(), Some(TxFramesCtrlReq(TxFramesCtrlReqPayload::new(&data[1..]).unwrap())));
+    // ..end there's nothing left
+    assert_eq!(c.next(), None);
+}

--- a/lorawan-encoding/tests/certification.rs
+++ b/lorawan-encoding/tests/certification.rs
@@ -36,3 +36,41 @@ fn test_dutversionsans() {
 
     assert_eq!(cmd.build(), [cid, 0, 0, 0, 1, 1, 0, 4, 0, 2, 1, 0, 4]);
 }
+
+#[test]
+fn test_echopayload() {
+    let data = [EchoPayloadReqPayload::cid(), 1, 5, 255];
+    let mut c = parse_downlink_certification_messages(&data);
+
+    let Some(cmd) = c.next() else { panic!() };
+    // Check that whole frame was consumed
+    assert_eq!(c.next(), None);
+
+    // Check that all data is present...
+    let payload = EchoPayloadReqPayload::new_from_raw(&data[1..]);
+    assert_eq!(cmd, EchoPayloadReq(payload));
+
+    // Check that internal payload data actually matches
+    let payload = EchoPayloadReqPayload::new(&data[1..]).unwrap();
+    assert_eq!(&data[1..], payload.payload());
+
+    // // Check that EchoPayloadAns data transformation works
+    // let mut cmd = EchoPayloadAnsCreator::new();
+    // assert_eq!(payload.payload().len(), 3);
+    // cmd.set_payload(&payload.payload());
+
+    // let cid = EchoPayloadAnsPayload::cid();
+    // assert_eq!(cmd.build(), [cid, 2, 6, 0]);
+}
+
+#[test]
+fn test_echopayloadreq() {
+    let data = [EchoPayloadReqPayload::cid(), 1];
+    let mut c = parse_downlink_certification_messages(&data);
+
+    if let Some(EchoPayloadReq(payload)) = c.next() {
+        assert_eq!(payload.payload(), [1]);
+    } else {
+        panic!()
+    }
+}

--- a/lorawan-encoding/tests/certification.rs
+++ b/lorawan-encoding/tests/certification.rs
@@ -53,14 +53,6 @@ fn test_echopayload() {
     // Check that internal payload data actually matches
     let payload = EchoPayloadReqPayload::new(&data[1..]).unwrap();
     assert_eq!(&data[1..], payload.payload());
-
-    // // Check that EchoPayloadAns data transformation works
-    // let mut cmd = EchoPayloadAnsCreator::new();
-    // assert_eq!(payload.payload().len(), 3);
-    // cmd.set_payload(&payload.payload());
-
-    // let cid = EchoPayloadAnsPayload::cid();
-    // assert_eq!(cmd.build(), [cid, 2, 6, 0]);
 }
 
 #[test]


### PR DESCRIPTION
This adds partial list of payloads of Certification protocol to lorawan-encoding.
These together with bunch of glue code added to our lorawan-device's mac + async_device layer is good enough to pass the Activation Pre-Test for class A and C devices (at least when testing with virtual-device).