### PR TITLE
device: Implement LinkADRReq Datarate setting support

### DIFF
--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -84,6 +84,13 @@ impl<
     pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
         R::get_max_payload_length(datarate, repeater_compatible, dwell_time)
     }
+
+    pub fn check_data_rate(&self, datarate: u8) -> Option<DR> {
+        if (datarate as usize) < NUM_DATARATES && R::datarates()[datarate as usize].is_some() {
+            return Some(DR::try_from(datarate).unwrap());
+        }
+        None
+    }
 }
 
 pub(crate) trait DynamicChannelRegion<const NUM_JOIN_CHANNELS: usize, const NUM_DATARATES: usize>:

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -67,6 +67,13 @@ impl<const D: usize, F: FixedChannelRegion<D>> FixedChannelPlan<D, F> {
     pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
         F::get_max_payload_length(datarate, repeater_compatible, dwell_time)
     }
+
+    pub fn check_data_rate(&self, datarate: u8) -> Option<DR> {
+        if (datarate as usize) < D && F::datarates()[datarate as usize].is_some() {
+            return Some(DR::try_from(datarate).unwrap());
+        }
+        None
+    }
 }
 
 pub(crate) trait FixedChannelRegion<const D: usize>: ChannelRegion<D> {

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -100,6 +100,34 @@ seq_macro::seq!(
         }
     }
 );
+
+impl TryFrom<u8> for DR {
+    type Error = core::convert::Infallible;
+
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        let dr = match v & 0xf {
+            0 => DR::_0,
+            1 => DR::_1,
+            2 => DR::_2,
+            3 => DR::_3,
+            4 => DR::_4,
+            5 => DR::_5,
+            6 => DR::_6,
+            7 => DR::_7,
+            8 => DR::_8,
+            9 => DR::_9,
+            10 => DR::_10,
+            11 => DR::_11,
+            12 => DR::_12,
+            13 => DR::_13,
+            14 => DR::_14,
+            15 => DR::_15,
+            _ => unreachable!(),
+        };
+        Ok(dr)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Regions supported by this crate: AS923_1, AS923_2, AS923_3, AS923_4, AU915, EU868, EU433, IN865, US915.
@@ -390,6 +418,10 @@ impl Configuration {
                 ),
             },
         }
+    }
+
+    pub(crate) fn check_data_rate(&self, data_rate: u8) -> Option<DR> {
+        region_dispatch!(self, check_data_rate, data_rate)
     }
 
     fn get_tx_dr_and_frequency<RNG: RngCore>(

--- a/lorawan-encoding/src/multicast/group_status.rs
+++ b/lorawan-encoding/src/multicast/group_status.rs
@@ -57,7 +57,7 @@ impl<'a> McGroupStatusAnsPayload<'a> {
 
     /// NbTotalGroups is the number of multicast groups currently defined in the end-device.
     pub fn nb_total_groups(&self) -> u8 {
-        self.0[0] >> 4 & 0b111
+        (self.0[0] >> 4) & 0b111
     }
 
     /// Maximum possible length of the payload

--- a/lorawan-encoding/src/types.rs
+++ b/lorawan-encoding/src/types.rs
@@ -203,7 +203,7 @@ impl DLSettings {
     /// The offset between the uplink data rate and the downlink data rate used to communicate with
     /// the end-device on the first reception slot (RX1).
     pub fn rx1_dr_offset(&self) -> u8 {
-        self.0 >> 4 & 0x07
+        (self.0 >> 4) & 0x07
     }
 
     /// The data rate of a downlink using the second receive window.


### PR DESCRIPTION
This adds another missing piece towards fully supporting LinkADRReq MAC command.
Datarate setting is dependency to run RXParamSetupReq tests.

Tested with EU868 and US915 regions against LCTT.