### PR TITLE
Add default frequency ranges for regions and implement frequency validation support

### DIFF
--- a/lorawan-device/src/async_device/test/maccommands.rs
+++ b/lorawan-device/src/async_device/test/maccommands.rs
@@ -19,7 +19,7 @@ async fn maccommands_in_frmpayload() {
     ) -> usize {
         // FRMPayload contains:
         // - DevStatusReq(..)
-        // - RXParamSetupReq(RXParamSetupReqPayload([2, 210, 173, 132]))
+        // - RXParamSetupReq(RXParamSetupReqPayload([2, 210, 173, 132])) - freq: 869525000
         // - RXTimingSetupReq(RXTimingSetupReqPayload([1]))
         // - LinkADRReq(LinkADRReqPayload([80, 0, 0, 97]))
         let mut phy = lorawan::creator::DataPayloadCreator::new(rx_buffer).unwrap();
@@ -66,7 +66,8 @@ async fn maccommands_in_frmpayload() {
     if let Some(session) = device.mac.get_session() {
         let data = session.uplink.mac_commands();
         assert_eq!(parse_uplink_mac_commands(data).count(), 4);
-        assert_eq!(device.mac.configuration.rx2_frequency, Some(869525000));
+        // LinkADRReq sends freq = 869525000, but this is invalid in US915
+        assert_eq!(device.mac.configuration.rx2_frequency, None);
     } else {
         panic!("Session not joined?");
     }

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -330,17 +330,21 @@ impl Session {
                     }
                 }
                 RXParamSetupReq(payload) => {
-                    // TODO: Verify with region!
-                    configuration.rx2_frequency = Some(payload.frequency().value());
+                    let freq = payload.frequency().value();
+                    let freq_ack = region.frequency_valid(freq);
+
                     // TODO: Figure these out...
                     // let dl = payload.dl_settings();
                     // - rx1_dr_offset: dl.rx1_dr_offset()
                     // - rx2_data_rate = dl.rx2_data_rate());
+                    if freq_ack {
+                        configuration.rx2_frequency = Some(freq);
+                    }
+
                     let mut cmd = RXParamSetupAnsCreator::new();
-                    cmd
-                        //.set_rx1_data_rate_offset_ack(true)
-                        //.set_rx2_data_rate_ack(true);
-                        .set_channel_ack(true);
+                    cmd.set_rx1_data_rate_offset_ack(true)
+                        .set_rx2_data_rate_ack(true)
+                        .set_channel_ack(freq_ack);
                     self.uplink.add_mac_command(cmd);
                 }
                 RXTimingSetupReq(payload) => {

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -24,6 +24,26 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> ChannelRegion for AS923Region<DE
     }
 }
 
+fn as924_generic_freq_check(f: u32) -> bool {
+    (915_000_000..=928_000_000).contains(&f)
+}
+
+fn as924_4_freq_check(f: u32) -> bool {
+    (917_000_000..=920_000_000).contains(&f)
+}
+
+impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
+    DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
+{
+    pub fn new_as924() -> Self {
+        Self::new(as924_generic_freq_check)
+    }
+
+    pub fn new_as924_4() -> Self {
+        Self::new(as924_4_freq_check)
+    }
+}
+
 impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2>
     for AS923Region<DEFAULT_RX2, OFFSET>
 {

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -15,6 +15,18 @@ pub(crate) type EU433 = DynamicChannelPlan<3, EU433Region>;
 #[allow(clippy::upper_case_acronyms)]
 pub struct EU433Region;
 
+fn eu433_freq_check(f: u32) -> bool {
+    (433_050_000..=434_790_000).contains(&f)
+}
+
+impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
+    DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
+{
+    pub fn new_eu433() -> Self {
+        Self::new(eu433_freq_check)
+    }
+}
+
 impl ChannelRegion for EU433Region {
     fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -16,6 +16,18 @@ pub(crate) type EU868 = DynamicChannelPlan<3, EU868Region>;
 #[allow(clippy::upper_case_acronyms)]
 pub struct EU868Region;
 
+fn eu868_freq_check(f: u32) -> bool {
+    (863_000_000..=870_000_000).contains(&f)
+}
+
+impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
+    DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
+{
+    pub fn new_eu868() -> Self {
+        Self::new(eu868_freq_check)
+    }
+}
+
 impl ChannelRegion for EU868Region {
     fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -15,6 +15,18 @@ pub(crate) type IN865 = DynamicChannelPlan<3, IN865Region>;
 #[allow(clippy::upper_case_acronyms)]
 pub struct IN865Region;
 
+fn in865_freq_check(f: u32) -> bool {
+    (865_000_000..=867_000_000).contains(&f)
+}
+
+impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
+    DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
+{
+    pub fn new_in865() -> Self {
+        Self::new(in865_freq_check)
+    }
+}
+
 impl ChannelRegion for IN865Region {
     fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES as usize] {
         &DATARATES

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -30,8 +30,7 @@ pub(crate) use eu868::EU868;
 #[cfg(feature = "region-in865")]
 pub(crate) use in865::IN865;
 
-#[derive(Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone)]
 pub(crate) struct DynamicChannelPlan<
     const NUM_JOIN_CHANNELS: usize,
     R: DynamicChannelRegion<NUM_JOIN_CHANNELS>,
@@ -42,11 +41,25 @@ pub(crate) struct DynamicChannelPlan<
     _fixed_channel_region: PhantomData<R>,
     rx1_offset: usize,
     rx2_dr: usize,
+
+    frequency_valid: fn(u32) -> bool,
 }
 
 impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
     DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
 {
+    fn new(freq_fn: fn(u32) -> bool) -> Self {
+        Self {
+            additional_channels: Default::default(),
+            channel_mask: Default::default(),
+            last_tx_channel: Default::default(),
+            _fixed_channel_region: Default::default(),
+            rx1_offset: Default::default(),
+            rx2_dr: Default::default(),
+            frequency_valid: freq_fn,
+        }
+    }
+
     fn get_channel(&self, channel: usize) -> Option<u32> {
         if channel < NUM_JOIN_CHANNELS {
             Some(R::join_channels()[channel])

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -226,4 +226,8 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
         };
         R::datarates()[datarate].clone().unwrap()
     }
+
+    fn frequency_valid(&self, freq: u32) -> bool {
+        (self.frequency_valid)(freq)
+    }
 }

--- a/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
@@ -37,12 +37,22 @@ const DEFAULT_RX2: u32 = 923_300_000;
 /// au915.set_join_bias(Subband::_2);
 /// let configuration: Configuration = au915.into();
 /// ```
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct AU915(pub(crate) FixedChannelPlan<AU915Region>);
 
 impl AU915 {
     pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
         AU915Region::get_max_payload_length(datarate, repeater_compatible, dwell_time)
+    }
+}
+
+fn au915_default_freq(f: u32) -> bool {
+    (915_000_000..=928_000_000).contains(&f)
+}
+
+impl Default for AU915 {
+    fn default() -> AU915 {
+        AU915(FixedChannelPlan::new(au915_default_freq))
     }
 }
 

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -222,4 +222,8 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
     fn get_rx_datarate(&self, tx_datarate: DR, frame: &Frame, window: &Window) -> Datarate {
         F::get_rx_datarate(tx_datarate, frame, window)
     }
+
+    fn frequency_valid(&self, freq: u32) -> bool {
+        (self.frequency_valid)(freq)
+    }
 }

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -37,16 +37,27 @@ impl From<Subband> for usize {
     }
 }
 
-#[derive(Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone)]
 pub(crate) struct FixedChannelPlan<F: FixedChannelRegion> {
     last_tx_channel: u8,
     channel_mask: ChannelMask<9>,
     _fixed_channel_region: PhantomData<F>,
     join_channels: JoinChannels,
+
+    frequency_valid: fn(u32) -> bool,
 }
 
 impl<F: FixedChannelRegion> FixedChannelPlan<F> {
+    pub fn new(freq_fn: fn(u32) -> bool) -> Self {
+        Self {
+            last_tx_channel: Default::default(),
+            channel_mask: Default::default(),
+            _fixed_channel_region: Default::default(),
+            join_channels: Default::default(),
+            frequency_valid: freq_fn,
+        }
+    }
+
     pub fn set_125k_channels(&mut self, enabled: bool) {
         let mask = if enabled {
             0xFF

--- a/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
@@ -37,12 +37,22 @@ const DEFAULT_RX2: u32 = 923_300_000;
 /// us915.set_join_bias(Subband::_2);
 /// let configuration: Configuration = us915.into();
 /// ```
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct US915(pub(crate) FixedChannelPlan<US915Region>);
 
 impl US915 {
     pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
         US915Region::get_max_payload_length(datarate, repeater_compatible, dwell_time)
+    }
+}
+
+fn us915_default_freq(f: u32) -> bool {
+    (902_000_000..=928_000_000).contains(&f)
+}
+
+impl Default for US915 {
+    fn default() -> US915 {
+        US915(FixedChannelPlan::new(us915_default_freq))
     }
 }
 

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -181,21 +181,21 @@ impl State {
     pub fn new(region: Region) -> State {
         match region {
             #[cfg(feature = "region-as923-1")]
-            Region::AS923_1 => State::AS923_1(AS923_1::default()),
+            Region::AS923_1 => State::AS923_1(AS923_1::new_as924()),
             #[cfg(feature = "region-as923-2")]
-            Region::AS923_2 => State::AS923_2(AS923_2::default()),
+            Region::AS923_2 => State::AS923_2(AS923_2::new_as924()),
             #[cfg(feature = "region-as923-3")]
-            Region::AS923_3 => State::AS923_3(AS923_3::default()),
+            Region::AS923_3 => State::AS923_3(AS923_3::new_as924()),
             #[cfg(feature = "region-as923-4")]
-            Region::AS923_4 => State::AS923_4(AS923_4::default()),
+            Region::AS923_4 => State::AS923_4(AS923_4::new_as924_4()),
             #[cfg(feature = "region-au915")]
             Region::AU915 => State::AU915(AU915::default()),
             #[cfg(feature = "region-eu868")]
-            Region::EU868 => State::EU868(EU868::default()),
+            Region::EU868 => State::EU868(EU868::new_eu868()),
             #[cfg(feature = "region-eu433")]
-            Region::EU433 => State::EU433(EU433::default()),
+            Region::EU433 => State::EU433(EU433::new_eu433()),
             #[cfg(feature = "region-in865")]
-            Region::IN865 => State::IN865(IN865::default()),
+            Region::IN865 => State::IN865(IN865::new_in865()),
             #[cfg(feature = "region-us915")]
             Region::US915 => State::US915(US915::default()),
         }


### PR DESCRIPTION
Right now we only have default frequencies, but later we can expand the custom frequency checks (ie upper limit for EU868 in some countries is actually 873MHz, instead of default). And there are also additional countries like Belarus which have restricted sections.

But eventually we can support these regions with code like this:

```rust
fn freq_validator(freq: u32) -> bool {
   (863_000_000...=873_000_000).contains(&freq)
}
let region = Configuration::new_with_frequencies(Region::EU868, freq_validator);
```