### PR TITLE
Basic NewChannelReq stub implementation

### DIFF
--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -41,6 +41,7 @@ lorawan = { path = "../lorawan-encoding", default-features = false, features = [
     "default-crypto",
     "defmt-03",
 ] }
+hex = "0.4.3"
 
 [features]
 default = ["all-regions", "class-c"]

--- a/lorawan-device/src/async_device/test/util.rs
+++ b/lorawan-device/src/async_device/test/util.rs
@@ -8,6 +8,35 @@ use crate::mac::Session;
 pub(crate) use crate::test_util::{handle_data_uplink_with_link_adr_req, Uplink};
 use crate::{AppSKey, NwkSKey};
 
+fn default_session() -> Session {
+    Session {
+        nwkskey: NwkSKey::from(get_key()),
+        appskey: AppSKey::from(get_key()),
+        devaddr: get_dev_addr(),
+        fcnt_up: 0,
+        fcnt_down: 0,
+        confirmed: false,
+        uplink: Default::default(),
+        #[cfg(feature = "certification")]
+        override_adr: false,
+        #[cfg(feature = "certification")]
+        override_confirmed: None,
+    }
+}
+
+pub fn session_with_region(region: region::Configuration) -> (RadioChannel, TimerChannel, Device) {
+    let (radio_channel, mock_radio) = TestRadio::new();
+    let (timer_channel, mock_timer) = TestTimer::new();
+    let async_device = Device::new_with_session(
+        region,
+        mock_radio,
+        mock_timer,
+        rand::rngs::OsRng,
+        Some(default_session()),
+    );
+    (radio_channel, timer_channel, async_device)
+}
+
 fn setup_internal(session_data: Option<Session>) -> (RadioChannel, TimerChannel, Device) {
     let (radio_channel, mock_radio) = TestRadio::new();
     let (timer_channel, mock_timer) = TestTimer::new();
@@ -23,19 +52,7 @@ fn setup_internal(session_data: Option<Session>) -> (RadioChannel, TimerChannel,
 }
 
 pub fn setup_with_session() -> (RadioChannel, TimerChannel, Device) {
-    setup_internal(Some(Session {
-        nwkskey: NwkSKey::from(get_key()),
-        appskey: AppSKey::from(get_key()),
-        devaddr: get_dev_addr(),
-        fcnt_up: 0,
-        fcnt_down: 0,
-        confirmed: false,
-        uplink: Default::default(),
-        #[cfg(feature = "certification")]
-        override_adr: false,
-        #[cfg(feature = "certification")]
-        override_confirmed: None,
-    }))
+    setup_internal(Some(default_session()))
 }
 
 /// Handle an uplink and respond with two LinkAdrReq on Port 0

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -329,6 +329,13 @@ impl Session {
                         configuration.data_rate = dr.unwrap()
                     }
                 }
+                NewChannelReq(_payload) => {
+                    // Check whether region should skip handling this command.
+                    if region.skip_newchannelreq() {
+                        continue;
+                    }
+                    // TODO: Handle command
+                }
                 RXParamSetupReq(payload) => {
                     let freq = payload.frequency().value();
                     let freq_ack = region.frequency_valid(freq);

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -7,7 +7,8 @@ use crate::{region, AppSKey, Downlink, NwkSKey};
 use heapless::Vec;
 use lorawan::keys::CryptoFactory;
 use lorawan::maccommandcreator::{
-    DevStatusAnsCreator, LinkADRAnsCreator, RXParamSetupAnsCreator, RXTimingSetupAnsCreator,
+    DevStatusAnsCreator, LinkADRAnsCreator, NewChannelAnsCreator, RXParamSetupAnsCreator,
+    RXTimingSetupAnsCreator,
 };
 use lorawan::maccommands::{DownlinkMacCommand, MacCommandIterator};
 use lorawan::{
@@ -329,12 +330,20 @@ impl Session {
                         configuration.data_rate = dr.unwrap()
                     }
                 }
-                NewChannelReq(_payload) => {
+                NewChannelReq(payload) => {
                     // Check whether region should skip handling this command.
                     if region.skip_newchannelreq() {
                         continue;
                     }
-                    // TODO: Handle command
+                    let (ack_f, ack_d) = region.handle_new_channel(
+                        payload.channel_index(),
+                        payload.frequency().value(),
+                        payload.data_rate_range(),
+                    );
+
+                    let mut cmd = NewChannelAnsCreator::new();
+                    cmd.set_channel_frequency_ack(ack_f).set_data_rate_range_ack(ack_d);
+                    self.uplink.add_mac_command(cmd);
                 }
                 RXParamSetupReq(payload) => {
                     let freq = payload.frequency().value();

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -5,7 +5,7 @@
 /// 2. DR0 to DR7
 /// 3. DR0 to DR11 (all data rates implemented)
 ///
-/// Current status: DR0..DR6 is supported
+/// Current status: DR0..DR5 (minimum set is supported)
 use super::*;
 
 const JOIN_CHANNELS: [u32; 3] = [868_100_000, 868_300_000, 868_500_000];
@@ -89,13 +89,16 @@ pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES as usize] = [
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
-    // DR6
+    None,
+    /*
+    // TODO: DR6: Can be enabled once DR7 is implemented
     Some(Datarate {
         spreading_factor: SpreadingFactor::_7,
         bandwidth: Bandwidth::_250KHz,
         max_mac_payload_size: 250,
         max_mac_payload_size_with_dwell_time: 250,
     }),
+    */
     // TODO: DR7: FSK: 50 kbps
     None,
     // TODO: DR8: LR-FHSS CR1/3: 137 kHz BW

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -132,7 +132,7 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
                 }
             }
             Some(CfList::FixedChannel(_cf_list)) => {
-                //TODO: dynamic channel plans have corresponding fixed channel lists,
+                // TODO: dynamic channel plans have corresponding fixed channel lists,
                 // however, this feature is entirely optional
             }
             None => {}
@@ -229,5 +229,10 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
 
     fn frequency_valid(&self, freq: u32) -> bool {
         (self.frequency_valid)(freq)
+    }
+
+    // NewChannelReq MAC command is required in dynamic channel regions
+    fn skip_newchannelreq(&self) -> bool {
+        false
     }
 }

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -235,4 +235,20 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
     fn skip_newchannelreq(&self) -> bool {
         false
     }
+
+    fn handle_new_channel(&mut self, index: u8, freq: u32, _: DataRateRange) -> (bool, bool) {
+        // Join channels are readonly - these cannot be modified!
+        let index = index as usize;
+        if index < NUM_JOIN_CHANNELS {
+            return (false, false);
+        }
+        // Disable channel if frequency is 0
+        // TODO: We currently have only 5 of these?
+        if freq == 0 && index < self.additional_channels.len() {
+            self.additional_channels[index] = None;
+            return (true, true);
+        }
+        // TODO: Implement frequency and data range checks to define new channels
+        (false, false)
+    }
 }

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -231,4 +231,8 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
     fn skip_newchannelreq(&self) -> bool {
         true
     }
+
+    fn handle_new_channel(&mut self, _: u8, _: u32, _: DataRateRange) -> (bool, bool) {
+        unreachable!()
+    }
 }

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -226,4 +226,9 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
     fn frequency_valid(&self, freq: u32) -> bool {
         (self.frequency_valid)(freq)
     }
+
+    // NewChannelReq MAC command is not implemented in fixed channel regions
+    fn skip_newchannelreq(&self) -> bool {
+        true
+    }
 }

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -505,6 +505,10 @@ impl Configuration {
     pub(crate) fn get_current_region(&self) -> super::region::Region {
         self.state.region()
     }
+
+    pub(crate) fn skip_newchannelreq(&self) -> bool {
+        region_dispatch!(self, skip_newchannelreq)
+    }
 }
 
 macro_rules! from_region {
@@ -570,6 +574,9 @@ pub(crate) trait RegionHandler {
     }
 
     fn frequency_valid(&self, freq: u32) -> bool;
+
+    /// Fixed channel plan regions SHALL NOT implement NewChannelReq MAC command.
+    fn skip_newchannelreq(&self) -> bool;
 }
 
 #[cfg(test)]

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -1,6 +1,6 @@
 //! LoRaWAN device region definitions (eg: EU868, US915, etc).
 use lora_modulation::{Bandwidth, BaseBandModulationParams, CodingRate, SpreadingFactor};
-use lorawan::{maccommands::ChannelMask, parser::CfList};
+use lorawan::{maccommands::ChannelMask, parser::CfList, types::DataRateRange};
 use rand_core::RngCore;
 
 use crate::mac::{Frame, Window};
@@ -509,6 +509,15 @@ impl Configuration {
     pub(crate) fn skip_newchannelreq(&self) -> bool {
         region_dispatch!(self, skip_newchannelreq)
     }
+
+    pub(crate) fn handle_new_channel(
+        &mut self,
+        index: u8,
+        freq: u32,
+        data_rates: DataRateRange,
+    ) -> (bool, bool) {
+        mut_region_dispatch!(self, handle_new_channel, index, freq, data_rates)
+    }
 }
 
 macro_rules! from_region {
@@ -553,6 +562,13 @@ pub(crate) trait RegionHandler {
         channel_mask_control: u8,
         channel_mask: ChannelMask<2>,
     );
+
+    fn handle_new_channel(
+        &mut self,
+        index: u8,
+        freq: u32,
+        data_rates: DataRateRange,
+    ) -> (bool, bool);
 
     fn get_default_datarate(&self) -> DR {
         DR::_0


### PR DESCRIPTION
This adds basic stub for implementing NewChannelReq MAC command.
Should be good enough to commit as is, as a next step we'll need to implement following:
1. Define allowed frequency ranges for each region ( #359 )
2. Define supported frequencies for drivers (lora-phy)
3. Figure where to store the new channel information... current code has following:
   ```rust
   pub(crate) struct DynamicChannelPlan< const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>> {
      additional_channels: [Option<u32>; 5],   /// should I use this? But why only 5?
      channel_mask: ChannelMask<9>,
      last_tx_channel: u8,
      _fixed_channel_region: PhantomData<R>,
      rx1_offset: usize,
      rx2_dr: usize,
   }
   ```

LoRaWAN 1.0.4 documentation for NewChannelReq mentions:
>If the number of default channels is N (join channels?), the default channels go from 0 to N−1, and the acceptable range for ChIndex is N to 15. An
end-device SHALL be able to handle at least 16 different channel definitions.

But in the RP1.0.4:
> ...each region should support at least 24 channels (and maximum 80).