### PR TITLE
RxParamSetupReq: Add RX1_DR_OFFSET support

### DIFF
--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -69,9 +69,7 @@ multicast = []
 ## Enable [`serde`](https://docs.rs/serde/latest/serde/) serialization/deserialization for data structures.
 serde = ["dep:serde", "lorawan/serde"]
 
-## Experimental support for partially-implemented MAC-commands:
-## - LinkCheckAns - TODO: Missing "application" layer integration
-## - RxParamSetupReq - TODO: RX1 DR offset, RX2 DR
+## Experimental support for partially-implemented MAC-commands
 experimental = []
 
 ## Enable support for AS923-1 region (by default all regions are enabled).

--- a/lorawan-device/README.md
+++ b/lorawan-device/README.md
@@ -17,7 +17,6 @@ Both stacks share a dependency on the internal module, `mac` where LoRaWAN 1.0.x
 - Over-the-Air Activation (OTAA) and Activation by Personalization (ABP)
 - CFList is supported for fixed and dynamic channel plans
 - Regional support for AS923_1, AS923_2, AS923_3, AS923_4, AU915, EU868, EU433, IN865, US915 with following caveats:
-  * Regional power limits are not enforced ([#168](https://github.com/lora-rs/lora-rs/issues/168))
   * FSK and LR-FHSS modulations are not supported
 
 **Currently, not all MAC commands are fully implemented**. These commands

--- a/lorawan-device/src/async_device/test/certification/rxparamsetup_eu868.rs
+++ b/lorawan-device/src/async_device/test/certification/rxparamsetup_eu868.rs
@@ -5,6 +5,7 @@ use crate::test_util::Uplink;
 use lora_modulation::{Bandwidth, SpreadingFactor};
 use lorawan::maccommands::parse_uplink_mac_commands;
 use lorawan::parser::{DataHeader, DataPayload, PhyPayload};
+use lorawan::types::DR;
 
 use super::{build_mac, util};
 
@@ -27,7 +28,7 @@ async fn rxparamsetup_eu868() {
     });
 
     fn rxparamsetup_1(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
-        // RxParamSetupReq: RX1DRoffset=2, RX2DataRate=SF10BW125, Frequency=868525000
+        // RxParamSetupReq: RX1DRoffset=2, RX2DataRate=DR2 (SF10BW125), Frequency=868525000
         build_mac(buf, "0522c28684", 1)
     }
 
@@ -41,6 +42,10 @@ async fn rxparamsetup_eu868() {
     }
 
     let session = device.mac.get_session().unwrap();
+    assert_eq!(device.mac.configuration.rx1_dr_offset, 2);
+    assert_eq!(device.mac.configuration.rx2_data_rate, Some(DR::_2));
+    assert_eq!(device.mac.configuration.rx2_frequency, Some(868525000));
+
     let data = session.uplink.mac_commands();
     assert_eq!(parse_uplink_mac_commands(data).count(), 1);
     assert_eq!(data, [5, 7]);

--- a/lorawan-device/src/async_device/test/certification/rxparamsetup_eu868.rs
+++ b/lorawan-device/src/async_device/test/certification/rxparamsetup_eu868.rs
@@ -61,10 +61,10 @@ async fn rxparamsetup_eu868() {
     // RX1
     timer.fire_most_recent().await;
     radio.handle_timeout().await;
-    // TODO: Check for RX1 data rate once RX1DROffset is implemented
-    // let rx_conf = radio.get_rxconfig().await.unwrap();
-    // assert_eq!(rx_conf.rf.bb.sf, SpreadingFactor::..);
-    // assert_eq!(rx_conf.rf.bb.bw, Bandwidth::..);
+    // Validate RX1 data rate (RX1DROffset = 2)
+    let rx_conf = radio.get_rxconfig().await.unwrap();
+    assert_eq!(rx_conf.rf.bb.sf, SpreadingFactor::_12);
+    assert_eq!(rx_conf.rf.bb.bw, Bandwidth::_125KHz);
     // RX2
     timer.fire_most_recent().await;
     radio.handle_timeout().await;

--- a/lorawan-device/src/async_device/test/maccommands.rs
+++ b/lorawan-device/src/async_device/test/maccommands.rs
@@ -500,7 +500,7 @@ async fn newchannelreq_fixed_region_ignore() {
 
 #[tokio::test]
 #[cfg(all(feature = "region-us915", feature = "experimental"))]
-// TODO: Finalize RXParamSetupReq
+// TODO: Finalize RXParamSetupReq/RXTimingSetupReq
 async fn maccommands_in_frmpayload() {
     fn frmpayload_maccommands(
         _uplink: Option<Uplink>,

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -55,9 +55,8 @@ pub struct Configuration {
     join_accept_delay2: u32,
 
     pub(crate) tx_power: Option<u8>,
-    // Overriden with RxParamSetupReq
-    // TODO: rx1_data_rate_offset
-    rx2_data_rate: Option<DR>,
+    pub(crate) rx1_dr_offset: u8,
+    pub(crate) rx2_data_rate: Option<DR>,
     pub(crate) rx2_frequency: Option<u32>,
 }
 
@@ -110,6 +109,7 @@ impl Mac {
             configuration: Configuration {
                 data_rate,
                 rx1_delay: region::constants::RECEIVE_DELAY1,
+                rx1_dr_offset: 0,
                 join_accept_delay1: region::constants::JOIN_ACCEPT_DELAY1,
                 join_accept_delay2: region::constants::JOIN_ACCEPT_DELAY2,
                 rx2_data_rate: None,

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -344,7 +344,11 @@ impl Mac {
                 // TODO: RX1 DR offset
                 (
                     self.region.get_rx_frequency(frame, window),
-                    self.region.get_rx_datarate(self.configuration.data_rate, window),
+                    self.region.get_rx_datarate(
+                        self.configuration.data_rate,
+                        self.configuration.rx1_dr_offset,
+                        window,
+                    ),
                 )
             }
             Window::_2 => {
@@ -355,7 +359,11 @@ impl Mac {
                         .unwrap_or_else(|| self.region.get_rx_frequency(frame, window)),
                     // RX2 datarate override
                     self.configuration.rx2_data_rate.unwrap_or_else(|| {
-                        self.region.get_rx_datarate(self.configuration.data_rate, window)
+                        self.region.get_rx_datarate(
+                            self.configuration.data_rate,
+                            self.configuration.rx1_dr_offset,
+                            window,
+                        )
                     }),
                 )
             }
@@ -370,10 +378,11 @@ impl Mac {
                     dr, self.configuration.data_rate, window
                 );
                 self.region
-                    .get_datarate(
-                        self.region.get_rx_datarate(self.configuration.data_rate, &Window::_2)
-                            as u8,
-                    )
+                    .get_datarate(self.region.get_rx_datarate(
+                        self.configuration.data_rate,
+                        self.configuration.rx1_dr_offset,
+                        &Window::_2,
+                    ) as u8)
                     .unwrap()
             }
         };

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -433,7 +433,6 @@ impl Session {
                     cmd.set_channel_frequency_ack(ack_f).set_data_rate_range_ack(ack_d);
                     self.uplink.add_mac_command(cmd);
                 }
-                #[cfg(feature = "experimental")]
                 RXParamSetupReq(payload) => {
                     let freq = payload.frequency().value();
                     let freq_ack = region.frequency_valid(freq);

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -439,7 +439,7 @@ impl Session {
                     let freq_ack = region.frequency_valid(freq);
 
                     let dl = payload.dl_settings();
-                    // TODO: rx1_dr_offset = dl.rx1_dr_offset();
+                    let rx1_dr_offset = region.rx1_dr_offset_validate(dl.rx1_dr_offset());
                     let rx2_dr = match dl.rx2_data_rate() {
                         DR::_15 => Some(configuration.rx2_data_rate),
                         n => {
@@ -450,13 +450,14 @@ impl Session {
                             }
                         }
                     };
-                    if freq_ack && rx2_dr.is_some() {
+                    if freq_ack && rx2_dr.is_some() && rx1_dr_offset.is_some() {
                         configuration.rx2_data_rate = rx2_dr.unwrap();
                         configuration.rx2_frequency = Some(freq);
+                        configuration.rx1_dr_offset = rx1_dr_offset.unwrap();
                     }
 
                     let mut cmd = RXParamSetupAnsCreator::new();
-                    cmd.set_rx1_data_rate_offset_ack(true)
+                    cmd.set_rx1_data_rate_offset_ack(rx1_dr_offset.is_some())
                         .set_rx2_data_rate_ack(rx2_dr.is_some())
                         .set_channel_ack(freq_ack);
 

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -52,6 +52,8 @@ impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
 impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion
     for AS923Region<DEFAULT_RX2, OFFSET>
 {
+    const MAX_RX1_DR_OFFSET: u8 = 7;
+
     fn join_channels() -> u8 {
         2
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -62,7 +62,7 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion
         DEFAULT_RX2
     }
 
-    fn get_rx_datarate(tx_dr: DR, window: &Window) -> DR {
+    fn get_rx_datarate(tx_dr: DR, _rx1_dr_offset: u8, window: &Window) -> DR {
         // TODO: Handle DwellTime, current values correspond to Dwelltime = 0
         // TODO: Handle RX1 offset
         match window {

--- a/lorawan-device/src/region/dynamic_channel_plans/as923.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/as923.rs
@@ -62,12 +62,19 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion
         DEFAULT_RX2
     }
 
-    fn get_rx_datarate(tx_dr: DR, _rx1_dr_offset: u8, window: &Window) -> DR {
+    fn get_rx_datarate(tx_dr: DR, rx1_dr_offset: u8, window: &Window) -> DR {
         // TODO: Handle DwellTime, current values correspond to Dwelltime = 0
-        // TODO: Handle RX1 offset
+        // In case DwellTime is 1, minimum data rate is DR::_2
         match window {
             Window::_1 => match tx_dr {
-                DR::_0 | DR::_1 | DR::_2 | DR::_3 | DR::_4 | DR::_5 | DR::_6 | DR::_7 => tx_dr,
+                DR::_0 | DR::_1 | DR::_2 | DR::_3 | DR::_4 | DR::_5 | DR::_6 | DR::_7 => {
+                    if rx1_dr_offset < 6 {
+                        tx_dr.offset_sub(rx1_dr_offset)
+                    } else {
+                        u8::try_into(core::cmp::min(tx_dr as u8 + rx1_dr_offset - 5, DR::_7 as u8))
+                            .unwrap()
+                    }
+                }
                 DR::_8 | DR::_9 | DR::_10 | DR::_11 | DR::_12 | DR::_13 | DR::_14 | DR::_15 => {
                     DR::_0
                 }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -49,15 +49,17 @@ impl DynamicChannelRegion for EU433Region {
         434_665_000
     }
 
-    fn get_rx_datarate(tx_dr: DR, _rx1_dr_offset: u8, window: &Window) -> DR {
-        // TODO: Handle RX1 offset
+    fn get_rx_datarate(tx_dr: DR, rx1_dr_offset: u8, window: &Window) -> DR {
         match window {
-            Window::_1 => match tx_dr {
-                DR::_0 | DR::_1 | DR::_2 | DR::_3 | DR::_4 | DR::_5 | DR::_6 | DR::_7 => tx_dr,
-                DR::_8 | DR::_9 | DR::_10 | DR::_11 | DR::_12 | DR::_13 | DR::_14 | DR::_15 => {
-                    DR::_0
-                }
-            },
+            Window::_1 => {
+                let dr = match tx_dr {
+                    DR::_0 | DR::_1 | DR::_2 | DR::_3 | DR::_4 | DR::_5 | DR::_6 | DR::_7 => tx_dr,
+                    DR::_8 | DR::_9 | DR::_10 | DR::_11 | DR::_12 | DR::_13 | DR::_14 | DR::_15 => {
+                        DR::_0
+                    }
+                };
+                dr.offset_sub(rx1_dr_offset)
+            }
             Window::_2 => DR::_0,
         }
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -49,7 +49,7 @@ impl DynamicChannelRegion for EU433Region {
         434_665_000
     }
 
-    fn get_rx_datarate(tx_dr: DR, window: &Window) -> DR {
+    fn get_rx_datarate(tx_dr: DR, _rx1_dr_offset: u8, window: &Window) -> DR {
         // TODO: Handle RX1 offset
         match window {
             Window::_1 => match tx_dr {

--- a/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu433.rs
@@ -39,6 +39,8 @@ impl ChannelRegion for EU433Region {
 }
 
 impl DynamicChannelRegion for EU433Region {
+    const MAX_RX1_DR_OFFSET: u8 = 5;
+
     fn join_channels() -> u8 {
         3
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -46,17 +46,19 @@ impl DynamicChannelRegion for EU868Region {
         3
     }
 
-    fn get_rx_datarate(tx_dr: DR, _rx1_dr_offset: u8, window: &Window) -> DR {
-        // TODO: Handle RX1 offset
+    fn get_rx_datarate(tx_dr: DR, rx1_dr_offset: u8, window: &Window) -> DR {
         match window {
-            Window::_1 => match tx_dr {
-                DR::_0 | DR::_1 | DR::_2 | DR::_3 | DR::_4 | DR::_5 | DR::_6 | DR::_7 => tx_dr,
-                DR::_8 => DR::_1,
-                DR::_9 => DR::_2,
-                DR::_10 => DR::_1,
-                DR::_11 => DR::_2,
-                DR::_12 | DR::_13 | DR::_14 | DR::_15 => DR::_0,
-            },
+            Window::_1 => {
+                let dr = match tx_dr {
+                    DR::_0 | DR::_1 | DR::_2 | DR::_3 | DR::_4 | DR::_5 | DR::_6 | DR::_7 => tx_dr,
+                    DR::_8 => DR::_1,
+                    DR::_9 => DR::_2,
+                    DR::_10 => DR::_1,
+                    DR::_11 => DR::_2,
+                    DR::_12 | DR::_13 | DR::_14 | DR::_15 => DR::_0,
+                };
+                dr.offset_sub(rx1_dr_offset)
+            }
             Window::_2 => DR::_0,
         }
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -46,7 +46,7 @@ impl DynamicChannelRegion for EU868Region {
         3
     }
 
-    fn get_rx_datarate(tx_dr: DR, window: &Window) -> DR {
+    fn get_rx_datarate(tx_dr: DR, _rx1_dr_offset: u8, window: &Window) -> DR {
         // TODO: Handle RX1 offset
         match window {
             Window::_1 => match tx_dr {

--- a/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/eu868.rs
@@ -40,6 +40,8 @@ impl ChannelRegion for EU868Region {
 }
 
 impl DynamicChannelRegion for EU868Region {
+    const MAX_RX1_DR_OFFSET: u8 = 5;
+
     fn join_channels() -> u8 {
         3
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -48,7 +48,7 @@ impl DynamicChannelRegion for IN865Region {
         866_550_000
     }
 
-    fn get_rx_datarate(tx_dr: DR, window: &Window) -> DR {
+    fn get_rx_datarate(tx_dr: DR, _rx1_dr_offset: u8, window: &Window) -> DR {
         // TODO: Handle RX1 offset
         match window {
             Window::_1 => match tx_dr {

--- a/lorawan-device/src/region/dynamic_channel_plans/in865.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/in865.rs
@@ -38,6 +38,8 @@ impl ChannelRegion for IN865Region {
 }
 
 impl DynamicChannelRegion for IN865Region {
+    const MAX_RX1_DR_OFFSET: u8 = 7;
+
     fn join_channels() -> u8 {
         3
     }

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -10,9 +10,9 @@ use lorawan::types::DataRateRange;
 ))]
 mod as923;
 #[cfg(feature = "region-eu433")]
-mod eu433;
+pub(crate) mod eu433;
 #[cfg(feature = "region-eu868")]
-mod eu868;
+pub(crate) mod eu868;
 #[cfg(feature = "region-in865")]
 mod in865;
 

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -102,6 +102,7 @@ impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
 }
 
 pub(crate) trait DynamicChannelRegion: ChannelRegion {
+    const MAX_RX1_DR_OFFSET: u8;
     fn join_channels() -> u8;
     fn init_channels(channels: &mut ChannelPlan);
     fn default_rx2_freq() -> u32;
@@ -313,5 +314,13 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
             return (freq_valid, dr_supported);
         }
         (freq_valid, false)
+    }
+
+    fn rx1_dr_offset_validate(&self, value: u8) -> Option<u8> {
+        if value <= R::MAX_RX1_DR_OFFSET {
+            Some(value)
+        } else {
+            None
+        }
     }
 }

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -106,7 +106,7 @@ pub(crate) trait DynamicChannelRegion: ChannelRegion {
     fn join_channels() -> u8;
     fn init_channels(channels: &mut ChannelPlan);
     fn default_rx2_freq() -> u32;
-    fn get_rx_datarate(tx_datarate: DR, window: &Window) -> DR;
+    fn get_rx_datarate(tx_datarate: DR, rx1_dr_offset: u8, window: &Window) -> DR;
 }
 
 impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
@@ -245,8 +245,8 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
         }
     }
 
-    fn get_rx_datarate(&self, tx_datarate: DR, window: &Window) -> DR {
-        R::get_rx_datarate(tx_datarate, window)
+    fn get_rx_datarate(&self, tx_datarate: DR, rx1_dr_offset: u8, window: &Window) -> DR {
+        R::get_rx_datarate(tx_datarate, rx1_dr_offset, window)
     }
 
     fn check_tx_power(&self, tx_power: u8) -> Option<u8> {

--- a/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
@@ -84,21 +84,23 @@ impl FixedChannelRegion for AU915Region {
     fn default_rx2_freq() -> u32 {
         DEFAULT_RX2
     }
-    fn get_rx_datarate(tx_datarate: DR, _rx1_dr_offset: u8, window: &Window) -> DR {
+    fn get_rx_datarate(tx_dr: DR, rx1_dr_offset: u8, window: &Window) -> DR {
         match window {
             Window::_1 => {
-                // no support for RX1 DR Offset
-                match tx_datarate {
-                    DR::_0 => DR::_8,
-                    DR::_1 => DR::_9,
-                    DR::_2 => DR::_10,
-                    DR::_3 => DR::_11,
-                    DR::_4 => DR::_12,
-                    DR::_5 => DR::_13,
-                    DR::_6 => DR::_13,
-                    DR::_7 => DR::_9,
-                    // TODO: Figure out the best default DR
-                    _ => DR::_10,
+                match tx_dr {
+                    DR::_0 | DR::_1 | DR::_2 | DR::_3 | DR::_4 | DR::_5 | DR::_6 => {
+                        let dr = DR::_8 as u8 + tx_dr as u8 - rx1_dr_offset;
+                        u8::try_into(dr.clamp(DR::_8 as u8, DR::_13 as u8)).unwrap()
+                    }
+                    DR::_7 => {
+                        if rx1_dr_offset == 0 {
+                            DR::_9
+                        } else {
+                            DR::_8
+                        }
+                    }
+                    // Fall back to DR::_8 in this region
+                    _ => DR::_8,
                 }
             }
             Window::_2 => DR::_8,

--- a/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
@@ -84,7 +84,7 @@ impl FixedChannelRegion for AU915Region {
     fn default_rx2_freq() -> u32 {
         DEFAULT_RX2
     }
-    fn get_rx_datarate(tx_datarate: DR, window: &Window) -> DR {
+    fn get_rx_datarate(tx_datarate: DR, _rx1_dr_offset: u8, window: &Window) -> DR {
         match window {
             Window::_1 => {
                 // no support for RX1 DR Offset

--- a/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/mod.rs
@@ -73,6 +73,8 @@ impl ChannelRegion for AU915Region {
 }
 
 impl FixedChannelRegion for AU915Region {
+    const MAX_RX1_DR_OFFSET: u8 = 5;
+
     fn uplink_channels() -> &'static [u32; 72] {
         &UPLINK_CHANNEL_MAP
     }

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -95,7 +95,7 @@ pub(crate) trait FixedChannelRegion: ChannelRegion {
     fn uplink_channels() -> &'static [u32; 72];
     fn downlink_channels() -> &'static [u32; 8];
     fn default_rx2_freq() -> u32;
-    fn get_rx_datarate(tx_datarate: DR, window: &Window) -> DR;
+    fn get_rx_datarate(tx_dr: DR, rx1_dr_offset: u8, window: &Window) -> DR;
 }
 
 impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
@@ -244,8 +244,8 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
         }
     }
 
-    fn get_rx_datarate(&self, tx_datarate: DR, window: &Window) -> DR {
-        F::get_rx_datarate(tx_datarate, window)
+    fn get_rx_datarate(&self, tx_dr: DR, rx1_dr_offset: u8, window: &Window) -> DR {
+        F::get_rx_datarate(tx_dr, rx1_dr_offset, window)
     }
 
     fn check_tx_power(&self, tx_power: u8) -> Option<u8> {

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -91,6 +91,7 @@ impl<F: FixedChannelRegion> FixedChannelPlan<F> {
 }
 
 pub(crate) trait FixedChannelRegion: ChannelRegion {
+    const MAX_RX1_DR_OFFSET: u8;
     fn uplink_channels() -> &'static [u32; 72];
     fn downlink_channels() -> &'static [u32; 8];
     fn default_rx2_freq() -> u32;
@@ -265,5 +266,13 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
 
     fn handle_new_channel(&mut self, _: u8, _: u32, _: Option<DataRateRange>) -> (bool, bool) {
         unreachable!()
+    }
+
+    fn rx1_dr_offset_validate(&self, value: u8) -> Option<u8> {
+        if value <= F::MAX_RX1_DR_OFFSET {
+            Some(value)
+        } else {
+            None
+        }
     }
 }

--- a/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
@@ -89,7 +89,7 @@ impl FixedChannelRegion for US915Region {
     fn default_rx2_freq() -> u32 {
         DEFAULT_RX2
     }
-    fn get_rx_datarate(tx_datarate: DR, window: &Window) -> DR {
+    fn get_rx_datarate(tx_datarate: DR, _rx1_dr_offset: u8, window: &Window) -> DR {
         match window {
             Window::_1 => {
                 // no support for RX1 DR Offset

--- a/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/mod.rs
@@ -78,6 +78,8 @@ impl ChannelRegion for US915Region {
 }
 
 impl FixedChannelRegion for US915Region {
+    const MAX_RX1_DR_OFFSET: u8 = 3;
+
     fn uplink_channels() -> &'static [u32; 72] {
         &UPLINK_CHANNEL_MAP
     }

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -617,6 +617,21 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "region-au915")]
+    fn test_rx1_dr_offset_au915() {
+        let r = Configuration::new(Region::AU915);
+        assert_eq!(r.get_rx_datarate(DR::_0, 4, &Window::_1), DR::_8);
+        assert_eq!(r.get_rx_datarate(DR::_1, 0, &Window::_1), DR::_9);
+        assert_eq!(r.get_rx_datarate(DR::_6, 0, &Window::_1), DR::_13);
+        assert_eq!(r.get_rx_datarate(DR::_6, 1, &Window::_1), DR::_13);
+        assert_eq!(r.get_rx_datarate(DR::_6, 2, &Window::_1), DR::_12);
+        assert_eq!(r.get_rx_datarate(DR::_7, 0, &Window::_1), DR::_9);
+        assert_eq!(r.get_rx_datarate(DR::_7, 1, &Window::_1), DR::_8);
+        // Invalid DR should return DR::_8
+        assert_eq!(r.get_rx_datarate(DR::_12, 0, &Window::_1), DR::_8);
+    }
+
+    #[test]
     #[cfg(feature = "region-us915")]
     fn test_fixed_us915_frequency_range() {
         let r = Configuration::new(Region::US915);
@@ -626,5 +641,22 @@ mod tests {
 
         assert!(!r.frequency_valid(901_900_000));
         assert!(!r.frequency_valid(928_000_001));
+    }
+
+    #[test]
+    #[cfg(feature = "region-us915")]
+    fn test_rx1_dr_offset_us915() {
+        let r = Configuration::new(Region::US915);
+        assert_eq!(r.get_rx_datarate(DR::_0, 3, &Window::_1), DR::_8);
+        assert_eq!(r.get_rx_datarate(DR::_1, 0, &Window::_1), DR::_11);
+        assert_eq!(r.get_rx_datarate(DR::_4, 0, &Window::_1), DR::_13);
+        assert_eq!(r.get_rx_datarate(DR::_4, 1, &Window::_1), DR::_13);
+        assert_eq!(r.get_rx_datarate(DR::_4, 2, &Window::_1), DR::_12);
+        assert_eq!(r.get_rx_datarate(DR::_5, 0, &Window::_1), DR::_10);
+        assert_eq!(r.get_rx_datarate(DR::_5, 1, &Window::_1), DR::_9);
+        assert_eq!(r.get_rx_datarate(DR::_6, 0, &Window::_1), DR::_11);
+        assert_eq!(r.get_rx_datarate(DR::_6, 1, &Window::_1), DR::_10);
+        // Invalid DR should return DR::_8
+        assert_eq!(r.get_rx_datarate(DR::_12, 0, &Window::_1), DR::_8);
     }
 }

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -571,12 +571,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(any(
-        feature = "region-as923-1",
-        feature = "region-as923-2",
-        feature = "region-as923-3",
-        feature = "region-as923-4"
-    ))]
+    #[cfg(feature = "region-as923-1")]
     fn test_rx1_dr_offset_as923() {
         let r = Configuration::new(Region::AS923_1);
         assert_eq!(r.get_rx_datarate(DR::_0, 5, &Window::_1), DR::_0);
@@ -636,6 +631,33 @@ mod tests {
         assert_eq!(r.get_rx_datarate(DR::_11, 1, &Window::_1), DR::_1);
         // Invalid DR should return DR::_0
         assert_eq!(r.get_rx_datarate(DR::_12, 0, &Window::_1), DR::_0);
+    }
+
+    #[test]
+    #[cfg(feature = "region-in865")]
+    fn test_rx1_dr_offset_in865() {
+        let r = Configuration::new(Region::IN865);
+        assert_eq!(r.get_rx_datarate(DR::_0, 5, &Window::_1), DR::_0);
+        assert_eq!(r.get_rx_datarate(DR::_1, 0, &Window::_1), DR::_1);
+        assert_eq!(r.get_rx_datarate(DR::_1, 1, &Window::_1), DR::_0);
+        assert_eq!(r.get_rx_datarate(DR::_2, 0, &Window::_1), DR::_2);
+        assert_eq!(r.get_rx_datarate(DR::_2, 2, &Window::_1), DR::_0);
+        assert_eq!(r.get_rx_datarate(DR::_3, 0, &Window::_1), DR::_3);
+        assert_eq!(r.get_rx_datarate(DR::_3, 2, &Window::_1), DR::_1);
+        assert_eq!(r.get_rx_datarate(DR::_4, 0, &Window::_1), DR::_4);
+        assert_eq!(r.get_rx_datarate(DR::_4, 2, &Window::_1), DR::_2);
+        assert_eq!(r.get_rx_datarate(DR::_5, 0, &Window::_1), DR::_5);
+        assert_eq!(r.get_rx_datarate(DR::_5, 2, &Window::_1), DR::_3);
+        // No DR6 in this region
+        assert_eq!(r.get_rx_datarate(DR::_7, 0, &Window::_1), DR::_7);
+        assert_eq!(r.get_rx_datarate(DR::_7, 5, &Window::_1), DR::_2);
+        // Extra rates for offsets 6 and 7
+        assert_eq!(r.get_rx_datarate(DR::_0, 6, &Window::_1), DR::_1);
+        assert_eq!(r.get_rx_datarate(DR::_0, 7, &Window::_1), DR::_2);
+        assert_eq!(r.get_rx_datarate(DR::_5, 6, &Window::_1), DR::_5);
+        assert_eq!(r.get_rx_datarate(DR::_5, 7, &Window::_1), DR::_7);
+        assert_eq!(r.get_rx_datarate(DR::_7, 6, &Window::_1), DR::_7);
+        assert_eq!(r.get_rx_datarate(DR::_7, 7, &Window::_1), DR::_7);
     }
 
     #[test]

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -571,6 +571,14 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "region-eu433")]
+    fn test_rx1_dr_offset_eu433() {
+        let r = Configuration::new(Region::EU433);
+        assert_eq!(r.get_rx_datarate(DR::_0, 4, &Window::_1), DR::_0);
+        assert_eq!(r.get_rx_datarate(DR::_5, 4, &Window::_1), DR::_1);
+    }
+
+    #[test]
     #[cfg(feature = "region-eu868")]
     fn test_dynamic_region_frequency_range() {
         let r = Configuration::new(Region::EU868);
@@ -583,6 +591,18 @@ mod tests {
 
         // Invalid in default eu868 frequency range, but valid in some areas
         assert!(!r.frequency_valid(872_000_000));
+    }
+
+    #[test]
+    #[cfg(feature = "region-eu868")]
+    fn test_rx1_dr_offset_eu868() {
+        let r = Configuration::new(Region::EU868);
+        assert_eq!(r.get_rx_datarate(DR::_0, 4, &Window::_1), DR::_0);
+        assert_eq!(r.get_rx_datarate(DR::_5, 4, &Window::_1), DR::_1);
+        assert_eq!(r.get_rx_datarate(DR::_11, 0, &Window::_1), DR::_2);
+        assert_eq!(r.get_rx_datarate(DR::_11, 1, &Window::_1), DR::_1);
+        // Invalid DR should return DR::_0
+        assert_eq!(r.get_rx_datarate(DR::_12, 0, &Window::_1), DR::_0);
     }
 
     #[test]

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -433,8 +433,8 @@ impl Configuration {
         region_dispatch!(self, channel_mask_validate, channel_mask, dr)
     }
 
-    pub(crate) fn get_rx_datarate(&self, tx_datarate: DR, window: &Window) -> DR {
-        region_dispatch!(self, get_rx_datarate, tx_datarate, window)
+    pub(crate) fn get_rx_datarate(&self, tx_dr: DR, rx1_dr_offset: u8, window: &Window) -> DR {
+        region_dispatch!(self, get_rx_datarate, tx_dr, rx1_dr_offset, window)
     }
 
     pub(crate) fn get_rx_frequency(&self, frame: &Frame, window: &Window) -> u32 {
@@ -549,7 +549,7 @@ pub(crate) trait RegionHandler {
         frame: &Frame,
     ) -> (Datarate, u32);
 
-    fn get_rx_datarate(&self, datarate: DR, window: &Window) -> DR;
+    fn get_rx_datarate(&self, datarate: DR, rx1_dr_offset: u8, window: &Window) -> DR;
     fn get_rx_frequency(&self, frame: &Frame, window: &Window) -> u32;
     fn get_coding_rate(&self) -> CodingRate {
         DEFAULT_CODING_RATE

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -474,6 +474,10 @@ impl Configuration {
     ) -> (bool, bool) {
         mut_region_dispatch!(self, handle_new_channel, index, freq, data_rates)
     }
+
+    pub(crate) fn rx1_dr_offset_validate(&self, value: u8) -> Option<u8> {
+        region_dispatch!(self, rx1_dr_offset_validate, value)
+    }
 }
 
 macro_rules! from_region {
@@ -558,6 +562,8 @@ pub(crate) trait RegionHandler {
     /// Whether region supports modifying channel plan
     /// with `NewChannelReq`/`DlSettingsReq` MAC commands
     fn has_fixed_channel_plan(&self) -> bool;
+
+    fn rx1_dr_offset_validate(&self, value: u8) -> Option<u8>;
 }
 
 #[cfg(test)]

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -571,6 +571,39 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(any(
+        feature = "region-as923-1",
+        feature = "region-as923-2",
+        feature = "region-as923-3",
+        feature = "region-as923-4"
+    ))]
+    fn test_rx1_dr_offset_as923() {
+        let r = Configuration::new(Region::AS923_1);
+        assert_eq!(r.get_rx_datarate(DR::_0, 5, &Window::_1), DR::_0);
+        assert_eq!(r.get_rx_datarate(DR::_1, 0, &Window::_1), DR::_1);
+        assert_eq!(r.get_rx_datarate(DR::_1, 1, &Window::_1), DR::_0);
+        assert_eq!(r.get_rx_datarate(DR::_2, 0, &Window::_1), DR::_2);
+        assert_eq!(r.get_rx_datarate(DR::_2, 2, &Window::_1), DR::_0);
+        assert_eq!(r.get_rx_datarate(DR::_3, 0, &Window::_1), DR::_3);
+        assert_eq!(r.get_rx_datarate(DR::_3, 2, &Window::_1), DR::_1);
+        assert_eq!(r.get_rx_datarate(DR::_4, 0, &Window::_1), DR::_4);
+        assert_eq!(r.get_rx_datarate(DR::_4, 2, &Window::_1), DR::_2);
+        assert_eq!(r.get_rx_datarate(DR::_5, 0, &Window::_1), DR::_5);
+        assert_eq!(r.get_rx_datarate(DR::_5, 2, &Window::_1), DR::_3);
+        assert_eq!(r.get_rx_datarate(DR::_6, 0, &Window::_1), DR::_6);
+        assert_eq!(r.get_rx_datarate(DR::_6, 2, &Window::_1), DR::_4);
+        assert_eq!(r.get_rx_datarate(DR::_7, 0, &Window::_1), DR::_7);
+        assert_eq!(r.get_rx_datarate(DR::_7, 5, &Window::_1), DR::_2);
+        // Extra rates for offsets 6 and 7
+        assert_eq!(r.get_rx_datarate(DR::_0, 6, &Window::_1), DR::_1);
+        assert_eq!(r.get_rx_datarate(DR::_0, 7, &Window::_1), DR::_2);
+        assert_eq!(r.get_rx_datarate(DR::_6, 6, &Window::_1), DR::_7);
+        assert_eq!(r.get_rx_datarate(DR::_6, 7, &Window::_1), DR::_7);
+        assert_eq!(r.get_rx_datarate(DR::_7, 6, &Window::_1), DR::_7);
+        assert_eq!(r.get_rx_datarate(DR::_7, 7, &Window::_1), DR::_7);
+    }
+
+    #[test]
     #[cfg(feature = "region-eu433")]
     fn test_rx1_dr_offset_eu433() {
         let r = Configuration::new(Region::EU433);

--- a/lorawan-encoding/src/types.rs
+++ b/lorawan-encoding/src/types.rs
@@ -169,6 +169,12 @@ pub enum DR {
     _15 = 15,
 }
 
+impl DR {
+    pub fn offset_sub(&self, val: u8) -> DR {
+        u8::try_into((*self as u8).saturating_sub(val)).unwrap()
+    }
+}
+
 impl TryFrom<u8> for DR {
     type Error = core::convert::Infallible;
 


### PR DESCRIPTION
Now that RX1_DR_OFFSET is implemented, RxParamSetupReq MAC command is fully implemented and `TP_A_EU868_ED_MAC_104_BV_008` test passes.

IN865 offset algorithm seems a bit gnarly though, but seems to be working.

Closes #47 and #82 (and supersedes #354)