### PR TITLE
Refactor region/mac for RxParamSetup support

### DIFF
--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -232,15 +232,6 @@ impl Mac {
         }
     }
 
-    /// Gets the radio configuration and timing for a given frame type and window.
-    pub(crate) fn get_rx_parameters_legacy(
-        &mut self,
-        frame: &Frame,
-        window: &Window,
-    ) -> (RfConfig, u32) {
-        (self.get_rf_config(frame, window), self.get_rx_delay(frame, window))
-    }
-
     /// Handles a received RF frame. Returns None is unparseable, fails decryption, or fails MIC
     /// verification. Upon successful join, provides Response::JoinSuccess. Upon successful data
     /// rx, provides Response::DownlinkReceived. User must take the downlink from vec for
@@ -344,7 +335,7 @@ impl Mac {
 
     /// Build RfConfig for given `Frame` and `Window` and apply
     /// network-specific overrides.
-    fn get_rf_config(&self, frame: &Frame, window: &Window) -> RfConfig {
+    pub(crate) fn get_rf_config(&self, frame: &Frame, window: &Window) -> RfConfig {
         let (frequency, datarate) = match window {
             Window::_1 => {
                 // TODO: RX1 DR offset

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -380,7 +380,12 @@ impl Session {
                         if rate == 0xf {
                             Some(configuration.data_rate)
                         } else {
-                            region.check_data_rate(rate)
+                            // Check whether datarate is defined, and return its index
+                            if region.get_datarate(rate).is_some() {
+                                Some(u8::try_into(rate).unwrap())
+                            } else {
+                                None
+                            }
                         }
                     };
                     // Handle TxPower

--- a/lorawan-device/src/nb_device/state.rs
+++ b/lorawan-device/src/nb_device/state.rs
@@ -248,10 +248,10 @@ impl WaitingForRxWindow {
         match event {
             // we are waiting for a Timeout
             Event::TimeoutFired => {
-                let (rx_config, window_start) =
-                    mac.get_rx_parameters_legacy(&self.frame, &self.window.into());
+                let rf_config = mac.get_rf_config(&self.frame, &self.window.into());
+                let window_start = mac.get_rx_delay(&self.frame, &self.window.into());
                 // configure the radio for the RX
-                match radio.handle_event(radio::Event::RxRequest(rx_config)) {
+                match radio.handle_event(radio::Event::RxRequest(rf_config)) {
                     Ok(_) => {
                         let window_close: u32 = match self.window {
                             // RxWindow1 one must timeout before RxWindow2

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -60,7 +60,7 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion
         DEFAULT_RX2
     }
 
-    fn get_rx_datarate(tx_dr: DR, _frame: &Frame, window: &Window) -> Datarate {
+    fn get_rx_datarate(tx_dr: DR, window: &Window) -> Datarate {
         // TODO: Handle DwellTime, current values correspond to Dwelltime = 0
         // TODO: Handle RX1 offset
         let dr = match window {

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -56,7 +56,7 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion
         2
     }
 
-    fn get_default_rx2() -> u32 {
+    fn default_rx2_freq() -> u32 {
         DEFAULT_RX2
     }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -60,6 +60,21 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion
         DEFAULT_RX2
     }
 
+    fn get_rx_datarate(tx_dr: DR, _frame: &Frame, window: &Window) -> Datarate {
+        // TODO: Handle DwellTime, current values correspond to Dwelltime = 0
+        // TODO: Handle RX1 offset
+        let dr = match window {
+            Window::_1 => match tx_dr {
+                DR::_0 | DR::_1 | DR::_2 | DR::_3 | DR::_4 | DR::_5 | DR::_6 | DR::_7 => tx_dr,
+                DR::_8 | DR::_9 | DR::_10 | DR::_11 | DR::_12 | DR::_13 | DR::_14 | DR::_15 => {
+                    DR::_0
+                }
+            },
+            Window::_2 => DR::_0,
+        };
+        DATARATES[dr as usize].clone().unwrap()
+    }
+
     // Although Network gateways SHALL always listen on following frequencies
     // with DR0..=DR5, the default Join-Request Data Rate SHALL utilize DR2..=DR5
     // (SF10/125 kHz – SF7/125 kHz).

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -70,7 +70,7 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion
                     DR::_0
                 }
             },
-            Window::_2 => DR::_0,
+            Window::_2 => DR::_2,
         };
         DATARATES[dr as usize].clone().unwrap()
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -47,7 +47,7 @@ impl DynamicChannelRegion for EU433Region {
         434_665_000
     }
 
-    fn get_rx_datarate(tx_dr: DR, _frame: &Frame, window: &Window) -> Datarate {
+    fn get_rx_datarate(tx_dr: DR, window: &Window) -> Datarate {
         // TODO: Handle RX1 offset
         let dr = match window {
             Window::_1 => match tx_dr {

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -47,6 +47,20 @@ impl DynamicChannelRegion for EU433Region {
         434_665_000
     }
 
+    fn get_rx_datarate(tx_dr: DR, _frame: &Frame, window: &Window) -> Datarate {
+        // TODO: Handle RX1 offset
+        let dr = match window {
+            Window::_1 => match tx_dr {
+                DR::_0 | DR::_1 | DR::_2 | DR::_3 | DR::_4 | DR::_5 | DR::_6 | DR::_7 => tx_dr,
+                DR::_8 | DR::_9 | DR::_10 | DR::_11 | DR::_12 | DR::_13 | DR::_14 | DR::_15 => {
+                    DR::_0
+                }
+            },
+            Window::_2 => DR::_0,
+        };
+        DATARATES[dr as usize].clone().unwrap()
+    }
+
     fn init_channels(channels: &mut ChannelPlan) {
         channels[0] = Some(Channel::new(433_175_000, DR::_0, DR::_5));
         channels[1] = Some(Channel::new(433_375_000, DR::_0, DR::_5));

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -43,7 +43,7 @@ impl DynamicChannelRegion for EU433Region {
         3
     }
 
-    fn get_default_rx2() -> u32 {
+    fn default_rx2_freq() -> u32 {
         434_665_000
     }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -44,6 +44,22 @@ impl DynamicChannelRegion for EU868Region {
         3
     }
 
+    fn get_rx_datarate(tx_dr: DR, _frame: &Frame, window: &Window) -> Datarate {
+        // TODO: Handle RX1 offset
+        let dr = match window {
+            Window::_1 => match tx_dr {
+                DR::_0 | DR::_1 | DR::_2 | DR::_3 | DR::_4 | DR::_5 | DR::_6 | DR::_7 => tx_dr,
+                DR::_8 => DR::_1,
+                DR::_9 => DR::_2,
+                DR::_10 => DR::_1,
+                DR::_11 => DR::_2,
+                DR::_12 | DR::_13 | DR::_14 | DR::_15 => DR::_0,
+            },
+            Window::_2 => DR::_0,
+        };
+        DATARATES[dr as usize].clone().unwrap()
+    }
+
     fn default_rx2_freq() -> u32 {
         869_525_000
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -44,7 +44,7 @@ impl DynamicChannelRegion for EU868Region {
         3
     }
 
-    fn get_rx_datarate(tx_dr: DR, _frame: &Frame, window: &Window) -> Datarate {
+    fn get_rx_datarate(tx_dr: DR, window: &Window) -> Datarate {
         // TODO: Handle RX1 offset
         let dr = match window {
             Window::_1 => match tx_dr {

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -44,7 +44,7 @@ impl DynamicChannelRegion for EU868Region {
         3
     }
 
-    fn get_default_rx2() -> u32 {
+    fn default_rx2_freq() -> u32 {
         869_525_000
     }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -42,7 +42,7 @@ impl DynamicChannelRegion for IN865Region {
         3
     }
 
-    fn get_default_rx2() -> u32 {
+    fn default_rx2_freq() -> u32 {
         866_550_000
     }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -46,7 +46,7 @@ impl DynamicChannelRegion for IN865Region {
         866_550_000
     }
 
-    fn get_rx_datarate(tx_dr: DR, _frame: &Frame, window: &Window) -> Datarate {
+    fn get_rx_datarate(tx_dr: DR, window: &Window) -> Datarate {
         // TODO: Handle RX1 offset
         let dr = match window {
             Window::_1 => match tx_dr {

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -46,6 +46,26 @@ impl DynamicChannelRegion for IN865Region {
         866_550_000
     }
 
+    fn get_rx_datarate(tx_dr: DR, _frame: &Frame, window: &Window) -> Datarate {
+        // TODO: Handle RX1 offset
+        let dr = match window {
+            Window::_1 => match tx_dr {
+                DR::_0 | DR::_1 | DR::_2 | DR::_3 | DR::_4 | DR::_5 | DR::_7 => tx_dr,
+                DR::_6
+                | DR::_8
+                | DR::_9
+                | DR::_10
+                | DR::_11
+                | DR::_12
+                | DR::_13
+                | DR::_14
+                | DR::_15 => DR::_0,
+            },
+            Window::_2 => DR::_0,
+        };
+        DATARATES[dr as usize].clone().unwrap()
+    }
+
     fn init_channels(channels: &mut ChannelPlan) {
         channels[0] = Some(Channel::new(865_062_500, DR::_0, DR::_5));
         channels[1] = Some(Channel::new(865_402_500, DR::_0, DR::_5));

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -61,7 +61,7 @@ impl DynamicChannelRegion for IN865Region {
                 | DR::_14
                 | DR::_15 => DR::_0,
             },
-            Window::_2 => DR::_0,
+            Window::_2 => DR::_2,
         };
         DATARATES[dr as usize].clone().unwrap()
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -104,14 +104,6 @@ impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
     pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
         R::get_max_payload_length(datarate, repeater_compatible, dwell_time)
     }
-
-    pub fn check_data_rate(&self, datarate: u8) -> Option<DR> {
-        if (datarate as usize) < NUM_DATARATES.into() && R::datarates()[datarate as usize].is_some()
-        {
-            return Some(DR::try_from(datarate).unwrap());
-        }
-        None
-    }
 }
 
 pub(crate) trait DynamicChannelRegion: ChannelRegion {
@@ -204,6 +196,10 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
             }
         })
         // (2..9).all(|i| channel_mask.get_index(i) == 0)
+    }
+
+    fn get_datarate(&self, dr: u8) -> Option<&Datarate> {
+        R::datarates()[dr as usize].as_ref()
     }
 
     fn get_tx_dr_and_frequency<RNG: RngCore>(

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -64,10 +64,7 @@ pub(crate) struct DynamicChannelPlan<R: DynamicChannelRegion> {
     channels: ChannelPlan,
     channel_mask: ChannelMask<9>,
     last_tx_channel: u8,
-    _fixed_channel_region: PhantomData<R>,
-    rx1_offset: usize,
-    rx2_dr: usize,
-
+    _dynamic_channel_region: PhantomData<R>,
     frequency_valid: fn(u32) -> bool,
 }
 
@@ -77,12 +74,10 @@ impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
         R::init_channels(&mut channels);
 
         Self {
-            channel_mask: Default::default(),
             channels,
+            channel_mask: Default::default(),
             last_tx_channel: Default::default(),
-            _fixed_channel_region: Default::default(),
-            rx1_offset: Default::default(),
-            rx2_dr: Default::default(),
+            _dynamic_channel_region: Default::default(),
             frequency_valid: freq_fn,
         }
     }
@@ -110,7 +105,7 @@ pub(crate) trait DynamicChannelRegion: ChannelRegion {
     fn join_channels() -> u8;
     fn init_channels(channels: &mut ChannelPlan);
     fn default_rx2_freq() -> u32;
-    fn get_rx_datarate(tx_datarate: DR, frame: &Frame, window: &Window) -> Datarate;
+    fn get_rx_datarate(tx_datarate: DR, window: &Window) -> Datarate;
 }
 
 impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
@@ -249,8 +244,8 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
         }
     }
 
-    fn get_rx_datarate(&self, tx_datarate: DR, frame: &Frame, window: &Window) -> Datarate {
-        R::get_rx_datarate(tx_datarate, frame, window)
+    fn get_rx_datarate(&self, tx_datarate: DR, window: &Window) -> Datarate {
+        R::get_rx_datarate(tx_datarate, window)
     }
 
     fn check_tx_power(&self, tx_power: u8) -> Option<u8> {

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -117,7 +117,7 @@ impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
 pub(crate) trait DynamicChannelRegion: ChannelRegion {
     fn join_channels() -> u8;
     fn init_channels(channels: &mut ChannelPlan);
-    fn get_default_rx2() -> u32;
+    fn default_rx2_freq() -> u32;
 }
 
 impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
@@ -248,7 +248,7 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
         match window {
             // SAFETY: self.last_tx_channel will be populated after correct channel is chosen
             Window::_1 => self.channels[self.last_tx_channel as usize].unwrap().rx1_frequency(),
-            Window::_2 => R::get_default_rx2(),
+            Window::_2 => R::default_rx2_freq(),
         }
     }
 

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -110,6 +110,7 @@ pub(crate) trait DynamicChannelRegion: ChannelRegion {
     fn join_channels() -> u8;
     fn init_channels(channels: &mut ChannelPlan);
     fn default_rx2_freq() -> u32;
+    fn get_rx_datarate(tx_datarate: DR, frame: &Frame, window: &Window) -> Datarate;
 }
 
 impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
@@ -248,12 +249,8 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
         }
     }
 
-    fn get_rx_datarate(&self, tx_datarate: DR, _frame: &Frame, window: &Window) -> Datarate {
-        let datarate = match window {
-            Window::_1 => tx_datarate as usize + self.rx1_offset,
-            Window::_2 => self.rx2_dr,
-        };
-        R::datarates()[datarate].clone().unwrap()
+    fn get_rx_datarate(&self, tx_datarate: DR, frame: &Frame, window: &Window) -> Datarate {
+        R::get_rx_datarate(tx_datarate, frame, window)
     }
 
     fn check_tx_power(&self, tx_power: u8) -> Option<u8> {

--- a/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
@@ -79,7 +79,7 @@ impl FixedChannelRegion for AU915Region {
     fn downlink_channels() -> &'static [u32; 8] {
         &DOWNLINK_CHANNEL_MAP
     }
-    fn get_default_rx2() -> u32 {
+    fn default_rx2_freq() -> u32 {
         DEFAULT_RX2
     }
     fn get_rx_datarate(tx_datarate: DR, _frame: &Frame, window: &Window) -> Datarate {

--- a/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
@@ -82,7 +82,7 @@ impl FixedChannelRegion for AU915Region {
     fn default_rx2_freq() -> u32 {
         DEFAULT_RX2
     }
-    fn get_rx_datarate(tx_datarate: DR, _frame: &Frame, window: &Window) -> Datarate {
+    fn get_rx_datarate(tx_datarate: DR, window: &Window) -> Datarate {
         let datarate = match window {
             Window::_1 => {
                 // no support for RX1 DR Offset

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -88,14 +88,6 @@ impl<F: FixedChannelRegion> FixedChannelPlan<F> {
     pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
         F::get_max_payload_length(datarate, repeater_compatible, dwell_time)
     }
-
-    pub fn check_data_rate(&self, datarate: u8) -> Option<DR> {
-        if (datarate as usize) < NUM_DATARATES.into() && F::datarates()[datarate as usize].is_some()
-        {
-            return Some(DR::try_from(datarate).unwrap());
-        }
-        None
-    }
 }
 
 pub(crate) trait FixedChannelRegion: ChannelRegion {
@@ -175,6 +167,10 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
             }
         }
         false
+    }
+
+    fn get_datarate(&self, dr: u8) -> Option<&Datarate> {
+        F::datarates()[dr as usize].as_ref()
     }
 
     fn get_tx_dr_and_frequency<RNG: RngCore>(

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -94,7 +94,7 @@ pub(crate) trait FixedChannelRegion: ChannelRegion {
     fn uplink_channels() -> &'static [u32; 72];
     fn downlink_channels() -> &'static [u32; 8];
     fn default_rx2_freq() -> u32;
-    fn get_rx_datarate(tx_datarate: DR, frame: &Frame, window: &Window) -> Datarate;
+    fn get_rx_datarate(tx_datarate: DR, window: &Window) -> Datarate;
 }
 
 impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
@@ -243,8 +243,8 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
         }
     }
 
-    fn get_rx_datarate(&self, tx_datarate: DR, frame: &Frame, window: &Window) -> Datarate {
-        F::get_rx_datarate(tx_datarate, frame, window)
+    fn get_rx_datarate(&self, tx_datarate: DR, window: &Window) -> Datarate {
+        F::get_rx_datarate(tx_datarate, window)
     }
 
     fn check_tx_power(&self, tx_power: u8) -> Option<u8> {

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -101,7 +101,7 @@ impl<F: FixedChannelRegion> FixedChannelPlan<F> {
 pub(crate) trait FixedChannelRegion: ChannelRegion {
     fn uplink_channels() -> &'static [u32; 72];
     fn downlink_channels() -> &'static [u32; 8];
-    fn get_default_rx2() -> u32;
+    fn default_rx2_freq() -> u32;
     fn get_rx_datarate(tx_datarate: DR, frame: &Frame, window: &Window) -> Datarate;
 }
 
@@ -243,7 +243,7 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
         let channel = self.last_tx_channel % 8;
         match window {
             Window::_1 => F::downlink_channels()[channel as usize],
-            Window::_2 => F::get_default_rx2(),
+            Window::_2 => F::default_rx2_freq(),
         }
     }
 

--- a/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
@@ -84,7 +84,7 @@ impl FixedChannelRegion for US915Region {
     fn downlink_channels() -> &'static [u32; 8] {
         &DOWNLINK_CHANNEL_MAP
     }
-    fn get_default_rx2() -> u32 {
+    fn default_rx2_freq() -> u32 {
         DEFAULT_RX2
     }
     fn get_rx_datarate(tx_datarate: DR, _frame: &Frame, window: &Window) -> Datarate {

--- a/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
@@ -87,7 +87,7 @@ impl FixedChannelRegion for US915Region {
     fn default_rx2_freq() -> u32 {
         DEFAULT_RX2
     }
-    fn get_rx_datarate(tx_datarate: DR, _frame: &Frame, window: &Window) -> Datarate {
+    fn get_rx_datarate(tx_datarate: DR, window: &Window) -> Datarate {
         let datarate = match window {
             Window::_1 => {
                 // no support for RX1 DR Offset

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -384,8 +384,8 @@ impl Configuration {
         }
     }
 
-    pub(crate) fn check_data_rate(&self, data_rate: u8) -> Option<DR> {
-        region_dispatch!(self, check_data_rate, data_rate)
+    pub(crate) fn get_datarate(&self, dr: u8) -> Option<&Datarate> {
+        region_dispatch!(self, get_datarate, dr)
     }
 
     pub(crate) fn check_tx_power(&self, tx_power: u8) -> Option<Option<u8>> {
@@ -561,9 +561,12 @@ pub(crate) trait RegionHandler {
         data_rates: Option<DataRateRange>,
     ) -> (bool, bool);
 
+    fn get_datarate(&self, dr: u8) -> Option<&Datarate>;
+
     fn get_default_datarate(&self) -> DR {
         DR::_0
     }
+
     fn get_tx_dr_and_frequency<RNG: RngCore>(
         &mut self,
         rng: &mut RNG,

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -402,7 +402,7 @@ impl Configuration {
     }
 
     pub(crate) fn get_rx_config(&self, datarate: DR, frame: &Frame, window: &Window) -> RfConfig {
-        let dr = self.get_rx_datarate(datarate, frame, window);
+        let dr = self.get_rx_datarate(datarate, window);
         RfConfig {
             frequency: self.get_rx_frequency(frame, window),
             bb: BaseBandModulationParams::new(
@@ -453,8 +453,8 @@ impl Configuration {
         region_dispatch!(self, get_default_datarate)
     }
 
-    pub(crate) fn get_rx_datarate(&self, datarate: DR, frame: &Frame, window: &Window) -> Datarate {
-        region_dispatch!(self, get_rx_datarate, datarate, frame, window)
+    pub(crate) fn get_rx_datarate(&self, datarate: DR, window: &Window) -> Datarate {
+        region_dispatch!(self, get_rx_datarate, datarate, window)
     }
 
     // Unicast: The RXC parameters are identical to the RX2 parameters, and they use the same
@@ -462,7 +462,7 @@ impl Configuration {
     // commands also modifies the RXC parameters.
     #[cfg(feature = "class-c")]
     pub(crate) fn get_rxc_config(&self, datarate: DR) -> RfConfig {
-        let dr = self.get_rx_datarate(datarate, &Frame::Data, &Window::_2);
+        let dr = self.get_rx_datarate(datarate, &Window::_2);
         let frequency = self.get_rx_frequency(&Frame::Data, &Window::_2);
         RfConfig {
             frequency,
@@ -575,7 +575,7 @@ pub(crate) trait RegionHandler {
     ) -> (Datarate, u32);
 
     fn get_rx_frequency(&self, frame: &Frame, window: &Window) -> u32;
-    fn get_rx_datarate(&self, datarate: DR, frame: &Frame, window: &Window) -> Datarate;
+    fn get_rx_datarate(&self, datarate: DR, window: &Window) -> Datarate;
     fn get_coding_rate(&self) -> CodingRate {
         DEFAULT_CODING_RATE
     }


### PR DESCRIPTION
Changes:
* Use region-specific `get_rx_datarate` for dynamic channels as well. This allows us to use correct RX2 DR for AS923 and IN865 regions.
* Create RX RfConfig in single location - better name suggestions welcome for  `get_rf_config()` :)
* And various cleanups related to unused arguments and methods.