### PR TITLE
Initial mac <-> certification protocol integration

### DIFF
--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -65,6 +65,9 @@ defmt-03 = ["dep:defmt", "lorawan/defmt-03", "lora-modulation/defmt-03"]
 ## Enable support for Class C devices
 class-c = []
 
+## Enable certification protocol handler (`fport = 224`)
+certification = []
+
 ## Provide an `async_device::Timer` impl based on `embassy-time`.
 embassy-time = ["dep:embassy-time"]
 

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -565,6 +565,14 @@ where
                 radio_buffer.clear();
                 Ok(None)
             }
+            #[cfg(feature = "certification")]
+            mac::Response::UplinkPrepared => {
+                radio_buffer.clear();
+                let (tx_config, _fcnt_up) =
+                    mac.certification_setup_send::<C, G, N>(rng, radio_buffer)?;
+                radio.tx(tx_config, radio_buffer.as_ref_for_read()).await.map_err(Error::Radio)?;
+                Ok(Some(mac.rx2_complete()))
+            }
             #[cfg(feature = "multicast")]
             mac::Response::Multicast(response) => {
                 if let multicast::Response::GroupSetupTransmitRequest { group_id } = response {

--- a/lorawan-device/src/async_device/test/util.rs
+++ b/lorawan-device/src/async_device/test/util.rs
@@ -26,6 +26,8 @@ pub fn setup_with_session() -> (RadioChannel, TimerChannel, Device) {
         fcnt_down: 0,
         confirmed: false,
         uplink: Default::default(),
+        #[cfg(feature = "certification")]
+        override_confirmed: None,
     }))
 }
 

--- a/lorawan-device/src/async_device/test/util.rs
+++ b/lorawan-device/src/async_device/test/util.rs
@@ -27,6 +27,8 @@ pub fn setup_with_session() -> (RadioChannel, TimerChannel, Device) {
         confirmed: false,
         uplink: Default::default(),
         #[cfg(feature = "certification")]
+        override_adr: false,
+        #[cfg(feature = "certification")]
         override_confirmed: None,
     }))
 }

--- a/lorawan-device/src/mac/certification.rs
+++ b/lorawan-device/src/mac/certification.rs
@@ -1,0 +1,35 @@
+use lorawan::certification::parse_downlink_certification_messages;
+
+/// Certification protocol uses `fport = 224`
+pub(crate) const CERTIFICATION_PORT: u8 = 224;
+
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+pub(crate) enum Response {
+    NoUpdate,
+}
+
+pub(crate) struct Certification {}
+
+impl Certification {
+    pub(crate) fn handle_message(&mut self, data: &[u8]) -> Response {
+        use lorawan::certification::DownlinkDUTCommand::*;
+        let messages = parse_downlink_certification_messages(data);
+        for message in messages {
+            match message {
+                // TODO: Device layer
+                DutResetReq(..) | DutJoinReq(..) | DutVersionsReq(..) => {}
+                // TODO: MAC layer
+                AdrBitChangeReq(..)
+                | TxFramesCtrlReq(..)
+                | EchoPayloadReq(..)
+                | TxPeriodicityChangeReq(..) => {}
+            }
+        }
+        Response::NoUpdate
+    }
+
+    pub(crate) const fn fport(&self, fport: u8) -> bool {
+        CERTIFICATION_PORT == fport
+    }
+}

--- a/lorawan-device/src/mac/certification.rs
+++ b/lorawan-device/src/mac/certification.rs
@@ -9,6 +9,7 @@ pub(crate) enum Response {
     NoUpdate,
     AdrBitChange(bool),
     TxFramesCtrlReq(Option<bool>),
+    TxPeriodicityChange(Option<u16>),
 }
 
 pub(crate) struct Certification {}
@@ -19,11 +20,15 @@ impl Certification {
         let messages = parse_downlink_certification_messages(data);
         for message in messages {
             match message {
-                // TODO: Device layer
-                DutResetReq(..) | DutJoinReq(..) | TxPeriodicityChangeReq(..) => {}
+                // Device layer
+                DutResetReq(..) | DutJoinReq(..) => {}
+                TxPeriodicityChangeReq(payload) => {
+                    if let Ok(periodicity) = payload.periodicity() {
+                        return Response::TxPeriodicityChange(periodicity);
+                    }
+                }
                 // Uplink requests
                 EchoPayloadReq(..) | DutVersionsReq(..) => {}
-                // MAC layer
                 AdrBitChangeReq(payload) => {
                     if let Ok(adr) = payload.adr_enable() {
                         return Response::AdrBitChange(adr);

--- a/lorawan-device/src/mac/certification.rs
+++ b/lorawan-device/src/mac/certification.rs
@@ -7,6 +7,7 @@ pub(crate) const CERTIFICATION_PORT: u8 = 224;
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub(crate) enum Response {
     NoUpdate,
+    TxFramesCtrlReq(Option<bool>),
 }
 
 pub(crate) struct Certification {}
@@ -20,10 +21,12 @@ impl Certification {
                 // TODO: Device layer
                 DutResetReq(..) | DutJoinReq(..) | DutVersionsReq(..) => {}
                 // TODO: MAC layer
-                AdrBitChangeReq(..)
-                | TxFramesCtrlReq(..)
-                | EchoPayloadReq(..)
-                | TxPeriodicityChangeReq(..) => {}
+                AdrBitChangeReq(..) | EchoPayloadReq(..) | TxPeriodicityChangeReq(..) => {}
+                TxFramesCtrlReq(payload) => {
+                    if let Ok(frametype) = payload.frame_type_override() {
+                        return Response::TxFramesCtrlReq(frametype);
+                    }
+                }
             }
         }
         Response::NoUpdate

--- a/lorawan-device/src/mac/certification.rs
+++ b/lorawan-device/src/mac/certification.rs
@@ -8,6 +8,8 @@ pub(crate) const CERTIFICATION_PORT: u8 = 224;
 pub(crate) enum Response {
     NoUpdate,
     AdrBitChange(bool),
+    DutJoinReq,
+    DutResetReq,
     TxFramesCtrlReq(Option<bool>),
     TxPeriodicityChange(Option<u16>),
     UplinkPrepared,
@@ -27,7 +29,8 @@ impl Certification {
         for message in messages {
             match message {
                 // Device layer
-                DutResetReq(..) | DutJoinReq(..) => {}
+                DutJoinReq(..) => return Response::DutJoinReq,
+                DutResetReq(..) => return Response::DutResetReq,
                 TxPeriodicityChangeReq(payload) => {
                     if let Ok(periodicity) = payload.periodicity() {
                         return Response::TxPeriodicityChange(periodicity);

--- a/lorawan-device/src/mac/certification.rs
+++ b/lorawan-device/src/mac/certification.rs
@@ -34,7 +34,20 @@ impl Certification {
                     }
                 }
                 // Responses with uplink
-                DutVersionsReq(..) => {}
+                DutVersionsReq(..) => {
+                    let mut buf: heapless::Vec<u8, 256> = heapless::Vec::new();
+                    let mut ans = lorawan::certification::DutVersionsAnsCreator::new();
+                    ans.set_versions_raw([
+                        // TODO: Pass it via session::configuration?
+                        0, 0, 0, 1, 1, 0, 4, 0, // Lorawan version (1.0.4 \o/)
+                        // region version, RP002-1.0.4 == 2.1.0.4
+                        // TODO: define and import from crate::region::constants::REGION_VERSION?
+                        2, 1, 0, 4,
+                    ]);
+                    buf.extend_from_slice(ans.build()).unwrap();
+                    self.pending_uplink = Some(buf);
+                    return Response::UplinkPrepared;
+                }
                 EchoPayloadReq(payload) => {
                     let mut buf: heapless::Vec<u8, 256> = heapless::Vec::new();
                     let mut ans = lorawan::certification::EchoPayloadAnsCreator::new();

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -104,7 +104,7 @@ impl Mac {
                 join_accept_delay1: region::constants::JOIN_ACCEPT_DELAY1,
                 join_accept_delay2: region::constants::JOIN_ACCEPT_DELAY2,
             },
-            #[cfg(feature = "multicast")]
+            #[cfg(feature = "certification")]
             certification: certification::Certification {},
             #[cfg(feature = "multicast")]
             multicast: multicast::Multicast::new(),

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -105,7 +105,7 @@ impl Mac {
                 join_accept_delay2: region::constants::JOIN_ACCEPT_DELAY2,
             },
             #[cfg(feature = "certification")]
-            certification: certification::Certification {},
+            certification: certification::Certification::new(),
             #[cfg(feature = "multicast")]
             multicast: multicast::Multicast::new(),
         }

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -25,6 +25,8 @@ use crate::nb_device;
 
 pub(crate) mod uplink;
 
+#[cfg(feature = "certification")]
+pub(crate) mod certification;
 #[cfg(feature = "multicast")]
 pub(crate) mod multicast;
 
@@ -55,6 +57,8 @@ pub(crate) struct Mac {
     pub region: region::Configuration,
     board_eirp: BoardEirp,
     state: State,
+    #[cfg(feature = "certification")]
+    certification: certification::Certification,
     #[cfg(feature = "multicast")]
     pub multicast: multicast::Multicast,
 }
@@ -100,6 +104,8 @@ impl Mac {
                 join_accept_delay1: region::constants::JOIN_ACCEPT_DELAY1,
                 join_accept_delay2: region::constants::JOIN_ACCEPT_DELAY2,
             },
+            #[cfg(feature = "multicast")]
+            certification: certification::Certification {},
             #[cfg(feature = "multicast")]
             multicast: multicast::Multicast::new(),
         }
@@ -210,6 +216,8 @@ impl Mac {
             State::Joined(ref mut session) => session.handle_rx::<C, N, D>(
                 &mut self.region,
                 &mut self.configuration,
+                #[cfg(feature = "certification")]
+                &mut self.certification,
                 #[cfg(feature = "multicast")]
                 &mut self.multicast,
                 buf,
@@ -242,6 +250,8 @@ impl Mac {
             State::Joined(ref mut session) => Ok(session.handle_rx::<C, N, D>(
                 &mut self.region,
                 &mut self.configuration,
+                #[cfg(feature = "certification")]
+                &mut self.certification,
                 #[cfg(feature = "multicast")]
                 &mut self.multicast,
                 buf,

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -325,8 +325,17 @@ pub(crate) enum Response {
     JoinSuccess,
     NoUpdate,
     RxComplete,
+    #[cfg(feature = "certification")]
+    DeviceHandler(DeviceEvent),
     #[cfg(feature = "multicast")]
     Multicast(multicast::Response),
+}
+
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[derive(Debug)]
+#[cfg(feature = "certification")]
+pub(crate) enum DeviceEvent {
+    TxPeriodicityChange { periodicity: Option<u16> },
 }
 
 impl From<Response> for nb_device::Response {
@@ -339,6 +348,8 @@ impl From<Response> for nb_device::Response {
             Response::JoinSuccess => nb_device::Response::JoinSuccess,
             Response::NoUpdate => nb_device::Response::NoUpdate,
             Response::RxComplete => nb_device::Response::RxComplete,
+            #[cfg(feature = "certification")]
+            Response::DeviceHandler(_) => unimplemented!(),
             #[cfg(feature = "multicast")]
             Response::Multicast(_) => unimplemented!(),
         }

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -335,6 +335,8 @@ pub(crate) enum Response {
 #[derive(Debug)]
 #[cfg(feature = "certification")]
 pub(crate) enum DeviceEvent {
+    ResetDevice,
+    ResetMac,
     TxPeriodicityChange { periodicity: Option<u16> },
 }
 

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -13,6 +13,9 @@ use lorawan::{
     parser::{parse_with_factory as lorawan_parse, *},
 };
 
+#[cfg(feature = "certification")]
+use super::DeviceEvent;
+
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -25,7 +28,6 @@ pub struct Session {
     pub fcnt_up: u32,
     pub fcnt_down: u32,
     // TODO: ADR handling
-
     #[cfg(feature = "certification")]
     /// Whether to force ADR bit for subsequent frames
     pub override_adr: bool,
@@ -178,6 +180,11 @@ impl Session {
                                 }
                                 TxFramesCtrlReq(ftype) => {
                                     self.override_confirmed = ftype;
+                                }
+                                TxPeriodicityChange(periodicity) => {
+                                    return Response::DeviceHandler(
+                                        DeviceEvent::TxPeriodicityChange { periodicity },
+                                    )
                                 }
                                 NoUpdate => return Response::NoUpdate,
                             }

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -186,6 +186,7 @@ impl Session {
                                         DeviceEvent::TxPeriodicityChange { periodicity },
                                     )
                                 }
+                                UplinkPrepared => {}
                                 NoUpdate => return Response::NoUpdate,
                             }
                         }

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -192,7 +192,7 @@ impl Session {
                                         DeviceEvent::TxPeriodicityChange { periodicity },
                                     )
                                 }
-                                UplinkPrepared => {}
+                                UplinkPrepared => return Response::UplinkPrepared,
                                 NoUpdate => return Response::NoUpdate,
                             }
                         }

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -178,6 +178,12 @@ impl Session {
                                 AdrBitChange(adr) => {
                                     self.override_adr = adr;
                                 }
+                                DutJoinReq => {
+                                    return Response::DeviceHandler(DeviceEvent::ResetMac)
+                                }
+                                DutResetReq => {
+                                    return Response::DeviceHandler(DeviceEvent::ResetDevice)
+                                }
                                 TxFramesCtrlReq(ftype) => {
                                     self.override_confirmed = ftype;
                                 }


### PR DESCRIPTION
This is a self-contained patchset to implement part of the certification protocol which can be handled mostly in the mac layer and device layer without requiring extensive API changes.

There are still bunch of unknowns and WIP things in there though:
1. `DutVersionsAns` creation is somewhat WIP, but good enough for now. In future we can probably put the software version field (4 bytes) to devicehandler struct/trait and pass it through via `Mac::Session::Configuration`.
2. Instead of `mac::Response::Certification(..)` variant, I opted to use more generic `mac::Response::UplinkPrepared` which could hopefully be later used for `DevStatusAns` and `DeviceTimeReq` uplinks as well.

And finally, there are some other certification protocol parts not yet implemented, but I'm mostly stuck due to #335 
