### PR TITLE
Add basic stub for LinkCheckReq/LinkCheckAns MAC command

### DIFF
--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -563,6 +563,11 @@ where
         match response {
             mac::Response::NoUpdate => Ok(None),
             #[cfg(feature = "certification")]
+            mac::Response::LinkCheckReq => {
+                let _ = mac.add_uplink(lorawan::maccommandcreator::LinkCheckReqCreator::new());
+                Ok(Some(mac.rx2_complete()))
+            }
+            #[cfg(feature = "certification")]
             mac::Response::UplinkPrepared => {
                 let (tx_config, _fcnt_up) =
                     mac.certification_setup_send::<G, N>(rng, radio_buffer)?;

--- a/lorawan-device/src/async_device/test/certification.rs
+++ b/lorawan-device/src/async_device/test/certification.rs
@@ -4,28 +4,62 @@ use crate::radio::RfConfig;
 use crate::test_util::{get_key, Uplink};
 use lorawan::creator::DataPayloadCreator;
 use lorawan::default_crypto::DefaultFactory;
+use lorawan::maccommands::parse_uplink_mac_commands;
+use lorawan::parser::{
+    DataHeader, DataPayload, DecryptedDataPayload, EncryptedDataPayload, FRMPayload, PhyPayload,
+};
 
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-fn build_packet(buf: &mut [u8], payload_in_hex: &str, fcnt: u16) -> usize {
+/// Decrypts the payload allowing access to payload contents
+fn decrypt<T>(data: EncryptedDataPayload<T>, fcnt: u32) -> DecryptedDataPayload<T>
+where
+    T: AsMut<[u8]>,
+    T: AsRef<[u8]>,
+{
+    data.decrypt(Some(&get_key().into()), Some(&get_key().into()), fcnt, &DefaultFactory).unwrap()
+}
+
+fn _build(buf: &mut [u8], payload_in_hex: &str, fcnt: u16, fport: u8) -> usize {
     let mut phy = DataPayloadCreator::new(buf).unwrap();
     phy.set_confirmed(false);
-    phy.set_f_port(224);
+    phy.set_f_port(fport);
     phy.set_dev_addr(&[0; 4]);
     phy.set_uplink(false);
     phy.set_fcnt(fcnt.into());
     phy.set_fctrl(&lorawan::parser::FCtrl::new(0x20, true));
-    let finished = phy
-        .build(
-            &hex::decode(payload_in_hex).unwrap(),
-            [],
-            &get_key().into(),
-            &get_key().into(),
-            &DefaultFactory,
-        )
-        .unwrap();
+    let finished = match fport {
+        0 => phy
+            .build(
+                &[],
+                hex::decode(payload_in_hex).unwrap(),
+                &get_key().into(),
+                &get_key().into(),
+                &DefaultFactory,
+            )
+            .unwrap(),
+        _ => phy
+            .build(
+                &hex::decode(payload_in_hex).unwrap(),
+                [],
+                &get_key().into(),
+                &get_key().into(),
+                &DefaultFactory,
+            )
+            .unwrap(),
+    };
     finished.len()
+}
+
+/// Build fport = 0 packet with MAC commands in fopts
+fn build_mac(buf: &mut [u8], payload_in_hex: &str, fcnt: u16) -> usize {
+    _build(buf, payload_in_hex, fcnt, 0)
+}
+
+/// Build certification protocol packet (fport = 224)
+fn build_packet(buf: &mut [u8], payload_in_hex: &str, fcnt: u16) -> usize {
+    _build(buf, payload_in_hex, fcnt, 224)
 }
 
 #[tokio::test]
@@ -103,5 +137,107 @@ async fn txframectrlreq_no_change() {
     // Check that override_confirm has not changed!
     if let Some(session) = device.mac.get_session() {
         assert_eq!(session.override_confirmed, Some(true));
+    }
+}
+
+#[tokio::test]
+/// 2.5.7. LinkCheckReq test
+/// Same scenario is used for all regions.
+async fn eu868_linkcheckreq_test() {
+    let (radio, timer, mut device) =
+        util::session_with_region(crate::region::EU868::new_eu868().into());
+    let send_await_complete = Arc::new(Mutex::new(false));
+
+    // Step 1: send uplink, TCL responds with CP:LinkCheckReq
+    let complete = send_await_complete.clone();
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 1, false).await;
+        let mut complete = complete.lock().await;
+        *complete = true;
+        (device, response)
+    });
+
+    timer.fire_most_recent().await;
+    fn fp_linkcheckreq(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_packet(buf, "20", 1)
+    }
+    radio.handle_rxtx(fp_linkcheckreq).await;
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        // TODO: LinkCheckReq should be triggered automatically or not?
+        Ok(SendResponse::RxComplete) => {}
+        _ => panic!(),
+    }
+
+    // Check whether uplink has been populated with requested MAC:LinkCheckReq command
+    if let Some(session) = device.mac.get_session() {
+        let data = session.uplink.mac_commands();
+        assert_eq!(parse_uplink_mac_commands(data).count(), 1);
+        assert_eq!(session.uplink.mac_commands(), &[0x2]);
+    }
+
+    // Step 2: trigger uplink with no data, TCL responds with MAC:LinkCheckAns
+    let complete = send_await_complete.clone();
+    let task = tokio::spawn(async move {
+        let response = device.send(&[], 2, false).await;
+        let mut complete = complete.lock().await;
+        *complete = true;
+        (device, response)
+    });
+
+    fn tcl_mac_linkcheckans(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_mac(buf, "020301", 2)
+    }
+    timer.fire_most_recent().await;
+    radio.handle_rxtx(tcl_mac_linkcheckans).await;
+    let (mut device, response) = task.await.unwrap();
+
+    match response {
+        Ok(SendResponse::DownlinkReceived(2)) => {}
+        _ => panic!(),
+    }
+
+    // Check whether previous uplink contains required LinkCheckReq command
+    let mut uplink = radio.get_last_uplink().await;
+    match uplink.get_payload() {
+        PhyPayload::Data(DataPayload::Encrypted(data)) => {
+            assert_eq!(data.fhdr().data(), [0x2]);
+        }
+        _ => panic!(),
+    }
+
+    // Step 3: Trigger empty uplink, TCL responds with FP:EchoPayloadReq
+    let complete = send_await_complete.clone();
+    let task = tokio::spawn(async move {
+        let response = device.send(&[], 3, false).await;
+        let mut complete = complete.lock().await;
+        *complete = true;
+        (device, response)
+    });
+
+    fn fp_echopayloadreq(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_packet(buf, "08010203", 3)
+    }
+    timer.fire_most_recent().await;
+    radio.handle_rxtx(fp_echopayloadreq).await;
+    let (_device, response) = task.await.unwrap();
+
+    match response {
+        Ok(SendResponse::RxComplete) => {}
+        _ => panic!(),
+    }
+
+    // Step 4: DUT will automatically respond with FP:EchoPayloadAns
+    let _complete = send_await_complete.clone();
+
+    let mut uplink = radio.get_last_uplink().await;
+    match uplink.get_payload() {
+        PhyPayload::Data(DataPayload::Encrypted(data)) => {
+            assert_eq!(data.f_port(), Some(224));
+            let dl = decrypt(data, 3);
+            assert_eq!(dl.frm_payload(), FRMPayload::Data(&[0x08, 0x02, 0x03, 0x04]));
+        }
+        _ => panic!(),
     }
 }

--- a/lorawan-device/src/mac/certification.rs
+++ b/lorawan-device/src/mac/certification.rs
@@ -12,6 +12,7 @@ pub(crate) enum Response {
     AdrBitChange(bool),
     DutJoinReq,
     DutResetReq,
+    LinkCheckReq,
     TxFramesCtrlReq(Option<bool>),
     TxPeriodicityChange(Option<u16>),
     UplinkPrepared,
@@ -39,6 +40,7 @@ impl Certification {
                     }
                 }
                 // Responses with uplink
+                LinkCheckReq(..) => return Response::LinkCheckReq,
                 DutVersionsReq(..) => {
                     let mut buf: heapless::Vec<u8, 256> = heapless::Vec::new();
                     let mut ans = lorawan::certification::DutVersionsAnsCreator::new();

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -207,6 +207,9 @@ impl Session {
                                 DutResetReq => {
                                     return Response::DeviceHandler(DeviceEvent::ResetDevice)
                                 }
+                                LinkCheckReq => {
+                                    return Response::LinkCheckReq;
+                                }
                                 TxFramesCtrlReq(ftype) => {
                                     // None is a no-op, allowing network to trigger uplinks
                                     if ftype.is_some() {
@@ -403,6 +406,14 @@ impl Session {
                         self.uplink.add_mac_command(cmd);
                     }
                     num_adrreq = 0;
+                }
+                LinkCheckAns(..) => {
+                    /* TODO: Payload contents are not consumed/handled
+                     * by MAC layer, instead these might be useful to
+                     * application layer.
+                     * Therefore keep this as a placeholder until a proper
+                     * device <-> mac integration has been implemented.
+                     */
                 }
                 NewChannelReq(payload) => {
                     if region.has_fixed_channel_plan() {

--- a/lorawan-encoding/src/certification.rs
+++ b/lorawan-encoding/src/certification.rs
@@ -39,6 +39,10 @@ pub enum DownlinkDUTCommand<'a> {
     #[cmd(cid = 0x09, len = 0)]
     RxAppCntReq(RxAppCntReqPayload),
 
+    /// Requests the DUT to send a LinkCheckReq MAC command.
+    #[cmd(cid = 0x20, len = 0)]
+    LinkCheckReq(LinkCheckReqPayload),
+
     /// Request to send firmware version, LoRaWAN version, and regional parameters version
     #[cmd(cid = 0x7f, len = 0)]
     DutVersionsReq(DutVersionsReqPayload),


### PR DESCRIPTION
Also add end-to-end test based on LoRaWAN 1.0.4 End Device Certification Page Test Specification v1.6.1.

Note that this is still somewhat incomplete, as the result from LinkCheckAns should be consumed by application. Unfortunately this command is one of the commands required by further tests (MAC command handling priority for example).