### PR TITLE
Fix doc comment in set_tx_power_and_ramp_time: remove unused tx_boosted_if_possible line

### DIFF
--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -396,7 +396,6 @@ where
     // Set parameters associated with power for a send operation. Currently, over current protection (OCP) uses the default set automatically after set_pa_config()
     //   output_power            desired RF output power (dBm)
     //   mdltn_params            needed for a power vs channel frequency validation
-    //   tx_boosted_if_possible  not pertinent for sx126x
     //   is_tx_prep              indicates which ramp up time to use
     async fn set_tx_power_and_ramp_time(
         &mut self,

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -234,7 +234,6 @@ where
     // Set parameters associated with power for a send operation.
     //   p_out                   desired RF output power (dBm)
     //   mdltn_params            needed for a power vs channel frequency validation
-    //   tx_boosted_if_possible  determine if transmit boost is requested
     //   is_tx_prep              indicates which ramp up time to use
     async fn set_tx_power_and_ramp_time(
         &mut self,


### PR DESCRIPTION
The function comment for `set_tx_power_and_ramp_time` lists `tx_boosted_if_possible` as a parameter, but this parameter is not present in the function signature. This appears to be a leftover from an earlier version.

This PR removes the line to avoid confusion and keep the documentation accurate.

No functional changes.