### PR TITLE
Multicast: more fixes for MulticastGroupSetupDelete

### DIFF
--- a/lorawan-device/src/async_device/test/multicast.rs
+++ b/lorawan-device/src/async_device/test/multicast.rs
@@ -72,7 +72,6 @@ fn verify_multicast_setup_ans(
         let msg = msgs.next().unwrap();
         if let UplinkRemoteSetup::McGroupSetupAns(ans) = msg {
             assert_eq!(ans.mc_group_id_header(), 0x01);
-            assert_eq!(ans.mc_group_id_header(), 0x01);
         } else {
             panic!("Expected McGroupSetupAns");
         }
@@ -167,7 +166,7 @@ fn handle_regular_downlink_msg<const FCNT: u32>(
     rx_buffer: &mut [u8],
 ) -> usize {
     let mut phy = DataPayloadCreator::new(rx_buffer).unwrap();
-    phy.set_f_port(1); // Remote multicast setup port
+    phy.set_f_port(1); // a random fport that's not the multicast port
     phy.set_dev_addr(&[0; 4]);
     phy.set_uplink(false);
     phy.set_fcnt(FCNT);

--- a/lorawan-device/src/mac/multicast.rs
+++ b/lorawan-device/src/mac/multicast.rs
@@ -155,9 +155,12 @@ impl Multicast {
                 DownlinkRemoteSetup::McGroupDeleteReq(req) => {
                     let group_id = req.mc_group_id_header();
                     let mut ans = McGroupDeleteAnsCreator::new();
-                    ans.mc_group_id_header(group_id);
-                    ans.mc_group_undefined(self.sessions[group_id as usize].is_none());
-                    self.sessions[group_id as usize] = None;
+                    if self.sessions[group_id as usize].is_some() {
+                        ans.mc_group_id_header(group_id);
+                        self.sessions[group_id as usize] = None;
+                    } else {
+                        ans.mc_group_undefined(true);
+                    }
                     self.pending_uplinks.extend_from_slice(ans.build()).unwrap();
                 }
                 DownlinkRemoteSetup::McGroupStatusReq(r) => {

--- a/lorawan-encoding/src/multicast/mod.rs
+++ b/lorawan-encoding/src/multicast/mod.rs
@@ -86,7 +86,7 @@ impl McGroupDeleteAnsPayload<'_> {
         self.0[0] & 0b11
     }
     pub fn mc_group_undefined(&self) -> bool {
-        self.0[0] & 0b100 == 0
+        self.0[0] & 0b100 != 0
     }
 }
 
@@ -96,11 +96,12 @@ impl McGroupDeleteAnsCreator {
         self.data[1] |= mc_group_id_header & 0b11;
         self
     }
+
     pub fn mc_group_undefined(&mut self, mc_group_undefined: bool) -> &mut Self {
         if mc_group_undefined {
-            self.data[1] &= 0b1111_1011;
+            self.data[1] |= 0b100;
         } else {
-            self.data[1] |= 0b0000_0100;
+            self.data[1] &= 0b1111_1011;
         }
         self
     }


### PR DESCRIPTION
When receiving a McGroupDelete msg for a group that is undefined, we should answer with the undefined bit and NOT include the multicast group id.

Furthermore, there was a bug in the encoding of the McGroupDeleteReqAns undefined bit.