### PR TITLE
adjust tx power for sx1262 in the lowest range

### DIFF
--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -460,8 +460,10 @@ where
                     }
                     HIGH_POWER_MIN..=14 => {
                         self.set_pa_config(0x02, 0x02, DeviceSel::HighPowerPA).await?;
-                        // table indicates 14 dBm => txp = 22, therefore we add 8 to this range
-                        tx_params_power = txp as u8 + 8;
+                        // table indicates 14 dBm => txp = 22, therefore we should add 8 to this range
+                        // this however seems to be wrong when looking at the reference driver
+                        // https://github.com/STMicroelectronics/STM32CubeWL/blob/139e8d28bcec6af78dec8b52a9b9f9057868cc2e/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L675
+                        tx_params_power = txp as u8;
                     }
                     _ => {
                         unreachable!("Invalid output power value for high power PA!")


### PR DESCRIPTION
There is a problem with setting the tx power. I did a test by looping over a range of `-9..=22` and giving a pulse at each power level. The result should be linear but looks like this
![image](https://github.com/user-attachments/assets/03b32980-d09c-4302-9516-d9a220cb4a74)

After this change it looks like this:
![image](https://github.com/user-attachments/assets/36055059-c382-44ea-9bff-05fd25d9a2cf)

Still not completely linear but my device is not made for anything above 16dBm so the uneven result might be due to that.

I did also a test where I implemented this as suggested in the datasheet but the result was worse:
![image](https://github.com/user-attachments/assets/059ae6de-0b1c-4db1-9b62-82e16fcb7478)
```rs
                match txp {
                    22 => {
                        self.set_pa_config(0x04, 0x07, DeviceSel::HighPowerPA).await?;
                        tx_params_power = 22;
                    }
                    20 => {
                        self.set_pa_config(0x03, 0x05, DeviceSel::HighPowerPA).await?;
                        tx_params_power = 22;
                    }
                    17 => {
                        self.set_pa_config(0x02, 0x03, DeviceSel::HighPowerPA).await?;
                        tx_params_power = 22;
                    }
                    _ => {
                        self.set_pa_config(0x02, 0x02, DeviceSel::HighPowerPA).await?;
                        tx_params_power = txp;
                    }
                }
```
