### PR TITLE
Implement support for NewChannelReq MAC command

### DIFF
--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -363,7 +363,7 @@ impl Session {
                     let (ack_f, ack_d) = region.handle_new_channel(
                         payload.channel_index(),
                         payload.frequency().value(),
-                        payload.data_rate_range(),
+                        payload.data_rate_range().ok(),
                     );
 
                     let mut cmd = NewChannelAnsCreator::new();

--- a/lorawan-device/src/region/constants.rs
+++ b/lorawan-device/src/region/constants.rs
@@ -12,6 +12,7 @@ pub(crate) const ACK_TIMEOUT: usize = 2; // random delay between 1 and 3 seconds
 
 // Although there are 16 possible slots, last one is not defined as Datarate
 pub(crate) const NUM_DATARATES: u8 = 15;
+pub(crate) const NUM_CHANNELS_DYNAMIC: u8 = 16;
 
 pub(crate) const DEFAULT_BANDWIDTH: Bandwidth = Bandwidth::_125KHz;
 pub(crate) const DEFAULT_SPREADING_FACTOR: SpreadingFactor = SpreadingFactor::_7;

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -52,7 +52,7 @@ impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
 impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion
     for AS923Region<DEFAULT_RX2, OFFSET>
 {
-    fn num_join_channels() -> u8 {
+    fn join_channels() -> u8 {
         2
     }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -9,10 +9,10 @@ use super::*;
 
 const MAX_EIRP: u8 = 16;
 
-pub(crate) type AS923_1 = DynamicChannelPlan<2, AS923Region<923_200_000, 0>>;
-pub(crate) type AS923_2 = DynamicChannelPlan<2, AS923Region<921_400_000, 1800000>>;
-pub(crate) type AS923_3 = DynamicChannelPlan<2, AS923Region<916_500_000, 6600000>>;
-pub(crate) type AS923_4 = DynamicChannelPlan<2, AS923Region<917_300_000, 5900000>>;
+pub(crate) type AS923_1 = DynamicChannelPlan<AS923Region<923_200_000, 0>>;
+pub(crate) type AS923_2 = DynamicChannelPlan<AS923Region<921_400_000, 1800000>>;
+pub(crate) type AS923_3 = DynamicChannelPlan<AS923Region<916_500_000, 6600000>>;
+pub(crate) type AS923_4 = DynamicChannelPlan<AS923Region<917_300_000, 5900000>>;
 
 #[derive(Default, Clone)]
 #[allow(clippy::upper_case_acronyms)]
@@ -39,9 +39,7 @@ fn as924_4_freq_check(f: u32) -> bool {
     (917_000_000..=920_000_000).contains(&f)
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion>
-    DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
-{
+impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
     pub fn new_as924() -> Self {
         Self::new(as924_generic_freq_check)
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -7,12 +7,12 @@
 /// Current status: DR0..DR6 is supported
 use super::*;
 
-const JOIN_CHANNELS: [u32; 2] = [923200000, 923200000];
+const JOIN_CHANNELS: [u32; 2] = [923200000, 923400000];
 const MAX_EIRP: u8 = 16;
 
 pub(crate) type AS923_1 = DynamicChannelPlan<2, AS923Region<923_200_000, 0>>;
 pub(crate) type AS923_2 = DynamicChannelPlan<2, AS923Region<921_400_000, 1800000>>;
-pub(crate) type AS923_3 = DynamicChannelPlan<2, AS923Region<916_600_000, 6600000>>;
+pub(crate) type AS923_3 = DynamicChannelPlan<2, AS923Region<916_500_000, 6600000>>;
 pub(crate) type AS923_4 = DynamicChannelPlan<2, AS923Region<917_300_000, 5900000>>;
 
 #[derive(Default, Clone)]
@@ -56,7 +56,7 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2>
     for AS923Region<DEFAULT_RX2, OFFSET>
 {
     fn join_channels() -> [u32; 2] {
-        [JOIN_CHANNELS[0] + OFFSET, JOIN_CHANNELS[1] + OFFSET]
+        [JOIN_CHANNELS[0] - OFFSET, JOIN_CHANNELS[1] - OFFSET]
     }
 
     fn get_default_rx2() -> u32 {

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -39,7 +39,7 @@ fn as924_4_freq_check(f: u32) -> bool {
     (917_000_000..=920_000_000).contains(&f)
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
+impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion>
     DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
 {
     pub fn new_as924() -> Self {
@@ -51,7 +51,7 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
     }
 }
 
-impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2>
+impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion
     for AS923Region<DEFAULT_RX2, OFFSET>
 {
     fn num_join_channels() -> u8 {

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -7,7 +7,6 @@
 /// Current status: DR0..DR6 is supported
 use super::*;
 
-const JOIN_CHANNELS: [u32; 2] = [923200000, 923400000];
 const MAX_EIRP: u8 = 16;
 
 pub(crate) type AS923_1 = DynamicChannelPlan<2, AS923Region<923_200_000, 0>>;
@@ -55,10 +54,6 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
 impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2>
     for AS923Region<DEFAULT_RX2, OFFSET>
 {
-    fn join_channels() -> [u32; 2] {
-        [JOIN_CHANNELS[0] - OFFSET, JOIN_CHANNELS[1] - OFFSET]
-    }
-
     fn num_join_channels() -> u8 {
         2
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -59,6 +59,10 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2>
         [JOIN_CHANNELS[0] - OFFSET, JOIN_CHANNELS[1] - OFFSET]
     }
 
+    fn num_join_channels() -> u8 {
+        2
+    }
+
     fn get_default_rx2() -> u32 {
         DEFAULT_RX2
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -62,6 +62,14 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2>
     fn get_default_rx2() -> u32 {
         DEFAULT_RX2
     }
+
+    // Although Network gateways SHALL always listen on following frequencies
+    // with DR0..=DR5, the default Join-Request Data Rate SHALL utilize DR2..=DR5
+    // (SF10/125 kHz – SF7/125 kHz).
+    fn init_channels(channels: &mut ChannelPlan) {
+        channels[0] = Some(Channel::new(923200000 - OFFSET, DR::_2, DR::_5));
+        channels[1] = Some(Channel::new(923400000 - OFFSET, DR::_2, DR::_5));
+    }
 }
 
 use super::{Bandwidth, Datarate, SpreadingFactor};

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -9,7 +9,7 @@ use super::*;
 
 const MAX_EIRP: u8 = 16;
 
-pub(crate) type EU433 = DynamicChannelPlan<3, EU433Region>;
+pub(crate) type EU433 = DynamicChannelPlan<EU433Region>;
 
 #[derive(Default, Clone)]
 #[allow(clippy::upper_case_acronyms)]
@@ -19,9 +19,7 @@ fn eu433_freq_check(f: u32) -> bool {
     (433_050_000..=434_790_000).contains(&f)
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion>
-    DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
-{
+impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
     pub fn new_eu433() -> Self {
         Self::new(eu433_freq_check)
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -46,6 +46,10 @@ impl DynamicChannelRegion<3> for EU433Region {
         JOIN_CHANNELS
     }
 
+    fn num_join_channels() -> u8 {
+        3
+    }
+
     fn get_default_rx2() -> u32 {
         434_665_000
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -19,7 +19,7 @@ fn eu433_freq_check(f: u32) -> bool {
     (433_050_000..=434_790_000).contains(&f)
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
+impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion>
     DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
 {
     pub fn new_eu433() -> Self {
@@ -40,7 +40,7 @@ impl ChannelRegion for EU433Region {
     }
 }
 
-impl DynamicChannelRegion<3> for EU433Region {
+impl DynamicChannelRegion for EU433Region {
     fn num_join_channels() -> u8 {
         3
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -7,7 +7,6 @@
 /// Current status: DR7 (FSK) is unimplemented
 use super::*;
 
-const JOIN_CHANNELS: [u32; 3] = [433_175_000, 433_375_000, 433_575_000];
 const MAX_EIRP: u8 = 16;
 
 pub(crate) type EU433 = DynamicChannelPlan<3, EU433Region>;
@@ -42,10 +41,6 @@ impl ChannelRegion for EU433Region {
 }
 
 impl DynamicChannelRegion<3> for EU433Region {
-    fn join_channels() -> [u32; 3] {
-        JOIN_CHANNELS
-    }
-
     fn num_join_channels() -> u8 {
         3
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -49,6 +49,12 @@ impl DynamicChannelRegion<3> for EU433Region {
     fn get_default_rx2() -> u32 {
         434_665_000
     }
+
+    fn init_channels(channels: &mut ChannelPlan) {
+        channels[0] = Some(Channel::new(433_175_000, DR::_0, DR::_5));
+        channels[1] = Some(Channel::new(433_375_000, DR::_0, DR::_5));
+        channels[2] = Some(Channel::new(433_575_000, DR::_0, DR::_5));
+    }
 }
 
 use super::{Bandwidth, Datarate, SpreadingFactor};

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -39,7 +39,7 @@ impl ChannelRegion for EU433Region {
 }
 
 impl DynamicChannelRegion for EU433Region {
-    fn num_join_channels() -> u8 {
+    fn join_channels() -> u8 {
         3
     }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -20,7 +20,7 @@ fn eu868_freq_check(f: u32) -> bool {
     (863_000_000..=870_000_000).contains(&f)
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
+impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion>
     DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
 {
     pub fn new_eu868() -> Self {
@@ -41,7 +41,7 @@ impl ChannelRegion for EU868Region {
     }
 }
 
-impl DynamicChannelRegion<3> for EU868Region {
+impl DynamicChannelRegion for EU868Region {
     fn num_join_channels() -> u8 {
         3
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -8,7 +8,6 @@
 /// Current status: DR0..DR5 (minimum set is supported)
 use super::*;
 
-const JOIN_CHANNELS: [u32; 3] = [868_100_000, 868_300_000, 868_500_000];
 const MAX_EIRP: u8 = 16;
 
 pub(crate) type EU868 = DynamicChannelPlan<3, EU868Region>;
@@ -43,10 +42,6 @@ impl ChannelRegion for EU868Region {
 }
 
 impl DynamicChannelRegion<3> for EU868Region {
-    fn join_channels() -> [u32; 3] {
-        JOIN_CHANNELS
-    }
-
     fn num_join_channels() -> u8 {
         3
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -10,7 +10,7 @@ use super::*;
 
 const MAX_EIRP: u8 = 16;
 
-pub(crate) type EU868 = DynamicChannelPlan<3, EU868Region>;
+pub(crate) type EU868 = DynamicChannelPlan<EU868Region>;
 
 #[derive(Default, Clone)]
 #[allow(clippy::upper_case_acronyms)]
@@ -20,9 +20,7 @@ fn eu868_freq_check(f: u32) -> bool {
     (863_000_000..=870_000_000).contains(&f)
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion>
-    DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
-{
+impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
     pub fn new_eu868() -> Self {
         Self::new(eu868_freq_check)
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -40,7 +40,7 @@ impl ChannelRegion for EU868Region {
 }
 
 impl DynamicChannelRegion for EU868Region {
-    fn num_join_channels() -> u8 {
+    fn join_channels() -> u8 {
         3
     }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -47,6 +47,10 @@ impl DynamicChannelRegion<3> for EU868Region {
         JOIN_CHANNELS
     }
 
+    fn num_join_channels() -> u8 {
+        3
+    }
+
     fn get_default_rx2() -> u32 {
         869_525_000
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -50,6 +50,12 @@ impl DynamicChannelRegion<3> for EU868Region {
     fn get_default_rx2() -> u32 {
         869_525_000
     }
+
+    fn init_channels(channels: &mut ChannelPlan) {
+        channels[0] = Some(Channel::new(868_100_000, DR::_0, DR::_5));
+        channels[1] = Some(Channel::new(868_300_000, DR::_0, DR::_5));
+        channels[2] = Some(Channel::new(868_500_000, DR::_0, DR::_5));
+    }
 }
 
 use super::{Bandwidth, Datarate, SpreadingFactor};

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -38,7 +38,7 @@ impl ChannelRegion for IN865Region {
 }
 
 impl DynamicChannelRegion for IN865Region {
-    fn num_join_channels() -> u8 {
+    fn join_channels() -> u8 {
         3
     }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -7,7 +7,6 @@
 /// Current status: DR0..DR5 is supported
 use super::*;
 
-const JOIN_CHANNELS: [u32; 3] = [865_062_500, 865_402_500, 865_985_000];
 const MAX_EIRP: u8 = 30;
 
 pub(crate) type IN865 = DynamicChannelPlan<3, IN865Region>;
@@ -41,10 +40,6 @@ impl ChannelRegion for IN865Region {
 }
 
 impl DynamicChannelRegion<3> for IN865Region {
-    fn join_channels() -> [u32; 3] {
-        JOIN_CHANNELS
-    }
-
     fn num_join_channels() -> u8 {
         3
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -9,7 +9,7 @@ use super::*;
 
 const MAX_EIRP: u8 = 30;
 
-pub(crate) type IN865 = DynamicChannelPlan<3, IN865Region>;
+pub(crate) type IN865 = DynamicChannelPlan<IN865Region>;
 
 #[derive(Default, Clone)]
 pub struct IN865Region;
@@ -18,9 +18,7 @@ fn in865_freq_check(f: u32) -> bool {
     (865_000_000..=867_000_000).contains(&f)
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion>
-    DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
-{
+impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
     pub fn new_in865() -> Self {
         Self::new(in865_freq_check)
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -48,6 +48,12 @@ impl DynamicChannelRegion<3> for IN865Region {
     fn get_default_rx2() -> u32 {
         866_550_000
     }
+
+    fn init_channels(channels: &mut ChannelPlan) {
+        channels[0] = Some(Channel::new(865_062_500, DR::_0, DR::_5));
+        channels[1] = Some(Channel::new(865_402_500, DR::_0, DR::_5));
+        channels[2] = Some(Channel::new(865_985_000, DR::_0, DR::_5));
+    }
 }
 
 use super::{Bandwidth, Datarate, SpreadingFactor};

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -18,7 +18,7 @@ fn in865_freq_check(f: u32) -> bool {
     (865_000_000..=867_000_000).contains(&f)
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
+impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion>
     DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
 {
     pub fn new_in865() -> Self {
@@ -39,7 +39,7 @@ impl ChannelRegion for IN865Region {
     }
 }
 
-impl DynamicChannelRegion<3> for IN865Region {
+impl DynamicChannelRegion for IN865Region {
     fn num_join_channels() -> u8 {
         3
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -45,6 +45,10 @@ impl DynamicChannelRegion<3> for IN865Region {
         JOIN_CHANNELS
     }
 
+    fn num_join_channels() -> u8 {
+        3
+    }
+
     fn get_default_rx2() -> u32 {
         866_550_000
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -135,7 +135,7 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
                 // CfList of Type 0 may contain up to 5 frequencies, which define
                 // channels J to (J+4). Data rates for these channels is DR0..=DR5
                 for (n, freq) in cf_list.iter().enumerate() {
-                    let index = NUM_JOIN_CHANNELS + n;
+                    let index = R::num_join_channels() as usize + n;
                     let value = freq.value();
                     // unused channels are set to 0
                     if value == 0 {
@@ -202,7 +202,7 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
                 let mut channel = (rng.next_u32() & 0b111) as u8;
                 // keep sampling until we select a join channel depending
                 // on the frequency plan
-                while channel as usize >= NUM_JOIN_CHANNELS {
+                while channel >= R::num_join_channels() {
                     channel = (rng.next_u32() & 0b111) as u8;
                 }
                 self.last_tx_channel = channel;
@@ -257,13 +257,12 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
 
     fn handle_new_channel(&mut self, index: u8, freq: u32, _: DataRateRange) -> (bool, bool) {
         // Join channels are readonly - these cannot be modified!
-        let index = index as usize;
-        if index < NUM_JOIN_CHANNELS {
+        if index < R::num_join_channels() {
             return (false, false);
         }
         // Disable channel if frequency is 0
-        if freq == 0 && index < self.channels.len() {
-            self.channels[index] = None;
+        if freq == 0 && (index as usize) < self.channels.len() {
+            self.channels[index as usize] = None;
             return (true, true);
         }
         // TODO: Implement frequency and data range checks to define new channels

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -117,6 +117,7 @@ pub(crate) trait DynamicChannelRegion<const NUM_JOIN_CHANNELS: usize>:
     ChannelRegion
 {
     fn join_channels() -> [u32; NUM_JOIN_CHANNELS];
+    fn num_join_channels() -> u8;
     fn init_channels(channels: &mut ChannelPlan);
     fn get_default_rx2() -> u32;
 }
@@ -134,7 +135,7 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
                 // CfList of Type 0 may contain up to 5 frequencies, which define
                 // channels J to (J+4). Data rates for these channels is DR0..=DR5
                 for (n, freq) in cf_list.iter().enumerate() {
-                    let index = NUM_JOIN_CHANNELS - 1 + n;
+                    let index = NUM_JOIN_CHANNELS + n;
                     let value = freq.value();
                     // unused channels are set to 0
                     if value == 0 {

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -109,7 +109,7 @@ impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
 }
 
 pub(crate) trait DynamicChannelRegion: ChannelRegion {
-    fn num_join_channels() -> u8;
+    fn join_channels() -> u8;
     fn init_channels(channels: &mut ChannelPlan);
     fn get_default_rx2() -> u32;
 }
@@ -125,7 +125,7 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
                 // CfList of Type 0 may contain up to 5 frequencies, which define
                 // channels J to (J+4). Data rates for these channels is DR0..=DR5
                 for (n, freq) in cf_list.iter().enumerate() {
-                    let index = R::num_join_channels() as usize + n;
+                    let index = R::join_channels() as usize + n;
                     let value = freq.value();
                     // unused channels are set to 0
                     if value == 0 {
@@ -191,7 +191,7 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
                 // There are at most 3 join channels in dynamic regions,
                 // keep sampling until we get a valid channel.
                 let mut index = (rng.next_u32() & 0b11) as u8;
-                while index >= R::num_join_channels() {
+                while index >= R::join_channels() {
                     index = (rng.next_u32() & 0b11) as u8;
                 }
                 self.last_tx_channel = index;
@@ -246,7 +246,7 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
 
     fn handle_new_channel(&mut self, index: u8, freq: u32, _: DataRateRange) -> (bool, bool) {
         // Join channels are readonly - these cannot be modified!
-        if index < R::num_join_channels() {
+        if index < R::join_channels() {
             return (false, false);
         }
         // Disable channel if frequency is 0

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -47,10 +47,7 @@ impl Channel {
 type ChannelPlan = [Option<Channel>; NUM_CHANNELS_DYNAMIC as usize];
 
 #[derive(Clone)]
-pub(crate) struct DynamicChannelPlan<
-    const NUM_JOIN_CHANNELS: usize,
-    R: DynamicChannelRegion<NUM_JOIN_CHANNELS>,
-> {
+pub(crate) struct DynamicChannelPlan<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion> {
     channels: ChannelPlan,
     channel_mask: ChannelMask<9>,
     last_tx_channel: u8,
@@ -61,7 +58,7 @@ pub(crate) struct DynamicChannelPlan<
     frequency_valid: fn(u32) -> bool,
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
+impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion>
     DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
 {
     fn new(freq_fn: fn(u32) -> bool) -> Self {
@@ -113,15 +110,13 @@ impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>>
     }
 }
 
-pub(crate) trait DynamicChannelRegion<const NUM_JOIN_CHANNELS: usize>:
-    ChannelRegion
-{
+pub(crate) trait DynamicChannelRegion: ChannelRegion {
     fn num_join_channels() -> u8;
     fn init_channels(channels: &mut ChannelPlan);
     fn get_default_rx2() -> u32;
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion<NUM_JOIN_CHANNELS>> RegionHandler
+impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion> RegionHandler
     for DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
 {
     fn process_join_accept<T: AsRef<[u8]>, C>(

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -47,7 +47,7 @@ impl Channel {
 type ChannelPlan = [Option<Channel>; NUM_CHANNELS_DYNAMIC as usize];
 
 #[derive(Clone)]
-pub(crate) struct DynamicChannelPlan<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion> {
+pub(crate) struct DynamicChannelPlan<R: DynamicChannelRegion> {
     channels: ChannelPlan,
     channel_mask: ChannelMask<9>,
     last_tx_channel: u8,
@@ -58,9 +58,7 @@ pub(crate) struct DynamicChannelPlan<const NUM_JOIN_CHANNELS: usize, R: DynamicC
     frequency_valid: fn(u32) -> bool,
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion>
-    DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
-{
+impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
     fn new(freq_fn: fn(u32) -> bool) -> Self {
         let mut channels = [None; NUM_CHANNELS_DYNAMIC as usize];
         R::init_channels(&mut channels);
@@ -116,9 +114,7 @@ pub(crate) trait DynamicChannelRegion: ChannelRegion {
     fn get_default_rx2() -> u32;
 }
 
-impl<const NUM_JOIN_CHANNELS: usize, R: DynamicChannelRegion> RegionHandler
-    for DynamicChannelPlan<NUM_JOIN_CHANNELS, R>
-{
+impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
     fn process_join_accept<T: AsRef<[u8]>, C>(
         &mut self,
         join_accept: &DecryptedJoinAcceptPayload<T, C>,

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -232,7 +232,7 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
         true
     }
 
-    fn handle_new_channel(&mut self, _: u8, _: u32, _: DataRateRange) -> (bool, bool) {
+    fn handle_new_channel(&mut self, _: u8, _: u32, _: Option<DataRateRange>) -> (bool, bool) {
         unreachable!()
     }
 }

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -475,7 +475,7 @@ impl Configuration {
         &mut self,
         index: u8,
         freq: u32,
-        data_rates: DataRateRange,
+        data_rates: Option<DataRateRange>,
     ) -> (bool, bool) {
         mut_region_dispatch!(self, handle_new_channel, index, freq, data_rates)
     }
@@ -528,7 +528,7 @@ pub(crate) trait RegionHandler {
         &mut self,
         index: u8,
         freq: u32,
-        data_rates: DataRateRange,
+        data_rates: Option<DataRateRange>,
     ) -> (bool, bool);
 
     fn get_default_datarate(&self) -> DR {

--- a/lorawan-encoding/src/maccommands.rs
+++ b/lorawan-encoding/src/maccommands.rs
@@ -372,8 +372,8 @@ impl NewChannelReqPayload<'_> {
     }
 
     /// The data rate range specifies allowed data rates for the new or modified channel.
-    pub fn data_rate_range(&self) -> DataRateRange {
-        DataRateRange::new_from_raw(self.0[4])
+    pub fn data_rate_range(&self) -> Result<DataRateRange, Error> {
+        DataRateRange::new(self.0[4])
     }
 }
 

--- a/lorawan-encoding/src/types.rs
+++ b/lorawan-encoding/src/types.rs
@@ -196,7 +196,7 @@ impl TryFrom<u8> for DR {
 }
 
 /// DataRateRange represents LoRaWAN DataRateRange.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DataRateRange(u8);
 
 impl DataRateRange {
@@ -210,6 +210,11 @@ impl DataRateRange {
         Self::can_build_from(byte)?;
 
         Ok(Self::new_from_raw(byte))
+    }
+
+    /// Constructs a new DataRateRange from lower and upper bounds (both inclusive)
+    pub fn new_range(min: DR, max: DR) -> Self {
+        DataRateRange(((max as u8) << 4) | min as u8)
     }
 
     /// Check if the byte can be used to create DataRateRange.

--- a/lorawan-encoding/tests/maccommands.rs
+++ b/lorawan-encoding/tests/maccommands.rs
@@ -163,7 +163,7 @@ fn test_new_channel_req() {
         5,
         (channel_index, 3),
         (frequency, Frequency::new_from_raw(&data[1..4])),
-        (data_rate_range, DataRateRange::new_from_raw(data[4])),
+        (data_rate_range, DataRateRange::new(data[4])),
     );
 }
 


### PR DESCRIPTION
* Introduce `Channel(frequency, dataraterange)` to keep track of each channel's supported data rates
* Refactor DynamicChannelRegion to use single 16 member array for channels. This allows us to get rid of generics in Dynamic region's data types
* **API break:** Introduce error handling to NewChannelReq's `data_rate_range()` getter.

And finally plug in the NewChannelReq support - with these changes we now pass `TP_A_EU868_ED_MAC_104_BV_006` testcase: **NewChannelReq MAC command for Dynamic Channel plan devices only**.

Only tested with EU868 for now, as this test takes ~32 minutes to complete...
