### PR TITLE
Update embassy-time version constraint

### DIFF
--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", default-features = false, features = [
     "derive",
 ], optional = true }
 document-features = "0.2.10"
-embassy-time = { version = ">=0.3, <0.5", optional = true }
+embassy-time = { version = ">=0.3, <0.6", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }


### PR DESCRIPTION
Going through the [changelog](https://github.com/embassy-rs/embassy/blob/main/embassy-time/CHANGELOG.md) and using a patched version of lora-rs with embassy-time v0.5 for the last 2 months, I don't see any issues with changing this version requirement.