### PR TITLE
Update aes and cmac crates

### DIFF
--- a/lorawan-encoding/Cargo.toml
+++ b/lorawan-encoding/Cargo.toml
@@ -14,8 +14,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aes = { version = "0.8" }
-cmac = { version = "0.7" }
+aes = { version = "0.9.0-rc.4" }
+cmac = { version = "0.8.0-rc.4" }
 hex = { version = "0", default-features = false }
 defmt = { version = "0.3", optional = true }
 serde = { version = "1", default-features = false, features = [

--- a/lorawan-encoding/src/default_crypto.rs
+++ b/lorawan-encoding/src/default_crypto.rs
@@ -1,10 +1,13 @@
 //! Provides a default software implementation for LoRaWAN's cryptographic functions.
 use super::keys::*;
-use aes::cipher::generic_array::GenericArray;
-use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+use aes::cipher::{
+    Array as GenericArray, BlockCipherDecrypt as BlockDecrypt, BlockCipherEncrypt as BlockEncrypt,
+    KeyInit,
+};
 use aes::Aes128;
+use cmac::Cmac as RustCmac;
 
-pub type Cmac = cmac::Cmac<Aes128>;
+pub type Cmac = RustCmac<Aes128>;
 
 /// Provides a default implementation for build object for using the crypto functions.
 #[derive(Default, Debug, PartialEq, Eq)]

--- a/lorawan-encoding/src/default_crypto.rs
+++ b/lorawan-encoding/src/default_crypto.rs
@@ -19,16 +19,15 @@ impl CryptoFactory for DefaultFactory {
     type M = Cmac;
 
     fn new_enc(&self, key: &AES128) -> Self::E {
-        Aes128::new(GenericArray::from_slice(&key.0[..]))
+        Self::E::new_from_slice(&key.0[..]).unwrap()
     }
 
     fn new_dec(&self, key: &AES128) -> Self::D {
-        Aes128::new(GenericArray::from_slice(&key.0[..]))
+        Self::D::new_from_slice(&key.0[..]).unwrap()
     }
 
     fn new_mac(&self, key: &AES128) -> Self::M {
-        let key = GenericArray::from_slice(&key.0[..]);
-        Cmac::new(key)
+        Self::M::new_from_slice(&key.0[..]).unwrap()
     }
 }
 


### PR DESCRIPTION
Switch to to maintained versions of aes and cmac crates as currently used crates depend on generic-array which is starting to bit-rot (broken docsrs feature in nightly).

This is a self-contained branch from #413 to get our CI green again.