### PR TITLE
Stm32wle5cx examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = [
     "examples/stm32l0",
     "examples/stm32wba",
     "examples/stm32wl",
+    "examples/stm32wle5cx",
 ]
 resolver = "2"
 

--- a/examples/stm32wle5cx/.cargo/config.toml
+++ b/examples/stm32wle5cx/.cargo/config.toml
@@ -1,0 +1,9 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# replace your chip as listed in `probe-rs chip list`
+runner = "probe-rs run --chip STM32WLE5CC --speed 1000 --connect-under-reset"
+
+[build]
+target = "thumbv7em-none-eabi"
+
+[env]
+DEFMT_LOG = "trace"

--- a/examples/stm32wle5cx/Cargo.toml
+++ b/examples/stm32wle5cx/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+edition = "2024"
+name = "lora-stm32wle5cx-examples"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+# Change stm32wle5cc to your chip name, if necessary. Also update .cargo/config.toml
+embassy-stm32 = { version = "0.5.0", features = [
+  "defmt",
+  "stm32wle5cc",
+  "time-driver-any",
+  "memory-x",
+  "unstable-pac",
+  "exti",
+  "chrono",
+] }
+embassy-executor = { version = "0.9.1", features = [
+  "arch-cortex-m",
+  "executor-thread",
+  "defmt",
+] }
+embassy-time = { version = "0.5.0", features = [
+  "defmt",
+  "defmt-timestamp-uptime",
+] }
+embassy-sync = { version = "0.7.2", features = ["defmt"] }
+embassy-futures = { version = "0", features = ["defmt"] }
+
+lora-phy = { path = "../../lora-phy", features = ["lorawan-radio", "defmt-03"] }
+lorawan-device = { path = "../../lorawan-device", features = [
+  "embassy-time",
+  "defmt-03",
+] }
+
+defmt = "1.0.1"
+defmt-rtt = "1.1.0"
+panic-probe = { version = "1.0.0", features = ["print-defmt"] }
+
+cortex-m = { version = "0.7.6", features = [
+  "inline-asm",
+  "critical-section-single-core",
+] }
+cortex-m-rt = "0.7.0"
+embedded-hal = { version = "1.0.0" }
+embedded-hal-async = { version = "1.0.0" }
+embedded-hal-bus = { version = "0.3.0", features = ["async"] }
+
+[profile.release]
+debug = 2

--- a/examples/stm32wle5cx/README.md
+++ b/examples/stm32wle5cx/README.md
@@ -1,0 +1,6 @@
+# stm32wle5cx examples
+
+## Overview
+
+These examples demonstrate how to use lora-phy (and sometimes lorawan-device) on the STM32WLE5Cx platform as used on the RAK3272s boards.
+The RAK3272s does not have an onboard debugger, so these examples are done using a J-Link but other probes might work and there are development boards for the RAK3272s.

--- a/examples/stm32wle5cx/build.rs
+++ b/examples/stm32wle5cx/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/examples/stm32wle5cx/src/bin/lora_lorawan_class_c.rs
+++ b/examples/stm32wle5cx/src/bin/lora_lorawan_class_c.rs
@@ -1,0 +1,175 @@
+//! This example runs on a RAK3272s board, which has a builtin Semtech Sx1262 radio.
+//! It demonstrates join bias for US868 devices and Class C functionality.
+#![no_std]
+#![no_main]
+
+#[path = "../iv.rs"]
+mod iv;
+
+use defmt::info;
+
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either, select};
+use embassy_stm32::exti::ExtiInput;
+use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
+use embassy_stm32::mode::Async;
+use embassy_stm32::rng::{self, Rng};
+use embassy_stm32::spi::Spi;
+use embassy_stm32::time::Hertz;
+use embassy_stm32::{bind_interrupts, peripherals};
+use embassy_sync::{
+    blocking_mutex::raw::ThreadModeRawMutex,
+    channel::{Channel, Receiver, Sender},
+};
+use embassy_time::Delay;
+
+use lora_phy::LoRa;
+use lora_phy::lorawan_radio::LorawanRadio;
+use lora_phy::sx126x::{self, Stm32wl, Sx126x, TcxoCtrlVoltage};
+use lorawan_device::async_device::{Device, EmbassyTimer, JoinMode, JoinResponse, SendResponse};
+use lorawan_device::region::{Configuration, Region, Subband};
+use lorawan_device::{AppEui, AppKey, DevEui};
+use {defmt_rtt as _, panic_probe as _};
+
+use self::iv::{InterruptHandler, Stm32wlInterfaceVariant, SubghzSpiDevice};
+
+const MAX_TX_POWER: u8 = 21;
+// During uplinks, it possible to receive a class A downlink and many Class C downlinks.
+// Increasing the stacks buffer to at least 3 is a good start.
+const DOWNLINK_BUFFER: usize = 3;
+
+bind_interrupts!(struct Irqs{
+    SUBGHZ_RADIO => InterruptHandler;
+    RNG => rng::InterruptHandler<peripherals::RNG>;
+});
+
+static CHANNEL: Channel<ThreadModeRawMutex, ButtonState, 3> = Channel::new();
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    info!("Setting up...");
+    let mut config = embassy_stm32::Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.msi = Some(embassy_stm32::rcc::MSIRange::RANGE48M);
+        config.rcc.sys = Sysclk::MSI;
+        config.rcc.mux.rngsel = mux::Rngsel::MSI;
+        config.enable_debug_during_sleep = true;
+    }
+    let p = embassy_stm32::init(config);
+
+    info!("config done...");
+    let tx_pin = Output::new(p.PC13, Level::Low, Speed::VeryHigh);
+    let rx_pin = Output::new(p.PB8, Level::Low, Speed::VeryHigh);
+
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
+    let spi = SubghzSpiDevice(spi);
+    let use_high_power_pa = true;
+    let config = sx126x::Config {
+        chip: Stm32wl { use_high_power_pa },
+        tcxo_ctrl: None,
+        use_dcdc: true,
+        rx_boost: false,
+    };
+    let iv = Stm32wlInterfaceVariant::new(Irqs, use_high_power_pa, Some(rx_pin), Some(tx_pin), None).unwrap();
+    let lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();
+    let _lora_task = spawner.spawn(lora_task(lora, Rng::new(p.RNG, Irqs), CHANNEL.receiver()));
+
+    // let _button_task = spawner.spawn(button_task(button, CHANNEL.sender()));
+}
+
+type Stm32wlLoRa<'d> =
+    LoRa<Sx126x<iv::SubghzSpiDevice<Spi<'d, Async>>, Stm32wlInterfaceVariant<Output<'d>>, Stm32wl>, Delay>;
+
+#[embassy_executor::task]
+async fn lora_task(
+    lora: Stm32wlLoRa<'static>,
+    rng: Rng<'static, peripherals::RNG>,
+    rx: Receiver<'static, ThreadModeRawMutex, ButtonState, 3>,
+) {
+    let radio: LorawanRadio<_, _, MAX_TX_POWER> = lora.into();
+    let mut us915 = Configuration::new(Region::EU868);
+    // Setting join bias causes the device to attempt the first join on subband 2.
+    // If it fails, it will proceed with the other subbands sequentially.
+    // us915.set_join_bias(Subband::_2);
+    let mut device: Device<_, _, _, 256, DOWNLINK_BUFFER> = Device::new(us915.into(), radio, EmbassyTimer::new(), rng);
+    device.enable_class_c();
+
+    // TODO: Adjust the EUI and Keys according to your network credentials
+    let join_mode = JoinMode::OTAA {
+        deveui: DevEui::from([0, 0, 0, 0, 0, 0, 0, 0]),
+        appeui: AppEui::from([0, 0, 0, 0, 0, 0, 0, 0]),
+        appkey: AppKey::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    };
+
+    info!("Joining LoRaWAN network");
+    loop {
+        let join_result = device.join(&join_mode).await;
+        if let Ok(JoinResponse::JoinSuccess) = join_result {
+            info!("LoRaWAN network joined");
+            break;
+        }
+        info!("Join failed: {:?}. Retrying...", join_result);
+    }
+
+    // After joining Class C, the LoRaWAN specification indicates that it is important to send a
+    // confirmed uplink immediately after joining until confirmed such that Class C downlinks are
+    // enabled.
+    loop {
+        info!("Sending uplink...");
+        let result = device.send(&[0x01, 0x02, 0x03, 0x04], 1, true).await;
+        if let Ok(SendResponse::DownlinkReceived(_)) = result {
+            // After an uplink with Class C enabled, it is important to check for multiple downlinks.
+            // It is theoretically possible to receive a Class A downlink and any number of Class C
+            // downlinks during the Class C windows.
+            while let Some(downlink) = device.take_downlink() {
+                info!("Received {:?}", downlink);
+            }
+            break;
+        } else {
+            info!("Uplink failed: {:?}. Retrying...", result);
+        }
+    }
+
+    loop {
+        let either = select(rx.receive(), device.rxc_listen()).await;
+        match either {
+            Either::First(button_state) => {
+                info!("Button state: {:?}", button_state);
+                let resp = device.send(&[0x03], 1, true).await;
+                info!("Sent uplink: {:?}", resp);
+                // After an uplink with Class C enabled, it is important to check for multiple downlinks.
+                // It is theoretically possible to receive a Class A downlink and any number of Class C
+                // downlinks during the Class C windows.
+                while let Some(downlink) = device.take_downlink() {
+                    info!("Received {:?}", downlink);
+                }
+            }
+            Either::Second(downlink) => {
+                info!("Received {:?}", downlink);
+                while let Some(downlink) = device.take_downlink() {
+                    info!("Received {:?}", downlink);
+                }
+            }
+        }
+    }
+}
+
+#[derive(defmt::Format)]
+enum ButtonState {
+    Pressed,
+    Released,
+}
+
+#[embassy_executor::task]
+async fn button_task(mut button: ExtiInput<'static>, tx: Sender<'static, ThreadModeRawMutex, ButtonState, 3>) {
+    info!("Press the USER button...");
+    loop {
+        button.wait_for_falling_edge().await;
+        tx.send(ButtonState::Pressed).await;
+        info!("Pressed!");
+        button.wait_for_rising_edge().await;
+        tx.send(ButtonState::Released).await;
+        info!("Released!");
+    }
+}

--- a/examples/stm32wle5cx/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wle5cx/src/bin/lora_p2p_receive.rs
@@ -1,0 +1,122 @@
+//! This example runs on the RAK3272s board, which has a builtin Semtech Sx1262 radio.
+//! It demonstrates LORA P2P receive functionality in conjunction with the lora_p2p_send example.
+#![no_std]
+#![no_main]
+
+#[path = "../iv.rs"]
+mod iv;
+
+use defmt::{error, info};
+use embassy_executor::Spawner;
+use embassy_stm32::{
+    Config, bind_interrupts,
+    gpio::{Level, Output, Speed},
+    rcc::{MSIRange, Sysclk, mux},
+    spi::Spi,
+};
+use embassy_time::{Delay, Timer};
+use lora_phy::sx126x::{Stm32wl, Sx126x};
+use lora_phy::{LoRa, RxMode};
+use lora_phy::{mod_params::*, sx126x};
+use {defmt_rtt as _, panic_probe as _};
+
+use self::iv::{InterruptHandler, Stm32wlInterfaceVariant, SubghzSpiDevice};
+
+const LORA_FREQUENCY_IN_HZ: u32 = 868_000_000; // warning: set this appropriately for the region
+
+bind_interrupts!(struct Irqs{
+    SUBGHZ_RADIO => InterruptHandler;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        config.rcc.msi = Some(MSIRange::RANGE48M);
+        config.rcc.sys = Sysclk::MSI;
+        config.rcc.mux.rngsel = mux::Rngsel::MSI;
+        config.enable_debug_during_sleep = true;
+    }
+    let p = embassy_stm32::init(config);
+
+    info!("config done...");
+    let tx_pin = Output::new(p.PC13, Level::Low, Speed::VeryHigh);
+    let rx_pin = Output::new(p.PB8, Level::Low, Speed::VeryHigh);
+
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
+    let spi = SubghzSpiDevice(spi);
+    let use_high_power_pa = true;
+    let config = sx126x::Config {
+        chip: Stm32wl { use_high_power_pa },
+        tcxo_ctrl: None,
+        use_dcdc: true,
+        rx_boost: false,
+    };
+    let iv: Stm32wlInterfaceVariant<Output<'_>> =
+        Stm32wlInterfaceVariant::new(Irqs, use_high_power_pa, Some(rx_pin), Some(tx_pin), None).unwrap();
+    let mut lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();
+    info!("lora setup done ...");
+
+    loop {
+        let mut receiving_buffer = [00u8; 100];
+        let mdltn_params = {
+            // TODO: Check configuration of these, how much can they be changed?
+            match lora.create_modulation_params(
+                SpreadingFactor::_12,
+                Bandwidth::_500KHz,
+                CodingRate::_4_8,
+                LORA_FREQUENCY_IN_HZ,
+            ) {
+                Ok(mp) => mp,
+                Err(err) => {
+                    info!("Radio error = {}", err);
+                    continue;
+                }
+            }
+        };
+
+        let rx_pkt_params = {
+            match lora.create_rx_packet_params(8, false, receiving_buffer.len() as u8, true, false, &mdltn_params) {
+                Ok(pp) => pp,
+                Err(err) => {
+                    info!("Radio error = {}", err);
+                    continue;
+                }
+            }
+        };
+
+        match lora
+            .prepare_for_rx(RxMode::Single(255), &mdltn_params, &rx_pkt_params)
+            .await
+        {
+            Ok(()) => {}
+            Err(err) => {
+                info!("Radio error = {}", err);
+                continue;
+            }
+        };
+        match lora.rx(&rx_pkt_params, &mut receiving_buffer).await {
+            Ok((received_len, _rx_pkt_status)) => {
+                if (received_len == 3)
+                    && (receiving_buffer[0] == 0x01u8)
+                    && (receiving_buffer[1] == 0x02u8)
+                    && (receiving_buffer[2] == 0x03u8)
+                {
+                    info!("rx successful");
+                    // debug_indicator.set_high();
+                    Timer::after_secs(5).await;
+                    // debug_indicator.set_low();
+                } else {
+                    info!(
+                        "rx unknown packet, status: {:?}: {:?}",
+                        _rx_pkt_status, receiving_buffer
+                    );
+                }
+            }
+            Err(err) => match err {
+                RadioError::ReceiveTimeout => continue,
+                _ => error!("Error in receiving_buffer: {:?}", err),
+            },
+        }
+    }
+}

--- a/examples/stm32wle5cx/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wle5cx/src/bin/lora_p2p_send.rs
@@ -1,0 +1,113 @@
+//! This example runs on a RAK3272s board, which has a builtin Semtech Sx1262 radio.
+//! It demonstrates LORA P2P send functionality.
+#![no_std]
+#![no_main]
+
+#[path = "../iv.rs"]
+mod iv;
+
+use defmt::{error, info};
+use embassy_executor::Spawner;
+use embassy_stm32::bind_interrupts;
+use embassy_stm32::gpio::{Level, Output, Speed};
+use embassy_stm32::spi::Spi;
+use embassy_time::{Delay, Timer};
+use lora_phy::LoRa;
+use lora_phy::sx126x::{Stm32wl, Sx126x};
+use lora_phy::{mod_params::*, sx126x};
+use {defmt_rtt as _, panic_probe as _};
+
+use self::iv::{InterruptHandler, Stm32wlInterfaceVariant, SubghzSpiDevice};
+
+const LORA_FREQUENCY_IN_HZ: u32 = 868_000_000; // warning: set this appropriately for the region
+
+bind_interrupts!(struct Irqs{
+    SUBGHZ_RADIO => InterruptHandler;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_stm32::Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.msi = Some(embassy_stm32::rcc::MSIRange::RANGE48M);
+        config.rcc.sys = Sysclk::MSI;
+        config.rcc.mux.rngsel = mux::Rngsel::MSI;
+        config.enable_debug_during_sleep = true;
+    }
+    let p = embassy_stm32::init(config);
+
+    info!("config done...");
+    let tx_pin = Output::new(p.PC13, Level::Low, Speed::VeryHigh);
+    let rx_pin = Output::new(p.PB8, Level::Low, Speed::VeryHigh);
+
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
+    let spi = SubghzSpiDevice(spi);
+    let use_high_power_pa = true;
+    let config = sx126x::Config {
+        chip: Stm32wl { use_high_power_pa },
+        tcxo_ctrl: None,
+        use_dcdc: true,
+        rx_boost: false,
+    };
+    let iv = Stm32wlInterfaceVariant::new(Irqs, use_high_power_pa, Some(rx_pin), Some(tx_pin), None).unwrap();
+    let mut lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();
+
+    info!("lora setup done ...");
+
+    loop {
+        let mdltn_params = {
+            match lora.create_modulation_params(
+                SpreadingFactor::_12,
+                Bandwidth::_500KHz,
+                CodingRate::_4_8,
+                LORA_FREQUENCY_IN_HZ,
+            ) {
+                Ok(mp) => mp,
+                Err(err) => {
+                    error!("Radio error = {}", err);
+                    continue;
+                }
+            }
+        };
+
+        let mut tx_pkt_params = {
+            match lora.create_tx_packet_params(8, false, true, false, &mdltn_params) {
+                Ok(pp) => pp,
+                Err(err) => {
+                    error!("Radio error = {}", err);
+                    continue;
+                }
+            }
+        };
+        let buffer = [0x01u8, 0x02u8, 0x03u8];
+
+        match lora
+            .prepare_for_tx(&mdltn_params, &mut tx_pkt_params, 20, &buffer)
+            .await
+        {
+            Ok(()) => {}
+            Err(err) => {
+                error!("Radio error = {}", err);
+                continue;
+            }
+        };
+
+        match lora.tx().await {
+            Ok(()) => {
+                info!("TX DONE");
+            }
+            Err(err) => {
+                error!("Radio error = {}", err);
+                continue;
+            }
+        };
+
+        match lora.sleep(false).await {
+            Ok(()) => info!("Sleep successful"),
+            Err(err) => error!("Sleep unsuccessful = {}", err),
+        }
+        Timer::after_secs(10u64).await;
+        info!("Waking up from sleep!");
+    }
+}

--- a/examples/stm32wle5cx/src/iv.rs
+++ b/examples/stm32wle5cx/src/iv.rs
@@ -1,0 +1,155 @@
+use embassy_stm32::interrupt::InterruptExt;
+use embassy_stm32::{interrupt, pac};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
+use embassy_time::Timer;
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::spi::{ErrorType, Operation, SpiBus, SpiDevice};
+use lora_phy::mod_params::RadioError;
+use lora_phy::mod_params::RadioError::*;
+use lora_phy::mod_traits::InterfaceVariant;
+use lora_phy::DelayNs;
+
+/// Interrupt handler.
+pub struct InterruptHandler {}
+
+impl interrupt::typelevel::Handler<interrupt::typelevel::SUBGHZ_RADIO> for InterruptHandler {
+    unsafe fn on_interrupt() {
+        interrupt::SUBGHZ_RADIO.disable();
+        IRQ_SIGNAL.signal(());
+    }
+}
+
+static IRQ_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
+/// Base for the InterfaceVariant implementation for an stm32wl/sx1262 combination
+pub struct Stm32wlInterfaceVariant<CTRL> {
+    use_high_power_pa: bool,
+    rf_switch_rx: Option<CTRL>,
+    rf_switch_tx: Option<CTRL>,
+    rf_switch_en: Option<CTRL>,
+}
+
+impl<CTRL> Stm32wlInterfaceVariant<CTRL>
+where
+    CTRL: OutputPin,
+{
+    /// Create an InterfaceVariant instance for an stm32wl/sx1262 combination
+    pub fn new(
+        _irq: impl interrupt::typelevel::Binding<interrupt::typelevel::SUBGHZ_RADIO, InterruptHandler> + 'static,
+        use_high_power_pa: bool,
+        rf_switch_rx: Option<CTRL>,
+        rf_switch_tx: Option<CTRL>,
+        rf_switch_en: Option<CTRL>,
+    ) -> Result<Self, RadioError> {
+        interrupt::SUBGHZ_RADIO.disable();
+        Ok(Self {
+            use_high_power_pa,
+            rf_switch_rx,
+            rf_switch_tx,
+            rf_switch_en,
+        })
+    }
+}
+
+impl<CTRL> InterfaceVariant for Stm32wlInterfaceVariant<CTRL>
+where
+    CTRL: OutputPin,
+{
+    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
+        pac::RCC.csr().modify(|w| w.set_rfrst(true));
+        pac::RCC.csr().modify(|w| w.set_rfrst(false));
+        Ok(())
+    }
+    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
+        while pac::PWR.sr2().read().rfbusys() {}
+        Ok(())
+    }
+
+    async fn await_irq(&mut self) -> Result<(), RadioError> {
+        unsafe { interrupt::SUBGHZ_RADIO.enable() };
+        IRQ_SIGNAL.wait().await;
+        Ok(())
+    }
+
+    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
+        if let Some(pin) = &mut self.rf_switch_tx {
+            pin.set_low().map_err(|_| RfSwitchTx)?
+        }
+        if let Some(pin) = &mut self.rf_switch_rx {
+            pin.set_high().map_err(|_| RfSwitchRx)?
+        }
+        if let Some(pin) = &mut self.rf_switch_en {
+            pin.set_high().map_err(|_| RfSwitchRx)?
+        }
+        Ok(())
+    }
+    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
+        if let Some(pin) = &mut self.rf_switch_rx {
+            pin.set_state((!self.use_high_power_pa).into())
+                .map_err(|_| RfSwitchTx)?
+        }
+        if let Some(pin) = &mut self.rf_switch_tx {
+            pin.set_high().map_err(|_| RfSwitchTx)?
+        }
+        if let Some(pin) = &mut self.rf_switch_en {
+            pin.set_high().map_err(|_| RfSwitchRx)?
+        }
+        Ok(())
+    }
+    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
+        if let Some(pin) = &mut self.rf_switch_en {
+            pin.set_low().map_err(|_| RfSwitchRx)?
+        }
+        if let Some(pin) = &mut self.rf_switch_rx {
+            pin.set_low().map_err(|_| RfSwitchRx)?
+        }
+        if let Some(pin) = &mut self.rf_switch_tx {
+            pin.set_low().map_err(|_| RfSwitchTx)?
+        }
+        Ok(())
+    }
+}
+pub struct SubghzSpiDevice<T>(pub T);
+
+impl<T: SpiBus> ErrorType for SubghzSpiDevice<T> {
+    type Error = T::Error;
+}
+
+impl<T: SpiBus> SpiDevice for SubghzSpiDevice<T> {
+    async fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        pac::PWR.subghzspicr().modify(|w| w.set_nss(false));
+
+        let op_res = 'ops: {
+            for op in operations {
+                let res = match op {
+                    Operation::Read(buf) => self.0.read(buf).await,
+                    Operation::Write(buf) => self.0.write(buf).await,
+                    Operation::Transfer(read, write) => self.0.transfer(read, write).await,
+                    Operation::TransferInPlace(buf) => self.0.transfer_in_place(buf).await,
+                    Operation::DelayNs(ns) => match self.0.flush().await {
+                        Err(e) => Err(e),
+                        Ok(()) => {
+                            Timer::after_nanos((*ns) as u64).await;
+                            Ok(())
+                        }
+                    },
+                };
+                if let Err(e) = res {
+                    break 'ops Err(e);
+                }
+            }
+            Ok(())
+        };
+
+        // On failure, it's important to still flush and deassert CS.
+        let flush_res = self.0.flush().await;
+
+        pac::PWR.subghzspicr().modify(|w| w.set_nss(true));
+
+        op_res?;
+        flush_res?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Working examples for using the RAK3272s, as discussed per https://github.com/lora-rs/lora-rs/issues/415. It is mainly copied from the STM32WL example, but because I had some trouble getting it to work with the correct internal pins I thought it might be nice to have an extra example working.

The examples use MSI compared to the other examples, mainly because my board had weird behaviour when i tried to use the HSE that is in the RAK3172 ( I think there is a 32.768K external oscillator clock on that board, but the datasheets i could find do not actually describe it), and with my limited knowledge of embedded boards and what clocks are used for, I just used what worked for me :).