### PR TITLE
Make use of all ctrl pins in stm32wl examples

### DIFF
--- a/examples/stm32wl/src/bin/lora_lorawan.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan.rs
@@ -55,23 +55,20 @@ async fn main(_spawner: Spawner) {
     }
     let p = embassy_stm32::init(config);
 
-    // Set CTRL1 and CTRL3 for high-power transmission, while CTRL2 acts as an RF switch between tx and rx
-    let _ctrl1 = Output::new(p.PC4.degrade(), Level::Low, Speed::High);
-    let ctrl2 = Output::new(p.PC5.degrade(), Level::High, Speed::High);
-    let _ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
+    let ctrl1 = Output::new(p.PC4.degrade(), Level::Low, Speed::High);
+    let ctrl2 = Output::new(p.PC5.degrade(), Level::Low, Speed::High);
+    let ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
 
     let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
     let spi = SubghzSpiDevice(spi);
-
+    let use_high_power_pa = true;
     let config = sx126x::Config {
-        chip: Stm32wl {
-            use_high_power_pa: true,
-        },
+        chip: Stm32wl { use_high_power_pa },
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         rx_boost: false,
     };
-    let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
+    let iv = Stm32wlInterfaceVariant::new(Irqs, use_high_power_pa, Some(ctrl1), Some(ctrl2), Some(ctrl3)).unwrap();
     let lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();
 
     let radio: LorawanRadio<_, _, MAX_TX_POWER> = lora.into();

--- a/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
@@ -68,24 +68,21 @@ async fn main(spawner: Spawner) {
     }
     let p = embassy_stm32::init(config);
 
-    // Set CTRL1 and CTRL3 for high-power transmission, while CTRL2 acts as an RF switch between tx and rx
-    let _ctrl1 = Output::new(p.PC4.degrade(), Level::Low, Speed::High);
-    let ctrl2 = Output::new(p.PC5.degrade(), Level::High, Speed::High);
-    let _ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
+    let ctrl1 = Output::new(p.PC4.degrade(), Level::Low, Speed::High);
+    let ctrl2 = Output::new(p.PC5.degrade(), Level::Low, Speed::High);
+    let ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
 
     let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
     let spi = SubghzSpiDevice(spi);
-
+    let use_high_power_pa = true;
     let config = sx126x::Config {
-        chip: Stm32wl {
-            use_high_power_pa: true,
-        },
+        chip: Stm32wl { use_high_power_pa },
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         rx_boost: false,
     };
-    let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
-    let lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();
+    let iv = Stm32wlInterfaceVariant::new(Irqs, use_high_power_pa, Some(ctrl1), Some(ctrl2), Some(ctrl3)).unwrap();
+    let lora = LoRa::new(Sx126x::new(spi, iv, config), false, Delay).await.unwrap();
 
     let _lora_task = spawner.spawn(lora_task(lora, Rng::new(p.RNG, Irqs), CHANNEL.receiver()));
 

--- a/examples/stm32wl/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_send.rs
@@ -48,23 +48,20 @@ async fn main(_spawner: Spawner) {
     }
     let p = embassy_stm32::init(config);
 
-    // Set CTRL1 and CTRL3 for high-power transmission, while CTRL2 acts as an RF switch between tx and rx
-    let _ctrl1 = Output::new(p.PC4.degrade(), Level::Low, Speed::High);
-    let ctrl2 = Output::new(p.PC5.degrade(), Level::High, Speed::High);
-    let _ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
+    let ctrl1 = Output::new(p.PC4.degrade(), Level::Low, Speed::High);
+    let ctrl2 = Output::new(p.PC5.degrade(), Level::Low, Speed::High);
+    let ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
 
     let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
     let spi = SubghzSpiDevice(spi);
-
+    let use_high_power_pa = true;
     let config = sx126x::Config {
-        chip: Stm32wl {
-            use_high_power_pa: true,
-        },
+        chip: Stm32wl { use_high_power_pa },
         tcxo_ctrl: Some(TcxoCtrlVoltage::Ctrl1V7),
         use_dcdc: true,
         rx_boost: false,
     };
-    let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
+    let iv = Stm32wlInterfaceVariant::new(Irqs, use_high_power_pa, Some(ctrl1), Some(ctrl2), Some(ctrl3)).unwrap();
     let mut lora = LoRa::new(Sx126x::new(spi, iv, config), false, Delay).await.unwrap();
 
     let mdltn_params = {


### PR DESCRIPTION
The example does not work for stm32wl-nucleo. It is not stated which board this example is for but the pins corresponds to the nucleo. The nucleo board needs to switch between rx and tx by alternating between two pins. Just using one does not work.

It was also not possible to use low_power_pa before so I added that to the switch too. Otherwise if somebody tries to use the low power PA without modifying the switch they will get in to trouble.