### PR TITLE
Fix continuous wave mode for SX1276

### DIFF
--- a/lora-phy/src/sx127x/sx1276.rs
+++ b/lora-phy/src/sx127x/sx1276.rs
@@ -204,11 +204,11 @@ impl Sx127xVariant for Sx1276 {
     async fn set_tx_continuous_wave_mode<SPI: SpiDevice<u8>, IV: InterfaceVariant>(
         radio: &mut Sx127x<SPI, IV, Self>,
     ) -> Result<(), RadioError> {
-        radio.intf.iv.enable_rf_switch_rx().await?;
+        radio.intf.iv.enable_rf_switch_tx().await?;
         let pa_config = radio.read_register(Register::RegPaConfig).await?;
         let new_pa_config = pa_config | 0b1000_0000;
         radio.write_register(Register::RegPaConfig, new_pa_config).await?;
-        radio.write_register(Register::RegOpMode, 0b1100_0011).await?;
+        radio.write_register(Register::RegOpMode, 0b1000_0011).await?;
         let modem_config = radio.read_register(Register::RegModemConfig2).await?;
         let new_modem_config = modem_config | 0b0000_1000;
         radio


### PR DESCRIPTION
Enable TX switch and use LoRa registers by not setting bit 6 in `RegOpMode`.
Confirmed to work with an EBYTE 915M30S LoRa module:
<img width="690" height="671" alt="image" src="https://github.com/user-attachments/assets/9b0b21b5-b681-4d91-ab9e-c6047a8e0ab2" />
