### PR TITLE
lora-phy: fix sx127x set_tx_rx_buffer_base_address function

### DIFF
--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -225,8 +225,10 @@ where
         if tx_base_addr > 255 || rx_base_addr > 255 {
             return Err(RadioError::InvalidBaseAddress(tx_base_addr, rx_base_addr));
         }
-        self.write_register(Register::RegFifoTxBaseAddr, tx_base_addr as u8).await?;
-        self.write_register(Register::RegFifoRxBaseAddr, rx_base_addr as u8).await
+        self.write_register(Register::RegFifoTxBaseAddr, tx_base_addr as u8)
+            .await?;
+        self.write_register(Register::RegFifoRxBaseAddr, rx_base_addr as u8)
+            .await
     }
 
     // Set parameters associated with power for a send operation.

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -225,8 +225,8 @@ where
         if tx_base_addr > 255 || rx_base_addr > 255 {
             return Err(RadioError::InvalidBaseAddress(tx_base_addr, rx_base_addr));
         }
-        self.write_register(Register::RegFifoTxBaseAddr, 0x00u8).await?;
-        self.write_register(Register::RegFifoRxBaseAddr, 0x00u8).await
+        self.write_register(Register::RegFifoTxBaseAddr, tx_base_addr as u8).await?;
+        self.write_register(Register::RegFifoRxBaseAddr, rx_base_addr as u8).await
     }
 
     // Set parameters associated with power for a send operation.


### PR DESCRIPTION
The previous function doesn't use the correct addresses, it instead uses the 0 base address, this works in the initial code since it's only set to 0 anyway, but breaks other code.