### PR TITLE
DevStatusReq - wire in SNR support

### DIFF
--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -69,9 +69,9 @@ multicast = []
 ## Enable [`serde`](https://docs.rs/serde/latest/serde/) serialization/deserialization for data structures.
 serde = ["dep:serde", "lorawan/serde"]
 
-## Experimental support for partially-implemetned MAC-commands:
-## - DevStatusReq: TODO: Battery state reporting, SNR
+## Experimental support for partially-implemented MAC-commands:
 ## - LinkADRReq - TODO: nbtrans support
+## - LinkCheckAns - TODO: Missing "application" layer integration
 ## - RxParamSetupReq - TODO: RX1 DR offset, RX2 DR
 experimental = []
 

--- a/lorawan-device/README.md
+++ b/lorawan-device/README.md
@@ -20,8 +20,8 @@ Both stacks share a dependency on the internal module, `mac` where LoRaWAN 1.0.x
   * Regional power limits are not enforced ([#168](https://github.com/lora-rs/lora-rs/issues/168))
   * FSK and LR-FHSS modulations are not supported
 
-**Currently, MAC commands are minimally mocked. For example, an ADRReq is responded with an ADRResp, but not much
-is actually done with the payload**.
+**Currently, not all MAC commands are fully implemented**. These commands
+are gated behind the "experimental" feature.
 
 Furthermore, both async and non-blocking implementation do not implement any retries for failed joins or failed
 confirmed uplinks. It is up to the client to implement retry behavior; see the examples for more.

--- a/lorawan-device/src/async_device/test/certification/mac_common.rs
+++ b/lorawan-device/src/async_device/test/certification/mac_common.rs
@@ -1,144 +1,31 @@
+//! LoRaWAN 1.0.4 Certification testcases
+//! Based on LoRaWAN 1.0.4 End Device Certification Test Specification v1.6.1
+//!
+//! MAC testcases common for all regions:
+//! * DevStatusReq (2.5.1)
+//! * LinkCheckReq (2.5.7)
+//!
+//! TODO:
+//! * NewChannelReq (2.5.2)
+//! * DlChannelReq (2.5.3)
+//! * RXParamSetupReq (2.5.4)
+//! * RXTimingSetupReq (2.5.5)
+//! * TXParamSetupReq (2.5.6)
+//! * LinkADRReq (2.5.8)
+//! * DutyCycleReq (2.5.9)
+//! * DeviceTimeReq (2.5.10)
 use super::util;
 use crate::async_device::SendResponse;
 use crate::radio::RfConfig;
-use crate::test_util::{get_key, Uplink};
-use lorawan::creator::DataPayloadCreator;
-use lorawan::default_crypto::DefaultFactory;
+use crate::test_util::Uplink;
+
 use lorawan::maccommands::parse_uplink_mac_commands;
-use lorawan::parser::{
-    DataHeader, DataPayload, DecryptedDataPayload, EncryptedDataPayload, FRMPayload, PhyPayload,
-};
+use lorawan::parser::{DataHeader, DataPayload, FRMPayload, PhyPayload};
 
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-/// Decrypts the payload allowing access to payload contents
-fn decrypt<T>(data: EncryptedDataPayload<T>, fcnt: u32) -> DecryptedDataPayload<T>
-where
-    T: AsMut<[u8]>,
-    T: AsRef<[u8]>,
-{
-    data.decrypt(Some(&get_key().into()), Some(&get_key().into()), fcnt, &DefaultFactory).unwrap()
-}
-
-fn _build(buf: &mut [u8], payload_in_hex: &str, fcnt: u16, fport: u8) -> usize {
-    let mut phy = DataPayloadCreator::new(buf).unwrap();
-    phy.set_confirmed(false);
-    phy.set_f_port(fport);
-    phy.set_dev_addr(&[0; 4]);
-    phy.set_uplink(false);
-    phy.set_fcnt(fcnt.into());
-    phy.set_fctrl(&lorawan::parser::FCtrl::new(0x20, true));
-    let finished = match fport {
-        0 => phy
-            .build(
-                &[],
-                hex::decode(payload_in_hex).unwrap(),
-                &get_key().into(),
-                &get_key().into(),
-                &DefaultFactory,
-            )
-            .unwrap(),
-        _ => phy
-            .build(
-                &hex::decode(payload_in_hex).unwrap(),
-                [],
-                &get_key().into(),
-                &get_key().into(),
-                &DefaultFactory,
-            )
-            .unwrap(),
-    };
-    finished.len()
-}
-
-/// Build fport = 0 packet with MAC commands in fopts
-fn build_mac(buf: &mut [u8], payload_in_hex: &str, fcnt: u16) -> usize {
-    _build(buf, payload_in_hex, fcnt, 0)
-}
-
-/// Build certification protocol packet (fport = 224)
-fn build_packet(buf: &mut [u8], payload_in_hex: &str, fcnt: u16) -> usize {
-    _build(buf, payload_in_hex, fcnt, 224)
-}
-
-#[tokio::test]
-async fn txframectrlreq_no_change() {
-    // This test will check how TxFrameReqCtrlReq is handled and
-    // whether it overrides confirmation flag for packets properly
-    fn txframectrlreq_override_confirmed(
-        _uplink: Option<Uplink>,
-        _config: RfConfig,
-        buf: &mut [u8],
-    ) -> usize {
-        // TxFrameReqCtrlReq([2]) - DUT should switch to Confirmed
-        build_packet(buf, "0702", 1)
-    }
-
-    fn txframectrlreq_no_change(
-        _uplink: Option<Uplink>,
-        _config: RfConfig,
-        buf: &mut [u8],
-    ) -> usize {
-        // TxFrameReqCtrlReq([0]) - no change
-        build_packet(buf, "0700", 2)
-    }
-
-    // Note: This test is region-agnostic
-    let (radio, timer, mut device) =
-        util::session_with_region(crate::region::EU868::new_eu868().into());
-    let send_await_complete = Arc::new(Mutex::new(false));
-
-    // Check that override is not set
-    if let Some(session) = device.mac.get_session() {
-        assert_eq!(session.override_confirmed, None);
-    }
-
-    // Trigger uplink
-    let complete = send_await_complete.clone();
-    let task = tokio::spawn(async move {
-        let response = device.send(&[1, 2, 3], 3, false).await;
-        let mut complete = complete.lock().await;
-        *complete = true;
-        (device, response)
-    });
-
-    timer.fire_most_recent().await;
-    radio.handle_rxtx(txframectrlreq_override_confirmed).await;
-
-    let (mut device, response) = task.await.unwrap();
-    match response {
-        Ok(SendResponse::DownlinkReceived(_)) => {}
-        _ => panic!(),
-    }
-    // Check that session is configured to override and send only confirmed packets
-    if let Some(session) = device.mac.get_session() {
-        assert_eq!(session.override_confirmed, Some(true));
-    }
-
-    // Trigger second uplink
-    let complete = send_await_complete.clone();
-    let task = tokio::spawn(async move {
-        let response = device.send(&[1, 2, 3], 3, false).await;
-        let mut complete = complete.lock().await;
-        *complete = true;
-        (device, response)
-    });
-
-    timer.fire_most_recent().await;
-    // TxFrameReqCtrl - no_change is no-op
-    radio.handle_rxtx(txframectrlreq_no_change).await;
-
-    let (device, response) = task.await.unwrap();
-    match response {
-        Ok(SendResponse::DownlinkReceived(_)) => {}
-        _ => panic!(),
-    }
-    // Check that override_confirm has not changed!
-    if let Some(session) = device.mac.get_session() {
-        assert_eq!(session.override_confirmed, Some(true));
-    }
-}
+use super::{build_mac, build_packet, decrypt};
 
 #[tokio::test]
 /// 2.5.1. DevStatusReq test
@@ -171,14 +58,14 @@ async fn eu868_devstatusreq_test() {
         _ => panic!(),
     }
 
-    let expected_mac = [0x06, 255, device.radio.snr_scaled()];
+    // TODO: Battery value is hardcoded to 255 in MAC for now
+    let expected_ans = [0x06, 255, device.radio.snr_scaled()];
 
     // Check whether uplink has been populated with requested MAC:DevstatusAns command
     if let Some(session) = device.mac.get_session() {
         let data = session.uplink.mac_commands();
         assert_eq!(parse_uplink_mac_commands(data).count(), 1);
-        // TODO: Battery value is hardcoded to 255 in MAC for now
-        assert_eq!(session.uplink.mac_commands(), &expected_mac);
+        assert_eq!(session.uplink.mac_commands(), &expected_ans);
     }
 
     // Step 2: send uplink, check whether DevStatusAns is present in MAC
@@ -195,7 +82,7 @@ async fn eu868_devstatusreq_test() {
     let mut uplink = radio.get_last_uplink().await;
     match uplink.get_payload() {
         PhyPayload::Data(DataPayload::Encrypted(data)) => {
-            assert_eq!(data.fhdr().data(), &expected_mac)
+            assert_eq!(data.fhdr().data(), &expected_ans)
         }
         _ => panic!(),
     }

--- a/lorawan-device/src/async_device/test/certification/mod.rs
+++ b/lorawan-device/src/async_device/test/certification/mod.rs
@@ -1,0 +1,142 @@
+//! LoRaWAN 1.0.4 Certification testcases
+//! Based on LoRaWAN 1.0.4 End Device Certification Test Specification v1.6.1
+use super::util;
+use crate::async_device::SendResponse;
+use crate::radio::RfConfig;
+use crate::test_util::{get_key, Uplink};
+use lorawan::creator::DataPayloadCreator;
+use lorawan::default_crypto::DefaultFactory;
+use lorawan::parser::{DecryptedDataPayload, EncryptedDataPayload};
+
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+mod mac_common;
+
+/// Decrypts the payload allowing access to payload contents
+fn decrypt<T>(data: EncryptedDataPayload<T>, fcnt: u32) -> DecryptedDataPayload<T>
+where
+    T: AsMut<[u8]>,
+    T: AsRef<[u8]>,
+{
+    data.decrypt(Some(&get_key().into()), Some(&get_key().into()), fcnt, &DefaultFactory).unwrap()
+}
+
+fn _build(buf: &mut [u8], payload_in_hex: &str, fcnt: u16, fport: u8) -> usize {
+    let mut phy = DataPayloadCreator::new(buf).unwrap();
+    phy.set_confirmed(false);
+    phy.set_f_port(fport);
+    phy.set_dev_addr(&[0; 4]);
+    phy.set_uplink(false);
+    phy.set_fcnt(fcnt.into());
+    phy.set_fctrl(&lorawan::parser::FCtrl::new(0x20, true));
+    let finished = match fport {
+        0 => phy
+            .build(
+                &[],
+                hex::decode(payload_in_hex).unwrap(),
+                &get_key().into(),
+                &get_key().into(),
+                &DefaultFactory,
+            )
+            .unwrap(),
+        _ => phy
+            .build(
+                &hex::decode(payload_in_hex).unwrap(),
+                [],
+                &get_key().into(),
+                &get_key().into(),
+                &DefaultFactory,
+            )
+            .unwrap(),
+    };
+    finished.len()
+}
+
+/// Build fport = 0 packet with MAC commands in fopts
+fn build_mac(buf: &mut [u8], payload_in_hex: &str, fcnt: u16) -> usize {
+    _build(buf, payload_in_hex, fcnt, 0)
+}
+
+/// Build certification protocol packet (fport = 224)
+fn build_packet(buf: &mut [u8], payload_in_hex: &str, fcnt: u16) -> usize {
+    _build(buf, payload_in_hex, fcnt, 224)
+}
+
+#[tokio::test]
+async fn txframectrlreq_no_change() {
+    // This test will check how TxFrameReqCtrlReq is handled and
+    // whether it overrides confirmation flag for packets properly
+    fn txframectrlreq_override_confirmed(
+        _uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        // TxFrameReqCtrlReq([2]) - DUT should switch to Confirmed
+        build_packet(buf, "0702", 1)
+    }
+
+    fn txframectrlreq_no_change(
+        _uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        // TxFrameReqCtrlReq([0]) - no change
+        build_packet(buf, "0700", 2)
+    }
+
+    // Note: This test is region-agnostic
+    let (radio, timer, mut device) =
+        util::session_with_region(crate::region::EU868::new_eu868().into());
+    let send_await_complete = Arc::new(Mutex::new(false));
+
+    // Check that override is not set
+    if let Some(session) = device.mac.get_session() {
+        assert_eq!(session.override_confirmed, None);
+    }
+
+    // Trigger uplink
+    let complete = send_await_complete.clone();
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        let mut complete = complete.lock().await;
+        *complete = true;
+        (device, response)
+    });
+
+    timer.fire_most_recent().await;
+    radio.handle_rxtx(txframectrlreq_override_confirmed).await;
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(_)) => {}
+        _ => panic!(),
+    }
+    // Check that session is configured to override and send only confirmed packets
+    if let Some(session) = device.mac.get_session() {
+        assert_eq!(session.override_confirmed, Some(true));
+    }
+
+    // Trigger second uplink
+    let complete = send_await_complete.clone();
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        let mut complete = complete.lock().await;
+        *complete = true;
+        (device, response)
+    });
+
+    timer.fire_most_recent().await;
+    // TxFrameReqCtrl - no_change is no-op
+    radio.handle_rxtx(txframectrlreq_no_change).await;
+
+    let (device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(_)) => {}
+        _ => panic!(),
+    }
+    // Check that override_confirm has not changed!
+    if let Some(session) = device.mac.get_session() {
+        assert_eq!(session.override_confirmed, Some(true));
+    }
+}

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -251,6 +251,7 @@ impl Mac {
         &mut self,
         buf: &mut RadioBuffer<N>,
         dl: &mut Vec<Downlink, D>,
+        snr: i8,
     ) -> Response {
         match &mut self.state {
             State::Joined(ref mut session) => session.handle_rx::<N, D>(
@@ -262,6 +263,7 @@ impl Mac {
                 &mut self.multicast,
                 buf,
                 dl,
+                snr,
                 false,
             ),
             State::Otaa(ref mut otaa) => {
@@ -286,6 +288,7 @@ impl Mac {
         &mut self,
         buf: &mut RadioBuffer<N>,
         dl: &mut Vec<Downlink, D>,
+        snr: i8,
     ) -> Result<Response> {
         match &mut self.state {
             State::Joined(ref mut session) => Ok(session.handle_rx::<N, D>(
@@ -297,6 +300,7 @@ impl Mac {
                 &mut self.multicast,
                 buf,
                 dl,
+                snr,
                 true,
             )),
             State::Otaa(_) => Err(Error::NotJoined),

--- a/lorawan-device/src/nb_device/state.rs
+++ b/lorawan-device/src/nb_device/state.rs
@@ -318,7 +318,7 @@ impl WaitingForRx {
                 // send the transmit request to the radio
                 match radio.handle_event(radio_event) {
                     Ok(response) => match response {
-                        radio::Response::RxDone(_quality) => {
+                        radio::Response::RxDone(quality) => {
                             // copy from radio buffer to mac buffer
                             buf.clear();
                             if let Err(()) =
@@ -329,7 +329,7 @@ impl WaitingForRx {
                                     Err(Error::BufferTooSmall.into()),
                                 );
                             }
-                            match mac.handle_rx::<N, D>(buf, dl) {
+                            match mac.handle_rx::<N, D>(buf, dl, quality.snr()) {
                                 // NoUpdate can occur when a stray radio packet is received. Maintain state
                                 mac::Response::NoUpdate => {
                                     (State::WaitingForRx(self), Ok(Response::NoUpdate))

--- a/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
@@ -328,7 +328,7 @@ mod test {
         let len = handle_join_request::<0>(Some(uplink), tx_config.rf, &mut rx_buf);
         buf.clear();
         buf.extend_from_slice(&rx_buf[..len]).unwrap();
-        let response = mac.handle_rx::<255, 3>(&mut buf, &mut downlinks);
+        let response = mac.handle_rx::<255, 3>(&mut buf, &mut downlinks, 0);
         if let Response::JoinSuccess = response {
         } else {
             panic!("Did not receive join success");
@@ -389,7 +389,7 @@ mod test {
         let len = handle_join_request::<0>(Some(uplink), tx_config.rf, &mut rx_buf);
         buf.clear();
         buf.extend_from_slice(&rx_buf[..len]).unwrap();
-        let response = mac.handle_rx::<255, 3>(&mut buf, &mut downlinks);
+        let response = mac.handle_rx::<255, 3>(&mut buf, &mut downlinks, 0);
         if let Response::JoinSuccess = response {
         } else {
             panic!("Did not receive JoinSuccess")


### PR DESCRIPTION
Adds support for SNR field in DevStatusReq/DevStatusAns MAC command.

And also updates README and reorganizes existing certification tests.