### PR TITLE
encoding: Skip generating boilerplate for variable-length command creators

### DIFF
--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -23,6 +23,26 @@ pub enum Error {
     FRMPayloadWithFportZero,
 }
 
+/// Helper trait to provide dummy Creator implementation for
+/// variable length commands.
+#[allow(clippy::len_without_is_empty)]
+pub trait UnimplementedCreator {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        unimplemented!()
+    }
+
+    fn build(&self) -> &[u8] {
+        unimplemented!()
+    }
+
+    fn len(&self) -> usize {
+        unimplemented!()
+    }
+}
+
 const PIGGYBACK_MAC_COMMANDS_MAX_LEN: usize = 15;
 
 /// JoinAcceptCreator serves for creating binary representation of Physical

--- a/lorawan-encoding/src/multicast/mod.rs
+++ b/lorawan-encoding/src/multicast/mod.rs
@@ -1,4 +1,5 @@
 mod group_setup;
+use crate::creator::UnimplementedCreator;
 use crate::maccommands::{Error, MacCommandIterator, SerializableMacCommand};
 pub use group_setup::Session;
 use lorawan_macros::CommandHandler;
@@ -73,6 +74,11 @@ impl<'a> McGroupStatusAnsPayload<'a> {
         Self::required_len(self.0[0])
     }
 }
+
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+pub struct McGroupStatusAnsCreator {}
+impl UnimplementedCreator for McGroupStatusAnsCreator {}
 
 pub fn parse_downlink_multicast_messages(
     data: &[u8],


### PR DESCRIPTION
Macro-generated Creator implementation does not seem to be working properly with variable-length commands.

As a workaround, stop generating Creator boilerplate for these and provide a stubbed `UnimplementedCreator` trait as an interim solution.

This issue in current code only affects `McGroupStatusAns` from multicast protocol, but there are also bunch of commands in certification protocol which will be affected as well.

This PR will be a dependency for #334 as it already contains one variable-length payload (TxFramesCtrlReq), and there will be at least two more (Echo Frame Request Commands).