### PR TITLE
reconfigure rx from mac_response after tx

### DIFF
--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -628,11 +628,9 @@ where
 
     /// When not involved in sending and RX1/RX2 windows, a class C configured device will be
     /// listening to RXC frames. The caller is expected to be awaiting this message at all times.
+    #[cfg(feature = "class-c")]
     pub async fn rxc_listen(&mut self) -> Result<ListenResponse, Error<R::PhyError>> {
-        #[cfg(feature = "class-c")]
-        let rx_config = Some(self.mac.get_rxc_config());
-        #[cfg(not(feature = "class-c"))]
-        let rx_config = None;
+        let rx_config = self.mac.get_rxc_config();
         loop {
             let (sz, _rx_quality) =
                 self.radio.rx_continuous(self.radio_buffer.as_mut()).await.map_err(Error::Radio)?;
@@ -645,7 +643,7 @@ where
                 &mut self.radio,
                 &mut self.rng,
                 mac_response,
-                rx_config,
+                Some(rx_config),
             )
             .await?
             {

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -12,7 +12,10 @@ use lorawan::{self, keys::CryptoFactory};
 use rand_core::RngCore;
 
 pub use crate::region::DR;
-use crate::{radio::RadioBuffer, rng};
+use crate::{
+    radio::{RadioBuffer, RxConfig},
+    rng,
+};
 
 pub mod radio;
 
@@ -478,6 +481,7 @@ where
                         &mut self.radio,
                         &mut self.rng,
                         mac_response,
+                        Some(rx_config),
                     )
                     .await?
                     {
@@ -553,12 +557,14 @@ where
     }
 
     /// Helper function to handle MAC responses and perform common actions
+    #[allow(unused_variables)]
     async fn handle_mac_response(
         radio_buffer: &mut RadioBuffer<N>,
         mac: &mut Mac,
         radio: &mut R,
         rng: &mut G,
         response: mac::Response,
+        rx_config: Option<RxConfig>,
     ) -> Result<Option<mac::Response>, Error<R::PhyError>> {
         radio_buffer.clear();
         match response {
@@ -579,6 +585,9 @@ where
                         .tx(tx_config, radio_buffer.as_ref_for_read())
                         .await
                         .map_err(Error::Radio)?;
+                    if let Some(rx_config) = rx_config {
+                        radio.setup_rx(rx_config).await.map_err(Error::Radio)?;
+                    }
                     // GroupSetupTransmitRequest needs to be transformed into a NewSession response
                     if let multicast::Response::GroupSetupTransmitRequest { group_id } = response {
                         response = multicast::Response::NewSession { group_id };
@@ -607,6 +616,7 @@ where
                         &mut self.radio,
                         &mut self.rng,
                         mac_response,
+                        None,
                     )
                     .await?
                 }
@@ -619,6 +629,10 @@ where
     /// When not involved in sending and RX1/RX2 windows, a class C configured device will be
     /// listening to RXC frames. The caller is expected to be awaiting this message at all times.
     pub async fn rxc_listen(&mut self) -> Result<ListenResponse, Error<R::PhyError>> {
+        #[cfg(feature = "class-c")]
+        let rx_config = Some(self.mac.get_rxc_config());
+        #[cfg(not(feature = "class-c"))]
+        let rx_config = None;
         loop {
             let (sz, _rx_quality) =
                 self.radio.rx_continuous(self.radio_buffer.as_mut()).await.map_err(Error::Radio)?;
@@ -631,6 +645,7 @@ where
                 &mut self.radio,
                 &mut self.rng,
                 mac_response,
+                rx_config,
             )
             .await?
             {

--- a/lorawan-device/src/mac/multicast.rs
+++ b/lorawan-device/src/mac/multicast.rs
@@ -198,7 +198,7 @@ impl Multicast {
         buf: &mut RadioBuffer<N>,
     ) -> mac::Result<mac::FcntUp> {
         let send_data = mac::SendData {
-            fport: REMOTE_MULTICAST_SETUP_PORT,
+            fport: self.remote_setup_port,
             data: self.pending_uplinks.as_ref(),
             confirmed: false,
         };


### PR DESCRIPTION
The PHY layer does not appreciate it when you transmit and then go to receive without "setup_rx" before it. The recent multicast additions automatically send uplink responses for certain messages and neglected to put the radio back into receive mode.

This also fixes a bug in the multicast code where the configurable multlicast message port was not used.