### PR TITLE
SX127x: Use provided payload length when receiving in implicit header mode

### DIFF
--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -369,10 +369,14 @@ where
 
     async fn get_rx_payload(
         &mut self,
-        _rx_pkt_params: &PacketParams,
+        rx_pkt_params: &PacketParams,
         receiving_buffer: &mut [u8],
     ) -> Result<u8, RadioError> {
-        let payload_length = self.read_register(Register::RegRxNbBytes).await?;
+        let payload_length = if rx_pkt_params.implicit_header {
+            rx_pkt_params.payload_length
+        } else {
+            self.read_register(Register::RegRxNbBytes).await?
+        };
         if (payload_length as usize) > receiving_buffer.len() {
             return Err(RadioError::PayloadSizeMismatch(
                 payload_length as usize,


### PR DESCRIPTION
The provided payload length should be used in implicit header mode, and `RegRxNbBytes` should only be used in explicit header mode. I have confirmed this works with a pair of SX1276 modules.