### PR TITLE
Migrate DR to lorawan::types

### DIFF
--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -28,7 +28,6 @@ rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", default-features = false, features = [
     "derive",
 ], optional = true }
-seq-macro = "0.3.5"
 document-features = "0.2.10"
 embassy-time = { version = ">=0.3, <0.5", optional = true }
 

--- a/lorawan-device/src/async_device/test/multicast.rs
+++ b/lorawan-device/src/async_device/test/multicast.rs
@@ -7,7 +7,6 @@ use lorawan::multicast::{
     UplinkRemoteSetup,
 };
 use lorawan::parser::{DataHeader, DataPayload, FRMPayload, PhyPayload};
-use std::time::Duration;
 
 fn handle_multicast_setup_req(
     _uplink: Option<Uplink>,

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -15,21 +15,22 @@ pub use au915::AU915;
 #[cfg(feature = "region-us915")]
 pub use us915::US915;
 
-seq_macro::seq!(
-    N in 1..=8 {
-        /// Subband definitions used to bias the join process for regions with fixed channel plans (ie: [`US915`], [`AU915`]).
-        ///
-        /// Each Subband holds 8 channels. eg: subband 1 contains: channels 0-7, subband 2: channels 8-15, etc.
-        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[repr(usize)]
-        pub enum Subband {
-            #(
-                _~N = N,
-            )*
-        }
-    }
-);
+/// Subband definitions used to bias the join process for regions with fixed channel plans (ie: [`US915`], [`AU915`]).
+///
+/// Each Subband holds 8 channels. eg: subband 1 contains: channels 0-7, subband 2: channels 8-15, etc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(usize)]
+pub enum Subband {
+    _1 = 1,
+    _2 = 2,
+    _3 = 3,
+    _4 = 4,
+    _5 = 5,
+    _6 = 6,
+    _7 = 7,
+    _8 = 8,
+}
 
 impl From<Subband> for usize {
     fn from(value: Subband) -> Self {

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -7,6 +7,8 @@ use crate::mac::{Frame, Window};
 pub(crate) mod constants;
 pub(crate) use crate::radio::*;
 use constants::*;
+// For backward compatibility
+pub use lorawan::types::DR;
 
 #[cfg(not(any(
     feature = "region-as923-1",
@@ -84,50 +86,6 @@ pub(crate) trait ChannelRegion {
 /// fine-tuning, like for example [`US915`] or [`AU915`].
 pub struct Configuration {
     state: State,
-}
-
-seq_macro::seq!(
-    N in 0..=15 {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-        #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
-        #[repr(u8)]
-        /// A restricted data rate type that exposes the number of variants to only what _may_ be
-        /// potentially be possible.
-        ///
-        /// Note that not all data rates are valid in all regions.
-        pub enum DR {
-            #(
-                _~N = N,
-            )*
-        }
-    }
-);
-
-impl TryFrom<u8> for DR {
-    type Error = core::convert::Infallible;
-
-    fn try_from(v: u8) -> Result<Self, Self::Error> {
-        let dr = match v & 0xf {
-            0 => DR::_0,
-            1 => DR::_1,
-            2 => DR::_2,
-            3 => DR::_3,
-            4 => DR::_4,
-            5 => DR::_5,
-            6 => DR::_6,
-            7 => DR::_7,
-            8 => DR::_8,
-            9 => DR::_9,
-            10 => DR::_10,
-            11 => DR::_11,
-            12 => DR::_12,
-            13 => DR::_13,
-            14 => DR::_14,
-            15 => DR::_15,
-            _ => unreachable!(),
-        };
-        Ok(dr)
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/lorawan-encoding/src/types.rs
+++ b/lorawan-encoding/src/types.rs
@@ -143,6 +143,58 @@ impl<const N: usize> AsRef<[u8]> for ChannelMask<N> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[repr(u8)]
+/// `DR` is a number from `0..=15` to indicate region-specific DataRate.
+/// Value `0xf` (decimal 15) has special meaning of no-op to continue with
+/// currently active setting.
+pub enum DR {
+    _0 = 0,
+    _1 = 1,
+    _2 = 2,
+    _3 = 3,
+    _4 = 4,
+    _5 = 5,
+    _6 = 6,
+    _7 = 7,
+    _8 = 8,
+    _9 = 9,
+    _10 = 10,
+    _11 = 11,
+    _12 = 12,
+    _13 = 13,
+    _14 = 14,
+    _15 = 15,
+}
+
+impl TryFrom<u8> for DR {
+    type Error = core::convert::Infallible;
+
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        let dr = match v & 0xf {
+            0 => DR::_0,
+            1 => DR::_1,
+            2 => DR::_2,
+            3 => DR::_3,
+            4 => DR::_4,
+            5 => DR::_5,
+            6 => DR::_6,
+            7 => DR::_7,
+            8 => DR::_8,
+            9 => DR::_9,
+            10 => DR::_10,
+            11 => DR::_11,
+            12 => DR::_12,
+            13 => DR::_13,
+            14 => DR::_14,
+            15 => DR::_15,
+            _ => unreachable!(),
+        };
+        Ok(dr)
+    }
+}
+
 /// DataRateRange represents LoRaWAN DataRateRange.
 #[derive(Debug, PartialEq, Eq)]
 pub struct DataRateRange(u8);


### PR DESCRIPTION
My future intention is to add a new constructor to DataRateRange: `new_with_min_max()`. This will eventually used for in session to deal with NewChannelReq. But in order to support new need to store the dataraterange as well.
Currently we don't support adding new channels and as existing join channels are all using DR0..DR5 things just happen to work by chance.. :)