### PR TITLE
device: Preliminary stubs for DeviceStatusReq and RXParamSetupReq MAC commands

### DIFF
--- a/lorawan-device/src/async_device/test/maccommands.rs
+++ b/lorawan-device/src/async_device/test/maccommands.rs
@@ -1,0 +1,74 @@
+use super::util;
+use crate::async_device::SendResponse;
+use crate::radio::RfConfig;
+use crate::test_util::{get_key, Uplink};
+
+use lorawan::default_crypto::DefaultFactory;
+use lorawan::maccommands::parse_uplink_mac_commands;
+
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[tokio::test]
+// TODO: Finalize RXParamSetupReq
+#[ignore]
+async fn maccommands_in_frmpayload() {
+    fn frmpayload_maccommands(
+        _uplink: Option<Uplink>,
+        _config: RfConfig,
+        rx_buffer: &mut [u8],
+    ) -> usize {
+        // FRMPayload contains:
+        // - DevStatusReq(..)
+        // - RXParamSetupReq(RXParamSetupReqPayload([2, 210, 173, 132]))
+        // - RXTimingSetupReq(RXTimingSetupReqPayload([1]))
+        // - LinkADRReq(LinkADRReqPayload([80, 0, 0, 97]))
+        let mut phy = lorawan::creator::DataPayloadCreator::new(rx_buffer).unwrap();
+        phy.set_confirmed(false);
+        phy.set_f_port(0);
+        phy.set_dev_addr(&[0; 4]);
+        phy.set_uplink(false);
+        phy.set_fcnt(5);
+        phy.set_fctrl(&lorawan::parser::FCtrl::new(0x00, true));
+        let finished = phy
+            .build(
+                &[],
+                [6, 5, 2, 0xd2, 0xad, 0x84, 8, 1, 3, 0x50, 0, 0, 0x61],
+                &get_key().into(),
+                &get_key().into(),
+                &DefaultFactory,
+            )
+            .unwrap();
+        finished.len()
+    }
+
+    let (radio, timer, mut async_device) = util::setup_with_session();
+    let send_await_complete = Arc::new(Mutex::new(false));
+
+    let complete = send_await_complete.clone();
+    let task = tokio::spawn(async move {
+        let response = async_device.send(&[1, 2, 3], 3, false).await;
+        let mut complete = complete.lock().await;
+        *complete = true;
+        (async_device, response)
+    });
+
+    // Handle reception in RX1
+    timer.fire_most_recent().await;
+
+    radio.handle_rxtx(frmpayload_maccommands).await;
+
+    let (device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(5)) => {}
+        _ => panic!(),
+    }
+
+    if let Some(session) = device.mac.get_session() {
+        let data = session.uplink.mac_commands();
+        let cmds = parse_uplink_mac_commands(data);
+        assert_eq!(cmds.count(), 4);
+    } else {
+        panic!("Session not joined?");
+    }
+}

--- a/lorawan-device/src/async_device/test/maccommands.rs
+++ b/lorawan-device/src/async_device/test/maccommands.rs
@@ -11,7 +11,6 @@ use tokio::sync::Mutex;
 
 #[tokio::test]
 // TODO: Finalize RXParamSetupReq
-#[ignore]
 async fn maccommands_in_frmpayload() {
     fn frmpayload_maccommands(
         _uplink: Option<Uplink>,
@@ -66,8 +65,8 @@ async fn maccommands_in_frmpayload() {
 
     if let Some(session) = device.mac.get_session() {
         let data = session.uplink.mac_commands();
-        let cmds = parse_uplink_mac_commands(data);
-        assert_eq!(cmds.count(), 4);
+        assert_eq!(parse_uplink_mac_commands(data).count(), 4);
+        assert_eq!(device.mac.configuration.rx2_frequency, Some(869525000));
     } else {
         panic!("Session not joined?");
     }

--- a/lorawan-device/src/async_device/test/mod.rs
+++ b/lorawan-device/src/async_device/test/mod.rs
@@ -17,6 +17,8 @@ use radio::TestRadio;
 mod util;
 pub(crate) use util::{setup, setup_with_session};
 
+mod maccommands;
+
 #[cfg(feature = "class-c")]
 mod class_c;
 

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -310,19 +310,19 @@ impl Session {
                     cmd.set_channel_mask_ack(true).set_data_rate_ack(true).set_tx_power_ack(true);
                     self.uplink.add_mac_command(cmd);
                 }
-                RXParamSetupReq(_payload) => {
-                    // TODO: Implement overrides via self.configuration:
+                RXParamSetupReq(payload) => {
+                    // TODO: Verify with region!
+                    configuration.rx2_frequency = Some(payload.frequency().value());
+                    // TODO: Figure these out...
                     // let dl = payload.dl_settings();
                     // - rx1_dr_offset: dl.rx1_dr_offset()
-                    // - rx2_data_rate: dl.rx2_data_rate()
-                    // - rx2_frequency: payload.frequency();
-                    /*
+                    // - rx2_data_rate = dl.rx2_data_rate());
                     let mut cmd = RXParamSetupAnsCreator::new();
-                    cmd.set_rx1_data_rate_offset_ack(true)
-                        .set_rx2_data_rate_ack(true)
+                    cmd
+                        //.set_rx1_data_rate_offset_ack(true)
+                        //.set_rx2_data_rate_ack(true);
                         .set_channel_ack(true);
                     self.uplink.add_mac_command(cmd);
-                    */
                 }
                 RXTimingSetupReq(payload) => {
                     configuration.rx1_delay = super::del_to_delay_ms(payload.delay());


### PR DESCRIPTION
DeviceStatusReq is currently "dummy" implementation:
* Battery value requires eventually integrating with user-defined device struct to provide proper functionality to report battery status.
* SNR value reported is also dummy and left as TODO (we need to bubble SNR value from rx to session).

RXParamSetupReq:
* RX2 frequency is implemented, though we still need to implement checks against region-supported values.
* Everything else in this request payload (RX1 datarate offset and RX2 data rate) seems to be missing some functionality in region and encoding code