### PR TITLE
phy: pre-command BUSY check per Semtech datasheets

### DIFF
--- a/lora-phy/src/interface.rs
+++ b/lora-phy/src/interface.rs
@@ -17,45 +17,42 @@ where
         Self { spi, iv }
     }
 
-    // Write a buffer to the radio.
+    // Write a buffer to the radio. Pre-waits for BUSY low per SX1261/2 §8.3.1.
+    // `is_sleep_command` skips the pre-wait for the wake-from-sleep pulse where
+    // BUSY is held HIGH until NSS falls (see `sx126x::ensure_ready`).
     pub async fn write(&mut self, write_buffer: &[u8], is_sleep_command: bool) -> Result<(), RadioError> {
-        self.spi.write(write_buffer).await.map_err(|_| SPI)?;
-        trace!("write: {=[u8]:02x}", write_buffer);
-
         if !is_sleep_command {
             self.iv.wait_on_busy().await?;
         }
+        self.spi.write(write_buffer).await.map_err(|_| SPI)?;
+        trace!("write: {=[u8]:02x}", write_buffer);
 
         Ok(())
     }
 
-    // Write
+    // Write a command buffer followed by an inline payload. Pre-waits as `write()`.
     pub async fn write_with_payload(
         &mut self,
         write_buffer: &[u8],
         payload: &[u8],
         is_sleep_command: bool,
     ) -> Result<(), RadioError> {
+        if !is_sleep_command {
+            self.iv.wait_on_busy().await?;
+        }
         let mut ops = [Operation::Write(write_buffer), Operation::Write(payload)];
         self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
         trace!("write_buf: {=[u8]:02x} -> {=[u8]:02x}", write_buffer, payload);
 
-        if !is_sleep_command {
-            self.iv.wait_on_busy().await?;
-        }
-
         Ok(())
     }
 
-    // Request a read, filling the provided buffer.
+    // Request a read, filling the provided buffer. Pre-waits for BUSY low.
     pub async fn read(&mut self, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<(), RadioError> {
-        {
-            let mut ops = [Operation::Write(write_buffer), Operation::Read(read_buffer)];
-
-            self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
-        }
-
         self.iv.wait_on_busy().await?;
+
+        let mut ops = [Operation::Write(write_buffer), Operation::Read(read_buffer)];
+        self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
 
         trace!(
             "read: addr={=[u8]:02x}, len={}, data={=[u8]:02x}",
@@ -67,20 +64,17 @@ where
         Ok(())
     }
 
-    // Request a read with status, filling the provided buffer and returning the status.
+    // Request a read with status, filling the buffer and returning the status. Pre-waits for BUSY low.
     pub async fn read_with_status(&mut self, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<u8, RadioError> {
-        let mut status = [0u8];
-        {
-            let mut ops = [
-                Operation::Write(write_buffer),
-                Operation::Read(&mut status),
-                Operation::Read(read_buffer),
-            ];
-
-            self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
-        }
-
         self.iv.wait_on_busy().await?;
+
+        let mut status = [0u8];
+        let mut ops = [
+            Operation::Write(write_buffer),
+            Operation::Read(&mut status),
+            Operation::Read(read_buffer),
+        ];
+        self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
 
         trace!(
             "read: addr={=[u8]:02x}, len={}, status={:02x}, buf={=[u8]:02x}",

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -947,7 +947,6 @@ where
     pub async fn bootloader_get_status(&mut self) -> Result<BootloaderStatus, RadioError> {
         // Direct read of 6 bytes (no command, just read status)
         let mut rbuffer = [0u8; 6];
-        self.intf.iv.wait_on_busy().await?;
 
         // Perform a direct read to get status bytes
         let opcode = BootloaderOpCode::GetStatus.bytes();
@@ -1132,7 +1131,6 @@ where
         }
 
         // Write command then data
-        self.intf.iv.wait_on_busy().await?;
         self.intf
             .write_with_payload(&cmd, &cdata[..data.len() * 4], false)
             .await
@@ -1197,7 +1195,6 @@ where
             address as u8,
         ];
 
-        self.intf.iv.wait_on_busy().await?;
         self.intf.write_with_payload(&cmd, data, false).await
     }
 
@@ -1233,7 +1230,6 @@ where
         let opcode = RegMemOpCode::WriteBuffer8.bytes();
         let cmd = [opcode[0], opcode[1]];
 
-        self.intf.iv.wait_on_busy().await?;
         self.intf.write_with_payload(&cmd, data, false).await
     }
 

--- a/lora-phy/src/lr1110_interface.rs
+++ b/lora-phy/src/lr1110_interface.rs
@@ -4,8 +4,9 @@
 //! than the SX126x/SX127x radios:
 //!
 //! - Commands are sent in separate SPI transactions from reads
-//! - After writing a command, wait for BUSY to go low
-//! - Then read the response in a new transaction
+//! - Before every command, wait for BUSY to go low (LR1121 UM §3)
+//! - For reads: wait for BUSY again after sending the command, then read
+//!   the response in a new transaction
 //! - Response always starts with a Stat1 status byte
 //!
 //! Reference: SWDR001 LR11xx Driver HAL specification
@@ -29,54 +30,53 @@ where
         Self { spi, iv }
     }
 
-    // Write a buffer to the radio.
+    // Write a buffer to the radio. Pre-waits for BUSY low per LR1121 UM §3.
+    // `is_sleep_command` skips the pre-wait for wake pulses where BUSY is
+    // held HIGH during sleep.
     pub async fn write(&mut self, write_buffer: &[u8], is_sleep_command: bool) -> Result<(), RadioError> {
-        self.spi.write(write_buffer).await.map_err(|_| SPI)?;
-        trace!("write: {=[u8]:02x}", write_buffer);
-
         if !is_sleep_command {
             self.iv.wait_on_busy().await?;
         }
+        self.spi.write(write_buffer).await.map_err(|_| SPI)?;
+        trace!("write: {=[u8]:02x}", write_buffer);
 
         Ok(())
     }
 
-    // Write command with payload appended
+    // Write command with payload appended. Pre-waits as `write()`.
     pub async fn write_with_payload(
         &mut self,
         write_buffer: &[u8],
         payload: &[u8],
         is_sleep_command: bool,
     ) -> Result<(), RadioError> {
-        let mut ops = [Operation::Write(write_buffer), Operation::Write(payload)];
-        self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
-        trace!("write_buf: {=[u8]:02x} -> {=[u8]:02x}", write_buffer, payload);
-
         if !is_sleep_command {
             self.iv.wait_on_busy().await?;
         }
+        let mut ops = [Operation::Write(write_buffer), Operation::Write(payload)];
+        self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
+        trace!("write_buf: {=[u8]:02x} -> {=[u8]:02x}", write_buffer, payload);
 
         Ok(())
     }
 
     // Request a read, filling the provided buffer.
-    // For LR11xx: This is a two-step operation per the HAL specification:
-    // 1. Write command (NSS low -> write -> NSS high)
-    // 2. Wait for BUSY to go low
+    // For LR11xx this is a two-transaction operation per the HAL spec:
+    // 1. Pre-wait, then write command (NSS low -> write -> NSS high)
+    // 2. Wait for BUSY to go low (chip preparing response)
     // 3. Read response (NSS low -> read with NOPs -> NSS high)
     // The first byte of the response is Stat1, followed by the actual data.
     pub async fn read(&mut self, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<(), RadioError> {
-        // Step 1: Write command in separate transaction
+        // Step 1: Pre-wait, then write command in separate transaction
+        self.iv.wait_on_busy().await?;
         if !write_buffer.is_empty() {
             self.spi.write(write_buffer).await.map_err(|_| SPI)?;
         }
 
-        // Step 2: Wait for BUSY to go low
+        // Step 2: Wait for BUSY to go low (chip preparing response on MISO)
         self.iv.wait_on_busy().await?;
 
-        // Step 3: Read response in separate transaction
-        // First byte is Stat1 (discarded), followed by actual data
-        // Read stat1 and data in a single SPI transaction using transfer
+        // Step 3: Read response; first byte is Stat1 (discarded), rest is data
         let mut stat1 = [0u8; 1];
         let mut ops = [Operation::Read(&mut stat1), Operation::Read(read_buffer)];
         self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
@@ -91,19 +91,19 @@ where
         Ok(())
     }
 
-    // Request a read with status, filling the provided buffer and returning the status.
-    // For LR11xx: Same two-step protocol as read(), but returns the Stat1 byte.
+    // Request a read with status, returning the Stat1 byte. Same two-transaction
+    // protocol as `read()`.
     pub async fn read_with_status(&mut self, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<u8, RadioError> {
-        // Step 1: Write command in separate transaction
+        // Step 1: Pre-wait, then write command in separate transaction
+        self.iv.wait_on_busy().await?;
         if !write_buffer.is_empty() {
             self.spi.write(write_buffer).await.map_err(|_| SPI)?;
         }
 
-        // Step 2: Wait for BUSY to go low
+        // Step 2: Wait for BUSY to go low (chip preparing response on MISO)
         self.iv.wait_on_busy().await?;
 
-        // Step 3: Read response in separate transaction
-        // First byte is Stat1, followed by actual data
+        // Step 3: Read response; first byte is Stat1, rest is data
         let mut stat1 = [0u8; 1];
         let mut ops = [Operation::Read(&mut stat1), Operation::Read(read_buffer)];
         self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
@@ -119,14 +119,11 @@ where
         Ok(stat1[0])
     }
 
-    // Direct read from SPI bus (no command write phase).
-    // For LR11xx: This is used by lr11xx_system_get_status to read stat1+stat2+irq_status.
-    // Unlike read(), this does NOT skip any bytes - all bytes read are returned.
+    // Direct read from SPI bus (no command write phase). Used by
+    // lr11xx_system_get_status to read stat1+stat2+irq_status without skipping
+    // any bytes.
     pub async fn direct_read(&mut self, read_buffer: &mut [u8]) -> Result<(), RadioError> {
-        // Wait for BUSY to go low
         self.iv.wait_on_busy().await?;
-
-        // Read directly - no stat1 skipping
         self.spi.read(read_buffer).await.map_err(|_| SPI)?;
 
         trace!("direct_read: len={}, data={=[u8]:02x}", read_buffer.len(), read_buffer);
@@ -134,20 +131,14 @@ where
         Ok(())
     }
 
-    // Wakeup the LR11xx from sleep mode by toggling NSS.
-    // For LR11xx: This is the HAL-level wakeup that simply asserts NSS low,
-    // waits for BUSY to go low, then de-asserts NSS high.
-    // Reference: SWDR001 lr11xx_hal_wakeup()
+    // Wake the LR11xx from sleep mode by pulsing NSS. BUSY is held HIGH in
+    // sleep, so this can't pre-wait — the next SPI op's pre-wait will catch
+    // the chip once it finishes waking. Reference: SWDR001 lr11xx_hal_wakeup().
     pub async fn wakeup(&mut self) -> Result<(), RadioError> {
-        // Perform a dummy read with an empty buffer
-        // This will assert NSS, wait for BUSY, and de-assert NSS
         let mut dummy = [0u8; 1];
         self.spi.read(&mut dummy).await.map_err(|_| SPI)?;
 
-        // Wait for BUSY to go low
-        self.iv.wait_on_busy().await?;
-
-        trace!("wakeup: chip awakened from sleep");
+        trace!("wakeup: NSS pulsed to wake chip");
 
         Ok(())
     }

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -253,7 +253,6 @@ where
             self.intf
                 .write(&[OpCode::Calibrate.value(), 0b0111_1111], false)
                 .await?;
-            self.intf.iv.wait_on_busy().await?;
         }
 
         // Enable LoRa packet engine...
@@ -337,12 +336,12 @@ where
 
     // Wakeup the radio if it is in Sleep or ReceiveDutyCycle mode; otherwise, ensure it is not busy.
     async fn ensure_ready(&mut self, mode: RadioMode) -> Result<(), RadioError> {
-        match mode {
-            RadioMode::Sleep | RadioMode::Receive(RxMode::DutyCycle(_)) => {
-                let op_code_and_null = [OpCode::GetStatus.value(), 0x00u8];
-                self.intf.write(&op_code_and_null, false).await?;
-            }
-            _ => self.intf.iv.wait_on_busy().await?,
+        // Wake from sleep: BUSY is stuck HIGH until NSS falls, so pass `true`
+        // to skip the pre-wait added by SpiInterface::write. For other modes
+        // the next op's pre-wait handles readiness on its own.
+        if matches!(mode, RadioMode::Sleep | RadioMode::Receive(RxMode::DutyCycle(_))) {
+            let op_code_and_null = [OpCode::GetStatus.value(), 0x00u8];
+            self.intf.write(&op_code_and_null, true).await?;
         }
         Ok(())
     }
@@ -362,7 +361,7 @@ where
             warm_start: warm_start_if_possible,
         };
         let op_code_and_sleep_params = [OpCode::SetSleep.value(), sleep_params.value()];
-        self.intf.write(&op_code_and_sleep_params, true).await?;
+        self.intf.write(&op_code_and_sleep_params, false).await?;
         delay.delay_ms(2).await;
 
         Ok(())


### PR DESCRIPTION
## Problem

While bringing up a downstream project (donglora), I hit a race where TX commands would occasionally fail. Tracked it down to lora-phy not following the BUSY-handshake algorithm Semtech recommends: the host should wait on BUSY *before* issuing each command, not after.

**Details:**

`SpiInterface::{write, write_with_payload, read,
read_with_status}` polls BUSY *after* each SPI op.

On fast MCUs (nRF52840 at 64 MHz, release build) this is racy — `embedded-hal-async`'s `wait_for_low` returns immediately if the pin is already low, and the chip takes up to T_SW ns (SX1261/2 §8.3, Fig. 8-3) to assert BUSY after NSS rises.

The host polls inside that pre-assertion window, sees a stale LOW, fires the next command while the chip is still busy, and the chip silently drops it. In my application, the first `lora.tx()` after a clean boot on Seeed Wio Tracker L1 hangs ~50% of the time.


## Authority

- [SX1261/2 datasheet, DS.SX1261-2.W.APP Rev. 1.2](https://cdn.sparkfun.com/assets/6/b/5/1/4/SX1262_datasheet.pdf) §8.3.1
  "BUSY Control Line": *"it is essential to wait for the BUSY line to
  go low before sending an SPI command."*
- [LR1121 User Manual, UM.LR1121.W.APP Rev. 1.2](https://files.waveshare.com/wiki/Core1121/UserManual_LR1121_v1_2.pdf) §3
  "Host-Controller Interface": *"it is necessary to check the status
  of BUSY prior to sending a command."* (Applies to the LR11xx family
  — see also [LR1110 DS Rev. 1.1](https://download.mikroe.com/documents/datasheets/LR1110_datasheet.pdf) §1.2.5.)
- [RadioLib](https://github.com/jgromes/RadioLib/blob/cffd5af/src/Module.cpp)
  `Module::SPIwriteStream` / `SPIreadStream` call `waitForBusy()` at
  the start of every transaction.
- The [SX1276/77/78/79 datasheet](https://cdn.sparkfun.com/assets/7/7/3/2/2/SX1276_Datasheet.pdf)
  Table 2 exposes no BUSY pin, so
  `GenericSx127xInterfaceVariant::wait_on_busy` stays a no-op and the
  change is behaviorally identical for SX127x.

## Fix

Replace the post-command BUSY wait with a pre-command BUSY check at the start of each `SpiInterface` / `Lr1110SpiInterface` read/write method. Drop the redundant explicit `wait_on_busy()` calls in `sx126x` (after Calibrate, `ensure_ready` non-sleep arm) and `lr1110::mod` (4 regmem/bootloader sites) — all now covered by the interface pre-wait.

The `is_sleep_command` flag keeps its name but now gates the pre-wait; set `true` only when BUSY is held HIGH by design (the wake-from-sleep GetStatus pulse in `sx126x::ensure_ready`). Two callsite flips as a result: `ensure_ready` Sleep arm `false`→`true`; `set_sleep` `true`→`false`.

No public API signature changes.


## Test

- `cargo clippy -p lora-phy --features defmt-03 -- -D warnings` clean.
- Hardware: Seeed Wio Tracker L1 (nRF52840 + SX1262), 20 consecutive
  clean-boot TX cycles → 20/20 (vs ~50% before).