### PR TITLE
device: Refactor Class-C tests into their own module

### DIFF
--- a/lorawan-device/src/async_device/test/class_c.rs
+++ b/lorawan-device/src/async_device/test/class_c.rs
@@ -1,0 +1,100 @@
+use super::util;
+use crate::async_device::{ListenResponse, SendResponse};
+use crate::radio::RfConfig;
+use crate::test_util::{get_key, Uplink};
+use lorawan::creator::DataPayloadCreator;
+use lorawan::default_crypto::DefaultFactory;
+
+pub fn class_c_downlink<const FCNT_DOWN: u32>(
+    _uplink: Option<Uplink>,
+    _config: RfConfig,
+    rx_buffer: &mut [u8],
+) -> usize {
+    let mut phy = DataPayloadCreator::new(rx_buffer).unwrap();
+    phy.set_f_port(3);
+    phy.set_dev_addr(&[0; 4]);
+    phy.set_uplink(false);
+    phy.set_fcnt(FCNT_DOWN);
+
+    let finished =
+        phy.build(&[1, 2, 3], [], &get_key().into(), &get_key().into(), &DefaultFactory).unwrap();
+    finished.len()
+}
+#[tokio::test]
+async fn test_class_c_data_before_rx1() {
+    let (radio, timer, mut async_device) = util::setup_with_session_class_c().await;
+    // Run the device
+    let task = tokio::spawn(async move {
+        let response = async_device.send(&[1, 2, 3], 3, true).await;
+        (async_device, response)
+    });
+
+    // send first downlink before RX1
+    radio.handle_rxtx(class_c_downlink::<1>).await;
+    // Trigger beginning of RX1
+    timer.fire_most_recent().await;
+    // We expect FCntUp 1 up since the test util for Class C setup sends first frame
+    // We set FcntDown to 2, since ACK to setup (1) and Class C downlink above (2)
+    radio.handle_rxtx(util::handle_data_uplink_with_link_adr_req::<1, 2>).await;
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(_)) => (),
+        _ => {
+            panic!()
+        }
+    }
+    let _ = device.take_downlink().unwrap();
+    let _ = device.take_downlink().unwrap();
+}
+
+#[tokio::test]
+async fn test_class_c_data_before_rx2() {
+    let (radio, timer, mut async_device) = util::setup_with_session_class_c().await;
+    // Run the device
+    let task = tokio::spawn(async move {
+        let response = async_device.send(&[1, 2, 3], 3, true).await;
+        (async_device, response)
+    });
+
+    // send first downlink before RX1
+    // Trigger beginning of RX1
+    timer.fire_most_recent().await;
+    // Trigger end of RX1
+    radio.handle_timeout().await;
+
+    radio.handle_rxtx(class_c_downlink::<1>).await;
+    // Trigger beginning of RX2
+    timer.fire_most_recent().await;
+    // We expect FCntUp 1 up since the test util for Class C setup sends first frame
+    // We set FcntDown to 2, since ACK to setup (1) and Class C downlink above (2)
+    radio.handle_rxtx(util::handle_data_uplink_with_link_adr_req::<1, 2>).await;
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(_)) => (),
+        _ => {
+            panic!()
+        }
+    }
+    let _ = device.take_downlink().unwrap();
+    let _ = device.take_downlink().unwrap();
+}
+
+#[tokio::test]
+async fn test_class_c_async_down() {
+    let (radio, _timer, mut async_device) = util::setup_with_session_class_c().await;
+    // Run the device
+    let task = tokio::spawn(async move {
+        let response = async_device.rxc_listen().await;
+        (async_device, response)
+    });
+
+    radio.handle_rxtx(class_c_downlink::<1>).await;
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(ListenResponse::DownlinkReceived(_)) => (),
+        _ => {
+            panic!()
+        }
+    }
+    let _ = device.take_downlink().unwrap();
+}

--- a/lorawan-device/src/async_device/test/util.rs
+++ b/lorawan-device/src/async_device/test/util.rs
@@ -1,6 +1,11 @@
-use super::{get_dev_addr, get_key, radio::*, region, timer::*, Device};
+use crate::radio::RfConfig;
+use lorawan::creator::DataPayloadCreator;
+use lorawan::default_crypto::DefaultFactory;
+use lorawan::parser::{DataHeader, DataPayload, FCtrl, PhyPayload};
 
+use super::{get_dev_addr, get_key, radio::*, region, timer::*, Device};
 use crate::mac::Session;
+pub(crate) use crate::test_util::{handle_data_uplink_with_link_adr_req, Uplink};
 use crate::{AppSKey, NwkSKey};
 
 fn setup_internal(session_data: Option<Session>) -> (RadioChannel, TimerChannel, Device) {
@@ -33,6 +38,38 @@ pub fn setup_with_session() -> (RadioChannel, TimerChannel, Device) {
     }))
 }
 
+/// Handle an uplink and respond with two LinkAdrReq on Port 0
+pub fn handle_class_c_uplink_after_join(
+    uplink: Option<Uplink>,
+    _config: RfConfig,
+    rx_buffer: &mut [u8],
+) -> usize {
+    if let Some(mut uplink) = uplink {
+        if let PhyPayload::Data(DataPayload::Encrypted(data)) = uplink.get_payload() {
+            let fcnt = data.fhdr().fcnt() as u32;
+            assert!(data.validate_mic(&get_key().into(), fcnt));
+            let uplink =
+                data.decrypt(Some(&get_key().into()), Some(&get_key().into()), fcnt).unwrap();
+            assert_eq!(uplink.fhdr().fcnt(), 0);
+            let mut phy = DataPayloadCreator::new(rx_buffer).unwrap();
+            let mut fctrl = FCtrl::new(0, false);
+            fctrl.set_ack();
+            phy.set_confirmed(false);
+            phy.set_dev_addr(&[0; 4]);
+            phy.set_uplink(false);
+            phy.set_fctrl(&fctrl);
+            // set ack bit
+            let finished =
+                phy.build(&[], [], &get_key().into(), &get_key().into(), &DefaultFactory).unwrap();
+            finished.len()
+        } else {
+            panic!("Did not decode PhyPayload::Data!");
+        }
+    } else {
+        panic!("No uplink passed to handle_class_c_uplink_after_join");
+    }
+}
+
 #[cfg(feature = "class-c")]
 pub async fn setup_with_session_class_c() -> (RadioChannel, TimerChannel, Device) {
     let (radio, timer, mut async_device) = setup_with_session();
@@ -44,7 +81,7 @@ pub async fn setup_with_session_class_c() -> (RadioChannel, TimerChannel, Device
     });
     // timeout the first sends RX windows which enables class C
     timer.fire_most_recent().await;
-    radio.handle_rxtx(crate::test_util::handle_class_c_uplink_after_join).await;
+    radio.handle_rxtx(handle_class_c_uplink_after_join).await;
 
     let (device, response) = task.await.unwrap();
 


### PR DESCRIPTION
There were too many `#[cfg(features = "class-c")]`. While at it, convert the FRMPayload test to regular Class A.