### PR TITLE
Bump heapless crate to 0.9

### DIFF
--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 lora-modulation = { path = "../lora-modulation", version = ">=0.1.2", default-features = false }
 lorawan = { path = "../lorawan-encoding", version = "0.9", default-features = false }
-heapless = "0.8"
+heapless = "0.9"
 defmt = { version = "0.3", optional = true }
 fastrand = { version = "2", default-features = false }
 futures = { version = "0.3", default-features = false }

--- a/lorawan-encoding/Cargo.toml
+++ b/lorawan-encoding/Cargo.toml
@@ -26,7 +26,7 @@ lorawan-macros = { path = "../lorawan-macros", version = "0.1.0" }
 [dev-dependencies]
 criterion = "0"
 trallocator = "0.2.1"
-heapless = "0.8"
+heapless = "0.9"
 
 [[bench]]
 name = "lorawan"


### PR DESCRIPTION
Heapless-0.8 has bit-rotted against rust-1.92.
This (and #413) will eventually get our CI green again...