### PR TITLE
Method that allows for faster frequency updating while receiving.

### DIFF
--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -279,7 +279,15 @@ where
         Ok(())
     }
 
-    /// Reconfigure radio that is presently receiving to listen to different frequency.
+    /// Reconfigure a radio that is presently receiving to listen on a different frequency,
+    /// without going through a full [`LoRa::prepare_for_rx`].
+    ///
+    /// Only the RF frequency is updated: modulation and packet parameters are kept, and
+    /// band-dependent configuration is not re-applied (image calibration, which the driver
+    /// performs once per [`LoRa::init`] at the first prepared frequency, and the sx127x
+    /// errata workarounds applied at [`LoRa::prepare_for_rx`] time). Intended for hops
+    /// between channels in the same band, like LoRaWAN channel hopping; for a band change,
+    /// use [`LoRa::prepare_for_rx`].
     pub async fn rx_switch_channel(&mut self, frequency_in_hz: u32) -> Result<(), RadioError> {
         if let RadioMode::Receive(listen_mode) = self.radio_mode {
             self.radio_kind.set_standby().await?;

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -279,6 +279,17 @@ where
         Ok(())
     }
 
+    /// Reconfigure radio that is presently receiving to listen to different frequency.
+    pub async fn rx_switch_channel(&mut self, frequency_in_hz: u32) -> Result<(), RadioError> {
+        if let RadioMode::Receive(listen_mode) = self.radio_mode {
+            self.radio_kind.set_standby().await?;
+            self.radio_kind.set_channel(frequency_in_hz).await?;
+            self.radio_kind.do_rx(listen_mode).await
+        } else {
+            Err(RadioError::InvalidRadioMode)
+        }
+    }
+
     /// Switch radio to receive mode (prepared via [`LoRa::prepare_for_rx`]).
     /// Call [`LoRa::complete_rx`] to wait and handle result.
     pub async fn start_rx(&mut self) -> Result<(), RadioError> {

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -51,7 +51,7 @@ pub struct ChipModel {
     pub buffer: [u8; 256],
     tx_base_addr: u8,
     payload_length: u8,
-    frequency_raw: u32,
+    pub frequency_raw: u32,
     irq_status: u16,
     irq_mask: u16,
     dio1_mask: u16,

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -3,11 +3,12 @@
 //! state machine against an emulated chip.
 mod emulator;
 mod fixtures;
-use emulator::{get_emulated_sx1261, Chip, Mode};
+use emulator::{get_emulated_sx1261, Chip, FakeIv, FakeSpi, Mode};
 use fixtures::{get_sx1262, get_sx126x, Delayer, TestFixture};
 
 use crate::mod_params::{RadioMode, RxMode};
 use crate::mod_traits::RadioKind;
+use crate::sx126x::{Sx1261, Sx126x};
 use crate::LoRa;
 use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 use smtc_modem_cores::sx126x::{
@@ -503,6 +504,54 @@ async fn test_emulated_rx_end_to_end() {
     assert_eq!(&buf[..len as usize], b"ping");
     assert_eq!(status.rssi, -80);
     assert_eq!(status.snr, 5);
+}
+
+#[tokio::test]
+async fn test_emulated_rx_switch_channel() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1261(&chip), true, Delayer).await.unwrap();
+
+    let mdltn_params = modulation(&mut lora);
+    let rx_pkt_params = lora
+        .create_rx_packet_params(8, false, 255, true, false, &mdltn_params)
+        .unwrap();
+    lora.prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params)
+        .await
+        .unwrap();
+    lora.start_rx().await.unwrap();
+    chip.with_model(|m| {
+        assert_eq!(m.mode, Mode::Rx);
+        assert_eq!(
+            m.frequency_raw,
+            Sx126x::<FakeSpi, FakeIv, Sx1261>::convert_freq_in_hz_to_pll_step(TEST_FREQ_HZ)
+        );
+    });
+
+    // switch while receiving: chip must end up back in RX on the new
+    // frequency, and the switched-to session must still receive (the model
+    // delivers a pending packet at SetRx time, i.e. through the switch's
+    // own re-enter into RX)
+    chip.inject_rx(b"hop", -80, 5);
+    let new_freq = TEST_FREQ_HZ + 200_000;
+    lora.rx_switch_channel(new_freq).await.unwrap();
+    chip.with_model(|m| {
+        assert_eq!(m.mode, Mode::Rx);
+        assert_eq!(
+            m.frequency_raw,
+            Sx126x::<FakeSpi, FakeIv, Sx1261>::convert_freq_in_hz_to_pll_step(new_freq)
+        );
+    });
+
+    let mut buf = [0u8; 255];
+    let (len, _) = lora.complete_rx(&rx_pkt_params, &mut buf).await.unwrap();
+    assert_eq!(&buf[..len as usize], b"hop");
+
+    // switching while not receiving is rejected
+    lora.sleep(true).await.unwrap();
+    assert_eq!(
+        lora.rx_switch_channel(TEST_FREQ_HZ).await,
+        Err(crate::mod_params::RadioError::InvalidRadioMode)
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Add [rx_switch_channel] method which performs frequency updating conditional on the radio being in receive mode.

Previously, I believe this required the entire dance of creating modulation params, creating rx packet params and preparing for rx thereby resetting a lot of the same parameters over the SPI bus to unchanged values.

This does the simplest thing of:
- entering standby mode
- updating just the frequency registers
- resuming rx

On an ESP32 + Sx1276 device, I observed this reducing frequency updating times from 1815us to 490us on a release build (and 2710us to 1325us on a debug build). This is useful for applications involving continuous receiving coupled with periodic frequency updating, which could be quite timing sensitive.