### PR TITLE
Fix handling of implicit header on Sx127x radios.

### DIFF
--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -289,6 +289,9 @@ where
         self.write_register(Register::RegPreambleLsb, (pkt_params.preamble_length & 0x00ff) as u8)
             .await?;
 
+        self.write_register(Register::RegPayloadLength, pkt_params.payload_length)
+            .await?;
+
         C::set_packet_params(self, pkt_params).await?;
 
         // IQ inversion:
@@ -357,7 +360,6 @@ where
         self.write_register(Register::RegLna, lna_gain).await?;
 
         self.write_register(Register::RegFifoAddrPtr, 0x00u8).await?;
-        self.write_register(Register::RegPayloadLength, 0xffu8).await?;
 
         self.write_register(Register::RegOpMode, mode.value()).await
     }


### PR DESCRIPTION
When configuring an Sx127x radio to use implicit headers, the current behaviour is that we receive 255 bytes of data regardless of the payload length that we configured and the data appears to be garbage.

Instead of setting the payload length register to 255 in [do_rx], set it to the configured value in [set_packet_params].