### PR TITLE
SX127x: Use integer maths for RSSI linearisation

### DIFF
--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -42,7 +42,7 @@ fn pll_step_to_freq(pll_step: u32) -> u32 {
 }
 
 // RSSI requires linearization when SNR >= 0
-// Section 5.5.5 - Note 3
+// Section 3.5.5 - Note 3
 fn linearize_rssi(rssi: u8) -> i16 {
     // Integer approximation for RSSI * 16.0 / 15.0
     (rssi as i16 * 16 + 7) / 15


### PR DESCRIPTION
Removes floats from RSSI linearisation calculation (see https://github.com/lora-rs/lora-rs/issues/282 and https://github.com/lora-rs/lora-rs/pull/285).
This implementation rounds to the closest integer instead of computing the floor like the current implementation. Therefore, the error between the equation in the datasheet and the calculated RSSI is now in the range [-0.5, 0.5] instead of [0, 1].