### PR TITLE
Set payload length correctly for SX127x Variant

### DIFF
--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -292,6 +292,10 @@ where
 
         C::set_packet_params(self, pkt_params).await?;
 
+        // Set the expected packet recieve size
+        self.write_register(Register::RegPayloadLength, pkt_params.payload_length)
+            .await?;
+
         // IQ inversion:
         // RegInvertiq - [0x33]
         // [6] - InvertIQRX
@@ -358,7 +362,6 @@ where
         self.write_register(Register::RegLna, lna_gain).await?;
 
         self.write_register(Register::RegFifoAddrPtr, 0x00u8).await?;
-        self.write_register(Register::RegPayloadLength, 0xffu8).await?;
 
         self.write_register(Register::RegOpMode, mode.value()).await
     }

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -292,9 +292,11 @@ where
 
         C::set_packet_params(self, pkt_params).await?;
 
-        // Set the expected packet receive size
-        self.write_register(Register::RegPayloadLength, pkt_params.payload_length)
-            .await?;
+        if pkt_params.implicit_header {
+            // Set the expected packet receive size, which is only applicable for implicit header mode
+            self.write_register(Register::RegPayloadLength, pkt_params.payload_length)
+                .await?;
+        }
 
         // IQ inversion:
         // RegInvertiq - [0x33]

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -292,7 +292,7 @@ where
 
         C::set_packet_params(self, pkt_params).await?;
 
-        // Set the expected packet recieve size
+        // Set the expected packet receive size
         self.write_register(Register::RegPayloadLength, pkt_params.payload_length)
             .await?;
 


### PR DESCRIPTION
Currently on the SX127x variant the payload length is set to 255 (0xff), causing PayloadSizeMismatch errors which this fixes