### PR TITLE
Add experimental feature to lorawan-device

### DIFF
--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -77,6 +77,9 @@ multicast = []
 ## Enable [`serde`](https://docs.rs/serde/latest/serde/) serialization/deserialization for data structures.
 serde = ["dep:serde", "lorawan/serde"]
 
+## Experimental (For testing WIP MAC-commands)
+experimental = []
+
 ## Enable support for AS923-1 region (by default all regions are enabled).
 region-as923-1 = []
 ## Enable support for AS923-2 region (by default all regions are enabled).

--- a/lorawan-device/src/async_device/test/maccommands.rs
+++ b/lorawan-device/src/async_device/test/maccommands.rs
@@ -200,9 +200,21 @@ async fn rxparamsetup_eu868() {
     // RX1
     timer.fire_most_recent().await;
     radio.handle_timeout().await;
+    // TODO: Check for RX1 data rate once RX1DROffset is implemented
+    // let rx_conf = radio.get_rxconfig().await.unwrap();
+    // assert_eq!(rx_conf.rf.bb.sf, SpreadingFactor::..);
+    // assert_eq!(rx_conf.rf.bb.bw, Bandwidth::..);
     // RX2
     timer.fire_most_recent().await;
     radio.handle_timeout().await;
+    let rx_conf = radio.get_rxconfig().await.unwrap();
+
+    assert_eq!(rx_conf.rf.frequency, 868525000);
+    // TODO: Test that rx2 data rate override works
+    // SF10BW125
+    // assert_eq!(rx_conf.rf.bb.sf, SpreadingFactor::_10);
+    // assert_eq!(rx_conf.rf.bb.bw, Bandwidth::_125KHz);
+
     // RxComplete (no answer)
     assert!(*send_await_complete.lock().await);
 

--- a/lorawan-device/src/async_device/test/maccommands.rs
+++ b/lorawan-device/src/async_device/test/maccommands.rs
@@ -153,7 +153,7 @@ async fn newchannelreq_fixed_region_ignore() {
 }
 
 #[tokio::test]
-#[cfg(feature = "region-eu868")]
+#[cfg(all(feature = "region-eu868", feature = "experimental"))]
 async fn rxparamsetup_eu868() {
     // RXParamSetupAns command SHALL be added in the FOpts field
     // (if FPort is either missing or >0) or in the FRMPayload field (if FPort=0)
@@ -297,6 +297,7 @@ async fn rxparamsetup_eu868() {
 }
 
 #[tokio::test]
+#[cfg(all(feature = "region-us915", feature = "experimental"))]
 // TODO: Finalize RXParamSetupReq
 async fn maccommands_in_frmpayload() {
     fn frmpayload_maccommands(

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -376,6 +376,7 @@ impl Session {
                     cmd.set_channel_frequency_ack(ack_f).set_data_rate_range_ack(ack_d);
                     self.uplink.add_mac_command(cmd);
                 }
+                #[cfg(feature = "experimental")]
                 RXParamSetupReq(payload) => {
                     let freq = payload.frequency().value();
                     let freq_ack = region.frequency_valid(freq);


### PR DESCRIPTION
Some time ago I half-implemened support for `RXParamSetupReq` MAC command, but there's still some work left. Therefore hide it behind `experimental` feature flag.