### PR TITLE
certification: Use correct EchoIncReq/EchoIncAns command names

### DIFF
--- a/lorawan-device/src/mac/certification.rs
+++ b/lorawan-device/src/mac/certification.rs
@@ -54,9 +54,9 @@ impl Certification {
                     self.pending_uplink = Some(buf);
                     return Response::UplinkPrepared;
                 }
-                EchoPayloadReq(payload) => {
+                EchoIncPayloadReq(payload) => {
                     let mut buf: heapless::Vec<u8, 256> = heapless::Vec::new();
-                    let mut ans = lorawan::certification::EchoPayloadAnsCreator::new();
+                    let mut ans = lorawan::certification::EchoIncPayloadAnsCreator::new();
                     ans.payload(payload.payload());
                     buf.extend_from_slice(ans.build()).unwrap();
                     self.pending_uplink = Some(buf);

--- a/lorawan-encoding/src/certification.rs
+++ b/lorawan-encoding/src/certification.rs
@@ -33,7 +33,7 @@ pub enum DownlinkDUTCommand<'a> {
 
     /// Requests the DUT to echo the provided payload, where each byte is incremented by 1
     #[cmd(cid = 0x08)]
-    EchoPayloadReq(EchoPayloadReqPayload<'a>),
+    EchoIncPayloadReq(EchoIncPayloadReqPayload<'a>),
 
     /// Request to send firmware version, LoRaWAN version, and regional parameters version
     #[cmd(cid = 0x7f, len = 0)]
@@ -43,9 +43,9 @@ pub enum DownlinkDUTCommand<'a> {
 #[derive(Debug, PartialEq, CommandHandler)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum UplinkDUTCommand<'a> {
-    /// Returns data sent by EchoPayloadReq, where each byte except the initial CID is incremented by 1
+    /// Returns data sent by EchoIncPayloadReq, where each byte except the initial CID is incremented by 1
     #[cmd(cid = 0x08)]
-    EchoPayloadAns(EchoPayloadAnsPayload<'a>),
+    EchoIncPayloadAns(EchoIncPayloadAnsPayload<'a>),
 
     #[cmd(cid = 0x7f, len = 12)]
     DutVersionsAns(DutVersionsAnsPayload<'a>),
@@ -75,12 +75,12 @@ impl DutVersionsAnsCreator {
     }
 }
 
-impl<'a> EchoPayloadAnsPayload<'a> {
+impl<'a> EchoIncPayloadAnsPayload<'a> {
     pub fn new(data: &'a [u8]) -> Result<Self, Error> {
         if data.is_empty() {
             return Err(Error::BufferTooShort);
         }
-        Ok(EchoPayloadAnsPayload(data))
+        Ok(EchoIncPayloadAnsPayload(data))
     }
 
     /// Possible maximum length of the payload not including CID
@@ -107,28 +107,28 @@ impl<'a> EchoPayloadAnsPayload<'a> {
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
-pub struct EchoPayloadAnsCreator {
-    pub(crate) data: [u8; EchoPayloadAnsPayload::max_len() + 1],
+pub struct EchoIncPayloadAnsCreator {
+    pub(crate) data: [u8; EchoIncPayloadAnsPayload::max_len() + 1],
     payload_len: usize,
 }
 
-impl Default for EchoPayloadAnsCreator {
+impl Default for EchoIncPayloadAnsCreator {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl EchoPayloadAnsCreator {
+impl EchoIncPayloadAnsCreator {
     pub fn new() -> Self {
-        let mut data = [0; EchoPayloadAnsPayload::max_len() + 1];
-        data[0] = EchoPayloadAnsPayload::cid();
+        let mut data = [0; EchoIncPayloadAnsPayload::max_len() + 1];
+        data[0] = EchoIncPayloadAnsPayload::cid();
         Self { data, payload_len: 0 }
     }
     pub fn build(&self) -> &[u8] {
         &self.data[..=self.payload_len]
     }
     pub const fn cid(&self) -> u8 {
-        EchoPayloadAnsPayload::cid()
+        EchoIncPayloadAnsPayload::cid()
     }
     /// Get the length including CID.
     #[allow(clippy::len_without_is_empty)]
@@ -148,15 +148,15 @@ impl EchoPayloadAnsCreator {
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
-pub struct EchoPayloadReqCreator {}
-impl UnimplementedCreator for EchoPayloadReqCreator {}
+pub struct EchoIncPayloadReqCreator {}
+impl UnimplementedCreator for EchoIncPayloadReqCreator {}
 
-impl<'a> EchoPayloadReqPayload<'a> {
+impl<'a> EchoIncPayloadReqPayload<'a> {
     pub fn new(data: &'a [u8]) -> Result<Self, Error> {
         if data.is_empty() {
             return Err(Error::BufferTooShort);
         }
-        Ok(EchoPayloadReqPayload(data))
+        Ok(EchoIncPayloadReqPayload(data))
     }
 
     /// Minimum length of the payload not including CID

--- a/lorawan-encoding/tests/certification.rs
+++ b/lorawan-encoding/tests/certification.rs
@@ -39,7 +39,7 @@ fn test_dutversionsans() {
 
 #[test]
 fn test_echopayload() {
-    let data = [EchoPayloadReqPayload::cid(), 1, 5, 255];
+    let data = [EchoIncPayloadReqPayload::cid(), 1, 5, 255];
     let mut c = parse_downlink_certification_messages(&data);
 
     let Some(cmd) = c.next() else { panic!() };
@@ -47,15 +47,15 @@ fn test_echopayload() {
     assert_eq!(c.next(), None);
 
     // Check that all data is present...
-    let payload = EchoPayloadReqPayload::new_from_raw(&data[1..]);
-    assert_eq!(cmd, EchoPayloadReq(payload));
+    let payload = EchoIncPayloadReqPayload::new_from_raw(&data[1..]);
+    assert_eq!(cmd, EchoIncPayloadReq(payload));
 
     // Check that internal payload data actually matches
-    let payload = EchoPayloadReqPayload::new(&data[1..]).unwrap();
+    let payload = EchoIncPayloadReqPayload::new(&data[1..]).unwrap();
     assert_eq!(&data[1..], payload.payload());
 
-    let mut cmd = EchoPayloadAnsCreator::new();
-    assert_eq!(cmd.build(), [EchoPayloadAnsPayload::cid()]);
+    let mut cmd = EchoIncPayloadAnsCreator::new();
+    assert_eq!(cmd.build(), [EchoIncPayloadAnsPayload::cid()]);
 
     // Push in data...
     cmd.payload(&data[1..]);
@@ -71,10 +71,10 @@ fn test_echopayload() {
 
 #[test]
 fn test_echopayloadreq() {
-    let data = [EchoPayloadReqPayload::cid(), 1];
+    let data = [EchoIncPayloadReqPayload::cid(), 1];
     let mut c = parse_downlink_certification_messages(&data);
 
-    if let Some(EchoPayloadReq(payload)) = c.next() {
+    if let Some(EchoIncPayloadReq(payload)) = c.next() {
         assert_eq!(payload.payload(), [1]);
     } else {
         panic!()


### PR DESCRIPTION
Table in LoRaWAN Certification protocol used as source for implementing these commands was missing "Inc" in the names.