### PR TITLE
Refactor Channel Activity Detection result and add quirk for IRQ handling with SMT32 subghz devices

### DIFF
--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -30,6 +30,11 @@ defmt-03 = ["dep:defmt", "lorawan-device?/defmt-03", "lora-modulation/defmt-03"]
 ## Async LoRaWAN Rx/Tx interface implementation
 lorawan-radio = ["dep:lorawan-device"]
 
+## Include workaround for IRQ handling on STM32's with integrated
+## LoRa chips (for example STM32WLE5Cx)
+## One failure case can be experienced when running CAD detection in loop
+stm32-subghz-irq-quirk = []
+
 [dev-dependencies]
 # Include lorawan-device unconditionally so all regions are enabled for tests
 lorawan-device = { path = "../lorawan-device" }

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -1879,14 +1879,14 @@ where
                     return Err(RadioError::ReceiveTimeout);
                 }
                 if IrqMask::PreambleDetected.is_set(irq_flags) || IrqMask::SyncWordHeaderValid.is_set(irq_flags) {
-                    return Ok(Some(IrqState::PreambleReceived));
+                    return Ok(Some(IrqState::Detect));
                 }
             }
             RadioMode::ChannelActivityDetection => {
+                if IrqMask::CadDetected.is_set(irq_flags) {
+                    return Ok(Some(IrqState::Detect));
+                }
                 if IrqMask::CadDone.is_set(irq_flags) {
-                    if IrqMask::CadDetected.is_set(irq_flags) {
-                        return Ok(Some(IrqState::CadDetected));
-                    }
                     return Ok(Some(IrqState::Done));
                 }
             }

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -23,11 +23,11 @@ pub trait InterfaceVariant {
 /// Specifies an IRQ processing state to run the loop to
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IrqState {
-    /// Runs the loop until after the preamble has been received
-    PreambleReceived,
-    /// Runs the loop until Channel Activity is Detected (or timeout occurs)
-    // TODO: Merge PreambleReceived + CadDetected into `Event`
-    CadDetected,
+    /// Runs until mode-specific event is detected.
+    /// Depending on Radio mode, it can be either:
+    /// * PreambleReceived in Rx mode
+    /// * CadDetected in CAD mode
+    Detect,
     /// Runs the loop until the operation is fully complete
     Done,
 }

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -25,6 +25,9 @@ pub trait InterfaceVariant {
 pub enum IrqState {
     /// Runs the loop until after the preamble has been received
     PreambleReceived,
+    /// Runs the loop until Channel Activity is Detected (or timeout occurs)
+    // TODO: Merge PreambleReceived + CadDetected into `Event`
+    CadDetected,
     /// Runs the loop until the operation is fully complete
     Done,
 }
@@ -111,16 +114,11 @@ pub trait RadioKind {
     async fn process_irq_event(
         &mut self,
         radio_mode: RadioMode,
-        cad_activity_detected: Option<&mut bool>,
         clear_interrupts: bool,
     ) -> Result<Option<IrqState>, RadioError>;
 
     /// Get IRQ state
-    async fn get_irq_state(
-        &mut self,
-        radio_mode: RadioMode,
-        cad_activity_detected: Option<&mut bool>,
-    ) -> Result<Option<IrqState>, RadioError>;
+    async fn get_irq_state(&mut self, radio_mode: RadioMode) -> Result<Option<IrqState>, RadioError>;
     /// Clear IRQ status
     async fn clear_irq_status(&mut self) -> Result<(), RadioError>;
 }

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -930,14 +930,14 @@ where
                     return Err(RadioError::ReceiveTimeout);
                 }
                 if IrqMask::PreambleDetected.is_set(irq_flags) || IrqMask::HeaderValid.is_set(irq_flags) {
-                    return Ok(Some(IrqState::PreambleReceived));
+                    return Ok(Some(IrqState::Detect));
                 }
             }
             RadioMode::ChannelActivityDetection => {
+                if IrqMask::CADActivityDetected.is_set(irq_flags) {
+                    return Ok(Some(IrqState::Detect));
+                }
                 if IrqMask::CADDone.is_set(irq_flags) {
-                    if IrqMask::CADActivityDetected.is_set(irq_flags) {
-                        return Ok(Some(IrqState::CadDetected));
-                    }
                     return Ok(Some(IrqState::Done));
                 }
             }

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -516,30 +516,30 @@ where
         let irq_flags = self.read_register(Register::RegIrqFlags).await?;
         match radio_mode {
             RadioMode::Transmit => {
-                if (irq_flags & IrqMask::TxDone.value()) == IrqMask::TxDone.value() {
+                if IrqMask::TxDone.is_set(irq_flags) {
                     debug!("TxDone in radio mode {}", radio_mode);
                     return Ok(Some(IrqState::Done));
                 }
             }
             RadioMode::Receive(RxMode::Continuous) | RadioMode::Receive(RxMode::Single(_)) => {
-                if (irq_flags & IrqMask::RxDone.value()) == IrqMask::RxDone.value() {
+                if IrqMask::RxDone.is_set(irq_flags) {
                     debug!("RxDone in radio mode {}", radio_mode);
                     return Ok(Some(IrqState::Done));
                 }
-                if (irq_flags & IrqMask::RxTimeout.value()) == IrqMask::RxTimeout.value() {
+                if IrqMask::RxTimeout.is_set(irq_flags) {
                     debug!("RxTimeout in radio mode {}", radio_mode);
                     return Err(RadioError::ReceiveTimeout);
                 }
-                if IrqMask::HeaderValid.is_set_in(irq_flags) {
+                if IrqMask::HeaderValid.is_set(irq_flags) {
                     debug!("HeaderValid in radio mode {}", radio_mode);
                     return Ok(Some(IrqState::Detect));
                 }
             }
             RadioMode::ChannelActivityDetection => {
-                if (irq_flags & IrqMask::CADActivityDetected.value()) == IrqMask::CADActivityDetected.value() {
+                if IrqMask::CADActivityDetected.is_set(irq_flags) {
                     return Ok(Some(IrqState::Detect));
                 }
-                if (irq_flags & IrqMask::CADDone.value()) == IrqMask::CADDone.value() {
+                if IrqMask::CADDone.is_set(irq_flags) {
                     return Ok(Some(IrqState::Done));
                 }
             }

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -532,15 +532,14 @@ where
                 }
                 if IrqMask::HeaderValid.is_set_in(irq_flags) {
                     debug!("HeaderValid in radio mode {}", radio_mode);
-                    return Ok(Some(IrqState::PreambleReceived));
+                    return Ok(Some(IrqState::Detect));
                 }
             }
             RadioMode::ChannelActivityDetection => {
+                if (irq_flags & IrqMask::CADActivityDetected.value()) == IrqMask::CADActivityDetected.value() {
+                    return Ok(Some(IrqState::Detect));
+                }
                 if (irq_flags & IrqMask::CADDone.value()) == IrqMask::CADDone.value() {
-                    debug!("CADDone in radio mode {}", radio_mode);
-                    if (irq_flags & IrqMask::CADActivityDetected.value()) == IrqMask::CADActivityDetected.value() {
-                        return Ok(Some(IrqState::CadDetected));
-                    }
                     return Ok(Some(IrqState::Done));
                 }
             }

--- a/lora-phy/src/sx127x/radio_kind_params.rs
+++ b/lora-phy/src/sx127x/radio_kind_params.rs
@@ -142,7 +142,7 @@ impl IrqMask {
         self as u8
     }
 
-    pub fn is_set_in(self, mask: u8) -> bool {
+    pub fn is_set(self, mask: u8) -> bool {
         self.value() & mask == self.value()
     }
 }


### PR DESCRIPTION
Ok, this PR ballooned a bit and now includes all the changes in an intertwined mess:
1. Firstly, it refactors the mutable argument passing when dealing with CAD results
2. Secondly, it includes the sx127x bit flags handling
3. Thirdly, it adds a quirk for IRQ handling (currently only applied in CAD operation) - #418

