### PR TITLE
Drop datarates generic and use a table with 15 rates for all regions

### DIFF
--- a/lorawan-device/README.md
+++ b/lorawan-device/README.md
@@ -16,8 +16,9 @@ Both stacks share a dependency on the internal module, `mac` where LoRaWAN 1.0.x
 - Class C device behavior (async only, enabled by default with the `class-c` feature)
 - Over-the-Air Activation (OTAA) and Activation by Personalization (ABP)
 - CFList is supported for fixed and dynamic channel plans
-- Regional support for AS923_1, AS923_2, AS923_3, AS923_4, AU915, EU868, EU433, IN865, US915 (note: regional power 
-limits are not enforced ([#168](https://github.com/lora-rs/lora-rs/issues/168))
+- Regional support for AS923_1, AS923_2, AS923_3, AS923_4, AU915, EU868, EU433, IN865, US915 with following caveats:
+  * Regional power limits are not enforced ([#168](https://github.com/lora-rs/lora-rs/issues/168))
+  * FSK and LR-FHSS modulations are not supported
 
 **Currently, MAC commands are minimally mocked. For example, an ADRReq is responded with an ADRResp, but not much
 is actually done with the payload**.

--- a/lorawan-device/src/region/constants.rs
+++ b/lorawan-device/src/region/constants.rs
@@ -11,7 +11,7 @@ pub(crate) const ADR_ACK_DELAY: usize = 32;
 pub(crate) const ACK_TIMEOUT: usize = 2; // random delay between 1 and 3 seconds
 
 // Although there are 16 possible slots, last one is not defined as Datarate
-pub(crate) const NUM_DATARATES: usize = 15;
+pub(crate) const NUM_DATARATES: u8 = 15;
 
 pub(crate) const DEFAULT_BANDWIDTH: Bandwidth = Bandwidth::_125KHz;
 pub(crate) const DEFAULT_SPREADING_FACTOR: SpreadingFactor = SpreadingFactor::_7;

--- a/lorawan-device/src/region/constants.rs
+++ b/lorawan-device/src/region/constants.rs
@@ -10,8 +10,8 @@ pub(crate) const ADR_ACK_LIMIT: usize = 64;
 pub(crate) const ADR_ACK_DELAY: usize = 32;
 pub(crate) const ACK_TIMEOUT: usize = 2; // random delay between 1 and 3 seconds
 
-// TODO: Switch to 15? DR15 is command to use currently active DR
-pub(crate) const NUM_DATARATES: usize = 16;
+// Although there are 16 possible slots, last one is not defined as Datarate
+pub(crate) const NUM_DATARATES: usize = 15;
 
 pub(crate) const DEFAULT_BANDWIDTH: Bandwidth = Bandwidth::_125KHz;
 pub(crate) const DEFAULT_SPREADING_FACTOR: SpreadingFactor = SpreadingFactor::_7;

--- a/lorawan-device/src/region/constants.rs
+++ b/lorawan-device/src/region/constants.rs
@@ -10,6 +10,9 @@ pub(crate) const ADR_ACK_LIMIT: usize = 64;
 pub(crate) const ADR_ACK_DELAY: usize = 32;
 pub(crate) const ACK_TIMEOUT: usize = 2; // random delay between 1 and 3 seconds
 
+// TODO: Switch to 15? DR15 is command to use currently active DR
+pub(crate) const NUM_DATARATES: usize = 16;
+
 pub(crate) const DEFAULT_BANDWIDTH: Bandwidth = Bandwidth::_125KHz;
 pub(crate) const DEFAULT_SPREADING_FACTOR: SpreadingFactor = SpreadingFactor::_7;
 pub(crate) const DEFAULT_CODING_RATE: CodingRate = CodingRate::_4_5;

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -2,24 +2,22 @@ use super::*;
 
 const JOIN_CHANNELS: [u32; 2] = [923200000, 923200000];
 
-pub(crate) type AS923_1 = DynamicChannelPlan<2, 7, AS923Region<923_200_000, 0>>;
-pub(crate) type AS923_2 = DynamicChannelPlan<2, 7, AS923Region<921_400_000, 1800000>>;
-pub(crate) type AS923_3 = DynamicChannelPlan<2, 7, AS923Region<916_600_000, 6600000>>;
-pub(crate) type AS923_4 = DynamicChannelPlan<2, 7, AS923Region<917_300_000, 5900000>>;
+pub(crate) type AS923_1 = DynamicChannelPlan<2, AS923Region<923_200_000, 0>>;
+pub(crate) type AS923_2 = DynamicChannelPlan<2, AS923Region<921_400_000, 1800000>>;
+pub(crate) type AS923_3 = DynamicChannelPlan<2, AS923Region<916_600_000, 6600000>>;
+pub(crate) type AS923_4 = DynamicChannelPlan<2, AS923Region<917_300_000, 5900000>>;
 
 #[derive(Default, Clone)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct AS923Region<const DEFAULT_RX2: u32, const O: u32>;
 
-impl<const DEFAULT_RX2: u32, const OFFSET: u32> ChannelRegion<7>
-    for AS923Region<DEFAULT_RX2, OFFSET>
-{
-    fn datarates() -> &'static [Option<Datarate>; 7] {
+impl<const DEFAULT_RX2: u32, const OFFSET: u32> ChannelRegion for AS923Region<DEFAULT_RX2, OFFSET> {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
         &DATARATES
     }
 }
 
-impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2, 7>
+impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2>
     for AS923Region<DEFAULT_RX2, OFFSET>
 {
     fn join_channels() -> [u32; 2] {
@@ -33,7 +31,7 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2, 7>
 
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
-pub(crate) const DATARATES: [Option<Datarate>; 7] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,
         bandwidth: Bandwidth::_125KHz,
@@ -77,4 +75,13 @@ pub(crate) const DATARATES: [Option<Datarate>; 7] = [
         max_mac_payload_size_with_dwell_time: 250,
     }),
     // TODO: ignore FSK data rate for now
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
 ];

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -1,3 +1,10 @@
+/// AS923 region support (915..928 MHz)
+///
+/// AS923 end-devices SHALL support one of the two following data rate options:
+/// 1. DR0 to DR5 (minimum set supported for certification)
+/// 2. DR0 to DR7
+///
+/// Current status: DR0..DR6 is supported
 use super::*;
 
 const JOIN_CHANNELS: [u32; 2] = [923200000, 923200000];
@@ -32,51 +39,58 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2>
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
+    // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 0,
     }),
+    // DR1
     Some(Datarate {
         spreading_factor: SpreadingFactor::_11,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 0,
     }),
+    // DR2
     Some(Datarate {
         spreading_factor: SpreadingFactor::_10,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 123,
         max_mac_payload_size_with_dwell_time: 19,
     }),
+    // DR3
     Some(Datarate {
         spreading_factor: SpreadingFactor::_9,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 123,
         max_mac_payload_size_with_dwell_time: 61,
     }),
+    // DR4
     Some(Datarate {
         spreading_factor: SpreadingFactor::_8,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 133,
     }),
+    // DR5
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR6
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_250KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
-    // TODO: ignore FSK data rate for now
+    // TODO: DR7: FSK: 50 kbps
     None,
-    None,
+    // DR8..DR14: RFU
     None,
     None,
     None,

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -19,7 +19,7 @@ pub(crate) type AS923_4 = DynamicChannelPlan<2, AS923Region<917_300_000, 5900000
 pub struct AS923Region<const DEFAULT_RX2: u32, const O: u32>;
 
 impl<const DEFAULT_RX2: u32, const OFFSET: u32> ChannelRegion for AS923Region<DEFAULT_RX2, OFFSET> {
-    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES
     }
 }
@@ -38,7 +38,7 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2>
 
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
-pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES as usize] = [
     // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -3,19 +3,19 @@ use super::*;
 
 const JOIN_CHANNELS: [u32; 3] = [433_175_000, 433_375_000, 433_575_000];
 
-pub(crate) type EU433 = DynamicChannelPlan<3, 7, EU433Region>;
+pub(crate) type EU433 = DynamicChannelPlan<3, EU433Region>;
 
 #[derive(Default, Clone)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct EU433Region;
 
-impl ChannelRegion<7> for EU433Region {
-    fn datarates() -> &'static [Option<Datarate>; 7] {
+impl ChannelRegion for EU433Region {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
         &DATARATES
     }
 }
 
-impl DynamicChannelRegion<3, 7> for EU433Region {
+impl DynamicChannelRegion<3> for EU433Region {
     fn join_channels() -> [u32; 3] {
         JOIN_CHANNELS
     }
@@ -27,7 +27,7 @@ impl DynamicChannelRegion<3, 7> for EU433Region {
 
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
-pub(crate) const DATARATES: [Option<Datarate>; 7] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,
         bandwidth: Bandwidth::_125KHz,
@@ -71,4 +71,13 @@ pub(crate) const DATARATES: [Option<Datarate>; 7] = [
         max_mac_payload_size_with_dwell_time: 250,
     }),
     // TODO 7 is defined in rp002-1-0-4
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
 ];

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -1,4 +1,10 @@
-#![allow(dead_code)]
+/// EU433 region support (MHz)
+///
+/// EU433 end-devices SHALL support one of the two following data rate options:
+/// 1. DR0 to DR5 (minimum set supported for certification)
+/// 2. DR0 to DR7
+///
+/// Current status: DR7 (FSK) is unimplemented
 use super::*;
 
 const JOIN_CHANNELS: [u32; 3] = [433_175_000, 433_375_000, 433_575_000];
@@ -28,51 +34,58 @@ impl DynamicChannelRegion<3> for EU433Region {
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
+    // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 0,
     }),
+    // DR1
     Some(Datarate {
         spreading_factor: SpreadingFactor::_11,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 0,
     }),
+    // DR2
     Some(Datarate {
         spreading_factor: SpreadingFactor::_10,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 123,
         max_mac_payload_size_with_dwell_time: 19,
     }),
+    // DR3
     Some(Datarate {
         spreading_factor: SpreadingFactor::_9,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 123,
         max_mac_payload_size_with_dwell_time: 61,
     }),
+    // DR4
     Some(Datarate {
         spreading_factor: SpreadingFactor::_8,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 133,
     }),
+    // DR5
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR6
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_250KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
-    // TODO 7 is defined in rp002-1-0-4
+    // TODO: DR7: FSK: 50 kbps
     None,
-    None,
+    // DR8..DR14: RFU
     None,
     None,
     None,

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -16,7 +16,7 @@ pub(crate) type EU433 = DynamicChannelPlan<3, EU433Region>;
 pub struct EU433Region;
 
 impl ChannelRegion for EU433Region {
-    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES
     }
 }
@@ -33,7 +33,7 @@ impl DynamicChannelRegion<3> for EU433Region {
 
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
-pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES as usize] = [
     // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -1,21 +1,30 @@
-#![allow(dead_code)]
+/// EU688 region support (863..870 MHz)
+///
+/// EU863-870 end-devices SHALL support one of the three following data rate options:
+/// 1. DR0 to DR5 (minimum set supported for certification)
+/// 2. DR0 to DR7
+/// 3. DR0 to DR11 (all data rates implemented)
+///
+/// Currently, support for only DR0..D6 is implemented
 use super::*;
 
 const JOIN_CHANNELS: [u32; 3] = [868_100_000, 868_300_000, 868_500_000];
 
-pub(crate) type EU868 = DynamicChannelPlan<3, 7, EU868Region>;
+const NUM_DR: usize = 7;
+
+pub(crate) type EU868 = DynamicChannelPlan<3, NUM_DR, EU868Region>;
 
 #[derive(Default, Clone)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct EU868Region;
 
-impl ChannelRegion<7> for EU868Region {
-    fn datarates() -> &'static [Option<Datarate>; 7] {
+impl ChannelRegion<NUM_DR> for EU868Region {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DR] {
         &DATARATES
     }
 }
 
-impl DynamicChannelRegion<3, 7> for EU868Region {
+impl DynamicChannelRegion<3, NUM_DR> for EU868Region {
     fn join_channels() -> [u32; 3] {
         JOIN_CHANNELS
     }
@@ -27,48 +36,65 @@ impl DynamicChannelRegion<3, 7> for EU868Region {
 
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
-pub(crate) const DATARATES: [Option<Datarate>; 7] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DR] = [
+    // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 59,
     }),
+    // DR1
     Some(Datarate {
         spreading_factor: SpreadingFactor::_11,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 59,
     }),
+    // DR2
     Some(Datarate {
         spreading_factor: SpreadingFactor::_10,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 59,
     }),
+    // DR3
     Some(Datarate {
         spreading_factor: SpreadingFactor::_9,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 123,
         max_mac_payload_size_with_dwell_time: 123,
     }),
+    // DR4
     Some(Datarate {
         spreading_factor: SpreadingFactor::_8,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR5
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR6
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_250KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
-    // TODO: ignore FSK data rate for now
+    /* Notes: FSK and LR-FHSS rates
+     * -  7: FSK: 50 kbps
+     * -  8: LR-FHSS CR1/3: 137 kHz BW
+     * -  9: LR-FHSS CR2/3: 137 kHz BW
+     * - 10: LR-FHSS CR1/3: 336 kHz BW
+     * - 11: LR-FHSS CR2/3: 336 kHz BW
+     * - 12..14: RFU
+     * - 15: The value of 0xF (decimal 15) of either DataRate or TXPower means
+     *       that the end-device SHALL ignore that field and keep the current
+     *       parameter values.
+     */
 ];

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -10,21 +10,19 @@ use super::*;
 
 const JOIN_CHANNELS: [u32; 3] = [868_100_000, 868_300_000, 868_500_000];
 
-const NUM_DR: usize = 7;
-
-pub(crate) type EU868 = DynamicChannelPlan<3, NUM_DR, EU868Region>;
+pub(crate) type EU868 = DynamicChannelPlan<3, EU868Region>;
 
 #[derive(Default, Clone)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct EU868Region;
 
-impl ChannelRegion<NUM_DR> for EU868Region {
-    fn datarates() -> &'static [Option<Datarate>; NUM_DR] {
+impl ChannelRegion for EU868Region {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
         &DATARATES
     }
 }
 
-impl DynamicChannelRegion<3, NUM_DR> for EU868Region {
+impl DynamicChannelRegion<3> for EU868Region {
     fn join_channels() -> [u32; 3] {
         JOIN_CHANNELS
     }
@@ -36,7 +34,7 @@ impl DynamicChannelRegion<3, NUM_DR> for EU868Region {
 
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
-pub(crate) const DATARATES: [Option<Datarate>; NUM_DR] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
     // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,
@@ -97,4 +95,13 @@ pub(crate) const DATARATES: [Option<Datarate>; NUM_DR] = [
      *       that the end-device SHALL ignore that field and keep the current
      *       parameter values.
      */
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
 ];

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -17,7 +17,7 @@ pub(crate) type EU868 = DynamicChannelPlan<3, EU868Region>;
 pub struct EU868Region;
 
 impl ChannelRegion for EU868Region {
-    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES
     }
 }
@@ -34,7 +34,7 @@ impl DynamicChannelRegion<3> for EU868Region {
 
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
-pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES as usize] = [
     // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -5,7 +5,7 @@
 /// 2. DR0 to DR7
 /// 3. DR0 to DR11 (all data rates implemented)
 ///
-/// Currently, support for only DR0..D6 is implemented
+/// Current status: DR0..DR6 is supported
 use super::*;
 
 const JOIN_CHANNELS: [u32; 3] = [868_100_000, 868_300_000, 868_500_000];
@@ -84,23 +84,17 @@ pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
-    /* Notes: FSK and LR-FHSS rates
-     * -  7: FSK: 50 kbps
-     * -  8: LR-FHSS CR1/3: 137 kHz BW
-     * -  9: LR-FHSS CR2/3: 137 kHz BW
-     * - 10: LR-FHSS CR1/3: 336 kHz BW
-     * - 11: LR-FHSS CR2/3: 336 kHz BW
-     * - 12..14: RFU
-     * - 15: The value of 0xF (decimal 15) of either DataRate or TXPower means
-     *       that the end-device SHALL ignore that field and keep the current
-     *       parameter values.
-     */
+    // TODO: DR7: FSK: 50 kbps
     None,
+    // TODO: DR8: LR-FHSS CR1/3: 137 kHz BW
     None,
+    // TODO: DR9: LR-FHSS CR2/3: 137 kHz BW
     None,
+    // TODO: DR10: LR-FHSS CR1/3: 336 kHz BW
     None,
+    // TODO: DR11: LR-FHSS CR2/3: 336 kHz BW
     None,
-    None,
+    // DR12..DR14: RFU
     None,
     None,
     None,

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -3,19 +3,19 @@ use super::*;
 
 const JOIN_CHANNELS: [u32; 3] = [865_062_500, 865_402_500, 865_985_000];
 
-pub(crate) type IN865 = DynamicChannelPlan<3, 6, IN865Region>;
+pub(crate) type IN865 = DynamicChannelPlan<3, IN865Region>;
 
 #[derive(Default, Clone)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct IN865Region;
 
-impl ChannelRegion<6> for IN865Region {
-    fn datarates() -> &'static [Option<Datarate>; 6] {
+impl ChannelRegion for IN865Region {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
         &DATARATES
     }
 }
 
-impl DynamicChannelRegion<3, 6> for IN865Region {
+impl DynamicChannelRegion<3> for IN865Region {
     fn join_channels() -> [u32; 3] {
         JOIN_CHANNELS
     }
@@ -27,7 +27,7 @@ impl DynamicChannelRegion<3, 6> for IN865Region {
 
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
-pub(crate) const DATARATES: [Option<Datarate>; 6] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,
         bandwidth: Bandwidth::_125KHz,
@@ -65,4 +65,14 @@ pub(crate) const DATARATES: [Option<Datarate>; 6] = [
         max_mac_payload_size_with_dwell_time: 250,
     }),
     // TODO: ignore FSK data rate for now
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
 ];

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -1,4 +1,10 @@
-#![allow(dead_code)]
+/// IN865 region support (865..867 MHz)
+///
+/// IN865-867 end-devices SHALL support one of the two following data rate options:
+/// 1. DR0 to DR5 (minimum set supported for certification)
+/// 2. DR0 to DR5 and DR7
+///
+/// Current status: DR0..DR5 is supported
 use super::*;
 
 const JOIN_CHANNELS: [u32; 3] = [865_062_500, 865_402_500, 865_985_000];
@@ -28,46 +34,53 @@ impl DynamicChannelRegion<3> for IN865Region {
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
+    // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 59,
     }),
+    // DR1
     Some(Datarate {
         spreading_factor: SpreadingFactor::_11,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 59,
     }),
+    // DR2
     Some(Datarate {
         spreading_factor: SpreadingFactor::_10,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 59,
     }),
+    // DR3
     Some(Datarate {
         spreading_factor: SpreadingFactor::_9,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 123,
         max_mac_payload_size_with_dwell_time: 123,
     }),
+    // DR4
     Some(Datarate {
         spreading_factor: SpreadingFactor::_8,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR5
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
-    // TODO: ignore FSK data rate for now
+    // DR6: RFU
     None,
+    // TODO: DR7: FSK: 50 kbps
     None,
-    None,
+    // DR8..DR14: RFU
     None,
     None,
     None,

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -16,7 +16,7 @@ pub(crate) type IN865 = DynamicChannelPlan<3, IN865Region>;
 pub struct IN865Region;
 
 impl ChannelRegion for IN865Region {
-    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES
     }
 }
@@ -33,7 +33,7 @@ impl DynamicChannelRegion<3> for IN865Region {
 
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
-pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES as usize] = [
     // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,

--- a/lorawan-device/src/region/fixed_channel_plans/au915/datarates.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/datarates.rs
@@ -1,6 +1,6 @@
 use super::{Bandwidth, Datarate, SpreadingFactor, NUM_DATARATES};
 
-pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES as usize] = [
     // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,

--- a/lorawan-device/src/region/fixed_channel_plans/au915/datarates.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/datarates.rs
@@ -1,85 +1,99 @@
-use super::{Bandwidth, Datarate, SpreadingFactor};
+use super::{Bandwidth, Datarate, SpreadingFactor, NUM_DATARATES};
 
-pub(crate) const DATARATES: [Option<Datarate>; 16] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
+    // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 0,
     }),
+    // DR1
     Some(Datarate {
         spreading_factor: SpreadingFactor::_11,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 0,
     }),
+    // DR2
     Some(Datarate {
         spreading_factor: SpreadingFactor::_10,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 59,
         max_mac_payload_size_with_dwell_time: 19,
     }),
+    // DR3
     Some(Datarate {
         spreading_factor: SpreadingFactor::_9,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 123,
         max_mac_payload_size_with_dwell_time: 61,
     }),
+    // DR4
     Some(Datarate {
         spreading_factor: SpreadingFactor::_8,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 133,
     }),
+    // DR5
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR6
     Some(Datarate {
         spreading_factor: SpreadingFactor::_8,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
-    None, // LR-FHSS -- not currently supported, TODO: defined in rp002-1-0-4
+    // TODO: DR7: LR-FHSS CR1/3: 1.523 MHz BW
+    None,
+    // DR8
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 61,
         max_mac_payload_size_with_dwell_time: 61,
     }),
+    // DR9
     Some(Datarate {
         spreading_factor: SpreadingFactor::_11,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 137,
         max_mac_payload_size_with_dwell_time: 137,
     }),
+    // DR10
     Some(Datarate {
         spreading_factor: SpreadingFactor::_10,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR11
     Some(Datarate {
         spreading_factor: SpreadingFactor::_9,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR12
     Some(Datarate {
         spreading_factor: SpreadingFactor::_8,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR13
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
-    None, // RFU, TODO: defined in rp002-1-0-4
-    None, // TODO: defined in rp002-1-0-4
+    // DR14: RFU
+    None,
 ];

--- a/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
@@ -1,3 +1,10 @@
+/// AU915 region support (915..928 MHz)
+///
+/// AU915-928 end-devices SHALL support one of the two following data rate options:
+/// 1. DR0 to DR6 and DR8 to DR13 (minimum set supported for certification)
+/// 2. DR0 to DR13 (all data rates implemented)
+///
+/// Current status: DR7 is unimplemented (LR-FHSS)
 use super::*;
 
 mod frequencies;

--- a/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
@@ -50,7 +50,7 @@ impl AU915 {
 pub(crate) struct AU915Region;
 
 impl ChannelRegion for AU915Region {
-    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES
     }
 }

--- a/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
@@ -31,7 +31,7 @@ const DEFAULT_RX2: u32 = 923_300_000;
 /// let configuration: Configuration = au915.into();
 /// ```
 #[derive(Default, Clone)]
-pub struct AU915(pub(crate) FixedChannelPlan<16, AU915Region>);
+pub struct AU915(pub(crate) FixedChannelPlan<AU915Region>);
 
 impl AU915 {
     pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
@@ -42,13 +42,13 @@ impl AU915 {
 #[derive(Default, Clone)]
 pub(crate) struct AU915Region;
 
-impl ChannelRegion<16> for AU915Region {
-    fn datarates() -> &'static [Option<Datarate>; 16] {
+impl ChannelRegion for AU915Region {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
         &DATARATES
     }
 }
 
-impl FixedChannelRegion<16> for AU915Region {
+impl FixedChannelRegion for AU915Region {
     fn uplink_channels() -> &'static [u32; 72] {
         &UPLINK_CHANNEL_MAP
     }

--- a/lorawan-device/src/region/fixed_channel_plans/us915/datarates.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/datarates.rs
@@ -1,6 +1,6 @@
 use super::{Bandwidth, Datarate, SpreadingFactor, NUM_DATARATES};
 
-pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES as usize] = [
     // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_10,

--- a/lorawan-device/src/region/fixed_channel_plans/us915/datarates.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/datarates.rs
@@ -1,75 +1,89 @@
 use super::{Bandwidth, Datarate, SpreadingFactor, NUM_DATARATES};
 
 pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
+    // DR0
     Some(Datarate {
         spreading_factor: SpreadingFactor::_10,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 19,
         max_mac_payload_size_with_dwell_time: 19,
     }),
+    // DR1
     Some(Datarate {
         spreading_factor: SpreadingFactor::_9,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 61,
         max_mac_payload_size_with_dwell_time: 61,
     }),
+    // DR2
     Some(Datarate {
         spreading_factor: SpreadingFactor::_8,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 133,
         max_mac_payload_size_with_dwell_time: 133,
     }),
+    // DR3
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_125KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR4
     Some(Datarate {
         spreading_factor: SpreadingFactor::_8,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
-    None, // TODO: defined in rp002-1-0-4
-    None, // TODO: defined in rp002-1-0-4
+    // TODO: DR5: LR-FHSS CR1/3: 1.523 MHz BW
     None,
+    // TODO: DR6: LR-FHSS CR2/3: 1.523 MHz BW
+    None,
+    // DR7: RFU
+    None,
+    // DR8
     Some(Datarate {
         spreading_factor: SpreadingFactor::_12,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 61,
         max_mac_payload_size_with_dwell_time: 61,
     }),
+    // DR9
     Some(Datarate {
         spreading_factor: SpreadingFactor::_11,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 137,
         max_mac_payload_size_with_dwell_time: 137,
     }),
+    // DR10
     Some(Datarate {
         spreading_factor: SpreadingFactor::_10,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR11
     Some(Datarate {
         spreading_factor: SpreadingFactor::_9,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR12
     Some(Datarate {
         spreading_factor: SpreadingFactor::_8,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    // DR13
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_500KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
-    None,
+    // DR14: RFU
     None,
 ];

--- a/lorawan-device/src/region/fixed_channel_plans/us915/datarates.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/datarates.rs
@@ -1,6 +1,6 @@
-use super::{Bandwidth, Datarate, SpreadingFactor};
+use super::{Bandwidth, Datarate, SpreadingFactor, NUM_DATARATES};
 
-pub(crate) const DATARATES: [Option<Datarate>; 14] = [
+pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES] = [
     Some(Datarate {
         spreading_factor: SpreadingFactor::_10,
         bandwidth: Bandwidth::_125KHz,
@@ -70,4 +70,6 @@ pub(crate) const DATARATES: [Option<Datarate>; 14] = [
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    None,
+    None,
 ];

--- a/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
@@ -1,3 +1,10 @@
+/// US915 region support (902..928 MHz)
+///
+/// US902-928 end-devices SHALL support one of the two following data rate options:
+/// 1. DR0 to DR4 and DR8 to DR13 (minimum set supported for certification)
+/// 2. DR0 to DR13 (all data rates implemented)
+///
+/// Current status: DR5 and DR6 are unimplemented (LR-FHSS)
 use super::*;
 
 mod frequencies;

--- a/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
@@ -50,7 +50,7 @@ impl US915 {
 pub(crate) struct US915Region;
 
 impl ChannelRegion for US915Region {
-    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES
     }
 }

--- a/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
@@ -31,7 +31,7 @@ const DEFAULT_RX2: u32 = 923_300_000;
 /// let configuration: Configuration = us915.into();
 /// ```
 #[derive(Default, Clone)]
-pub struct US915(pub(crate) FixedChannelPlan<14, US915Region>);
+pub struct US915(pub(crate) FixedChannelPlan<US915Region>);
 
 impl US915 {
     pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
@@ -42,13 +42,13 @@ impl US915 {
 #[derive(Default, Clone)]
 pub(crate) struct US915Region;
 
-impl ChannelRegion<14> for US915Region {
-    fn datarates() -> &'static [Option<Datarate>; 14] {
+impl ChannelRegion for US915Region {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES] {
         &DATARATES
     }
 }
 
-impl FixedChannelRegion<14> for US915Region {
+impl FixedChannelRegion for US915Region {
     fn uplink_channels() -> &'static [u32; 72] {
         &UPLINK_CHANNEL_MAP
     }

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -56,7 +56,7 @@ pub use fixed_channel_plans::AU915;
 pub use fixed_channel_plans::US915;
 
 pub(crate) trait ChannelRegion {
-    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES];
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize];
 
     fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
         let Some(Some(dr)) = Self::datarates().get(datarate as usize) else {

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -55,8 +55,8 @@ pub use fixed_channel_plans::AU915;
 #[cfg(feature = "region-us915")]
 pub use fixed_channel_plans::US915;
 
-pub(crate) trait ChannelRegion<const D: usize> {
-    fn datarates() -> &'static [Option<Datarate>; D];
+pub(crate) trait ChannelRegion {
+    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES];
 
     fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
         let Some(Some(dr)) = Self::datarates().get(datarate as usize) else {


### PR DESCRIPTION
As datarate table has maximum 16 elements (and last one isn't really a datarate), carrying the generic const around seems a bit pointless...  And we'll be gaining another generic once we'll plug in RXParamsetupReq which featuring rx1 datarate offsets.

Changes to lorawan crate size using `cargo bloat`:
```
nrf52840_lorawan all_regions
before: 17.7KiB
after: 17.8KiB

nrf52840_lorawan only eu868
before: 8.6KiB
after:  8.6KiB

stm32wl_lorawan_class_c
before: 20.2KiB
after: 20.3KiB
```