### PR TITLE
lorawan-encoding: Bump cmac crate to v0.8.0-rc5

### DIFF
--- a/lorawan-encoding/Cargo.toml
+++ b/lorawan-encoding/Cargo.toml
@@ -15,7 +15,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 aes = { version = "0.9.0-rc.4" }
-cmac = { version = "0.8.0-rc.4" }
+cmac = { version = "0.8.0-rc.5" }
 hex = { version = "0", default-features = false }
 defmt = { version = "0.3", optional = true }
 serde = { version = "1", default-features = false, features = [


### PR DESCRIPTION
This fixes the incompatibility with `digest` crate.

Fixes #424