### PR TITLE
LinkADRReq tx_power support

### DIFF
--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -51,6 +51,7 @@ pub struct Configuration {
     join_accept_delay1: u32,
     join_accept_delay2: u32,
 
+    pub(crate) tx_power: Option<u8>,
     // Overriden with RxParamSetupReq
     // TODO: rx1_data_rate_offset
     // TODO: rx2_data_rate
@@ -109,6 +110,7 @@ impl Mac {
                 join_accept_delay1: region::constants::JOIN_ACCEPT_DELAY1,
                 join_accept_delay2: region::constants::JOIN_ACCEPT_DELAY2,
                 rx2_frequency: None,
+                tx_power: None,
             },
             #[cfg(feature = "certification")]
             certification: certification::Certification::new(),
@@ -164,7 +166,10 @@ impl Mac {
         }?;
         let mut tx_config =
             self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Data);
-        tx_config.adjust_power(self.board_eirp.max_power, self.board_eirp.antenna_gain);
+        tx_config.adjust_power(
+            self.configuration.tx_power.unwrap_or(self.board_eirp.max_power),
+            self.board_eirp.antenna_gain,
+        );
         Ok((tx_config, fcnt))
     }
 
@@ -177,7 +182,10 @@ impl Mac {
         self.multicast.setup_send::<C, N>(&mut self.state, buf).map(|fcnt_up| {
             let mut tx_config =
                 self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Data);
-            tx_config.adjust_power(self.board_eirp.max_power, self.board_eirp.antenna_gain);
+            tx_config.adjust_power(
+                self.configuration.tx_power.unwrap_or(self.board_eirp.max_power),
+                self.board_eirp.antenna_gain,
+            );
             (tx_config, fcnt_up)
         })
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -8,6 +8,7 @@
 use super::*;
 
 const JOIN_CHANNELS: [u32; 2] = [923200000, 923200000];
+const MAX_EIRP: u8 = 16;
 
 pub(crate) type AS923_1 = DynamicChannelPlan<2, AS923Region<923_200_000, 0>>;
 pub(crate) type AS923_2 = DynamicChannelPlan<2, AS923Region<921_400_000, 1800000>>;
@@ -21,6 +22,13 @@ pub struct AS923Region<const DEFAULT_RX2: u32, const O: u32>;
 impl<const DEFAULT_RX2: u32, const OFFSET: u32> ChannelRegion for AS923Region<DEFAULT_RX2, OFFSET> {
     fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES
+    }
+
+    fn tx_power_adjust(pw: u8) -> Option<u8> {
+        match pw {
+            0..=7 => Some(MAX_EIRP - (2 * pw)),
+            _ => None,
+        }
     }
 }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -8,6 +8,7 @@
 use super::*;
 
 const JOIN_CHANNELS: [u32; 3] = [433_175_000, 433_375_000, 433_575_000];
+const MAX_EIRP: u8 = 16;
 
 pub(crate) type EU433 = DynamicChannelPlan<3, EU433Region>;
 
@@ -30,6 +31,13 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
 impl ChannelRegion for EU433Region {
     fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES
+    }
+
+    fn tx_power_adjust(pw: u8) -> Option<u8> {
+        match pw {
+            0..=5 => Some(MAX_EIRP - (2 * pw)),
+            _ => None,
+        }
     }
 }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -9,6 +9,7 @@
 use super::*;
 
 const JOIN_CHANNELS: [u32; 3] = [868_100_000, 868_300_000, 868_500_000];
+const MAX_EIRP: u8 = 16;
 
 pub(crate) type EU868 = DynamicChannelPlan<3, EU868Region>;
 
@@ -31,6 +32,13 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
 impl ChannelRegion for EU868Region {
     fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES
+    }
+
+    fn tx_power_adjust(pw: u8) -> Option<u8> {
+        match pw {
+            0..=7 => Some(MAX_EIRP - (2 * pw)),
+            _ => None,
+        }
     }
 }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -8,11 +8,11 @@
 use super::*;
 
 const JOIN_CHANNELS: [u32; 3] = [865_062_500, 865_402_500, 865_985_000];
+const MAX_EIRP: u8 = 30;
 
 pub(crate) type IN865 = DynamicChannelPlan<3, IN865Region>;
 
 #[derive(Default, Clone)]
-#[allow(clippy::upper_case_acronyms)]
 pub struct IN865Region;
 
 fn in865_freq_check(f: u32) -> bool {
@@ -30,6 +30,13 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
 impl ChannelRegion for IN865Region {
     fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES
+    }
+
+    fn tx_power_adjust(pw: u8) -> Option<u8> {
+        match pw {
+            0..=10 => Some(MAX_EIRP - (2 * pw)),
+            _ => None,
+        }
     }
 }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -227,6 +227,10 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
         R::datarates()[datarate].clone().unwrap()
     }
 
+    fn check_tx_power(&self, tx_power: u8) -> Option<u8> {
+        R::tx_power_adjust(tx_power)
+    }
+
     fn frequency_valid(&self, freq: u32) -> bool {
         (self.frequency_valid)(freq)
     }

--- a/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
@@ -13,7 +13,6 @@ use frequencies::*;
 mod datarates;
 use datarates::*;
 
-const AU_DBM: i8 = 21;
 const MAX_EIRP: u8 = 30;
 const DEFAULT_RX2: u32 = 923_300_000;
 
@@ -102,8 +101,5 @@ impl FixedChannelRegion for AU915Region {
             Window::_2 => DR::_8,
         };
         DATARATES[datarate as usize].clone().unwrap()
-    }
-    fn get_dbm() -> i8 {
-        AU_DBM
     }
 }

--- a/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
@@ -14,6 +14,7 @@ mod datarates;
 use datarates::*;
 
 const AU_DBM: i8 = 21;
+const MAX_EIRP: u8 = 30;
 const DEFAULT_RX2: u32 = 923_300_000;
 
 /// State struct for the `AU915` region. This struct may be created directly if you wish to fine-tune some parameters.
@@ -62,6 +63,13 @@ pub(crate) struct AU915Region;
 impl ChannelRegion for AU915Region {
     fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES
+    }
+
+    fn tx_power_adjust(pw: u8) -> Option<u8> {
+        match pw {
+            0..=14 => Some(MAX_EIRP - (2 * pw)),
+            _ => None,
+        }
     }
 }
 

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -223,6 +223,10 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
         F::get_rx_datarate(tx_datarate, frame, window)
     }
 
+    fn check_tx_power(&self, tx_power: u8) -> Option<u8> {
+        F::tx_power_adjust(tx_power)
+    }
+
     fn frequency_valid(&self, freq: u32) -> bool {
         (self.frequency_valid)(freq)
     }

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -93,7 +93,6 @@ pub(crate) trait FixedChannelRegion: ChannelRegion {
     fn downlink_channels() -> &'static [u32; 8];
     fn get_default_rx2() -> u32;
     fn get_rx_datarate(tx_datarate: DR, frame: &Frame, window: &Window) -> Datarate;
-    fn get_dbm() -> i8;
 }
 
 impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
@@ -213,10 +212,6 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
             Window::_1 => F::downlink_channels()[channel as usize],
             Window::_2 => F::get_default_rx2(),
         }
-    }
-
-    fn get_dbm(&self) -> i8 {
-        F::get_dbm()
     }
 
     fn get_rx_datarate(&self, tx_datarate: DR, frame: &Frame, window: &Window) -> Datarate {

--- a/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
@@ -104,7 +104,4 @@ impl FixedChannelRegion for US915Region {
         };
         DATARATES[datarate as usize].clone().unwrap()
     }
-    fn get_dbm() -> i8 {
-        (US_DBM as u8).try_into().unwrap()
-    }
 }

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -73,6 +73,8 @@ pub(crate) trait ChannelRegion {
             max_size
         }
     }
+
+    fn tx_power_adjust(pw: u8) -> Option<u8>;
 }
 
 #[derive(Clone)]
@@ -424,6 +426,10 @@ impl Configuration {
         region_dispatch!(self, check_data_rate, data_rate)
     }
 
+    pub(crate) fn check_tx_power(&self, tx_power: u8) -> Option<Option<u8>> {
+        region_dispatch!(self, check_tx_power, tx_power).map(Some)
+    }
+
     fn get_tx_dr_and_frequency<RNG: RngCore>(
         &mut self,
         rng: &mut RNG,
@@ -568,6 +574,8 @@ pub(crate) trait RegionHandler {
     fn get_coding_rate(&self) -> CodingRate {
         DEFAULT_CODING_RATE
     }
+
+    fn check_tx_power(&self, tx_power: u8) -> Option<u8>;
 
     fn frequency_valid(&self, freq: u32) -> bool;
 }

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -410,7 +410,8 @@ impl Configuration {
     ) -> TxConfig {
         let (dr, frequency) = self.get_tx_dr_and_frequency(rng, datarate, frame);
         TxConfig {
-            pw: self.get_dbm(),
+            // We can do this safely, as default output power will be positive
+            pw: self.check_tx_power(0).unwrap().unwrap() as i8,
             rf: RfConfig {
                 frequency,
                 bb: BaseBandModulationParams::new(
@@ -495,10 +496,6 @@ impl Configuration {
         }
     }
 
-    pub(crate) fn get_dbm(&self) -> i8 {
-        region_dispatch!(self, get_dbm)
-    }
-
     pub(crate) fn get_coding_rate(&self) -> CodingRate {
         region_dispatch!(self, get_coding_rate)
     }
@@ -568,9 +565,6 @@ pub(crate) trait RegionHandler {
 
     fn get_rx_frequency(&self, frame: &Frame, window: &Window) -> u32;
     fn get_rx_datarate(&self, datarate: DR, frame: &Frame, window: &Window) -> Datarate;
-    fn get_dbm(&self) -> i8 {
-        DEFAULT_DBM
-    }
     fn get_coding_rate(&self) -> CodingRate {
         DEFAULT_CODING_RATE
     }


### PR DESCRIPTION
This PR adds support for tx_power changes requested via `LinkADRReq`. Addresses #168 and passes LCTT subtest of (`TP_A_EU868_ED_MAC_104_BV_012_A - LinkADRReq MAC command `).

Also, all the changes are in MAC and Region level. BoardEirp stuff needs redesign, but that's for future...