### PR TITLE
phy: pre-command BUSY check before each SPI op

### DIFF
--- a/lora-phy/src/interface.rs
+++ b/lora-phy/src/interface.rs
@@ -17,8 +17,16 @@ where
         Self { spi, iv }
     }
 
+    // Wait for BUSY low before issuing a command (SX1261/2 DS §8.3.1).
+    async fn check_device_ready(&mut self) -> Result<(), RadioError> {
+        self.iv.wait_on_busy().await
+    }
+
     // Write a buffer to the radio.
     pub async fn write(&mut self, write_buffer: &[u8], is_sleep_command: bool) -> Result<(), RadioError> {
+        if !is_sleep_command {
+            self.check_device_ready().await?;
+        }
         self.spi.write(write_buffer).await.map_err(|_| SPI)?;
         trace!("write: {=[u8]:02x}", write_buffer);
 
@@ -36,6 +44,9 @@ where
         payload: &[u8],
         is_sleep_command: bool,
     ) -> Result<(), RadioError> {
+        if !is_sleep_command {
+            self.check_device_ready().await?;
+        }
         let mut ops = [Operation::Write(write_buffer), Operation::Write(payload)];
         self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
         trace!("write_buf: {=[u8]:02x} -> {=[u8]:02x}", write_buffer, payload);
@@ -49,6 +60,7 @@ where
 
     // Request a read, filling the provided buffer.
     pub async fn read(&mut self, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<(), RadioError> {
+        self.check_device_ready().await?;
         {
             let mut ops = [Operation::Write(write_buffer), Operation::Read(read_buffer)];
 
@@ -69,6 +81,7 @@ where
 
     // Request a read with status, filling the provided buffer and returning the status.
     pub async fn read_with_status(&mut self, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<u8, RadioError> {
+        self.check_device_ready().await?;
         let mut status = [0u8];
         {
             let mut ops = [

--- a/lora-phy/src/lr1110_interface.rs
+++ b/lora-phy/src/lr1110_interface.rs
@@ -29,8 +29,16 @@ where
         Self { spi, iv }
     }
 
+    // Wait for BUSY low before issuing a command (LR1121 UM §3).
+    async fn check_device_ready(&mut self) -> Result<(), RadioError> {
+        self.iv.wait_on_busy().await
+    }
+
     // Write a buffer to the radio.
     pub async fn write(&mut self, write_buffer: &[u8], is_sleep_command: bool) -> Result<(), RadioError> {
+        if !is_sleep_command {
+            self.check_device_ready().await?;
+        }
         self.spi.write(write_buffer).await.map_err(|_| SPI)?;
         trace!("write: {=[u8]:02x}", write_buffer);
 
@@ -48,6 +56,9 @@ where
         payload: &[u8],
         is_sleep_command: bool,
     ) -> Result<(), RadioError> {
+        if !is_sleep_command {
+            self.check_device_ready().await?;
+        }
         let mut ops = [Operation::Write(write_buffer), Operation::Write(payload)];
         self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
         trace!("write_buf: {=[u8]:02x} -> {=[u8]:02x}", write_buffer, payload);
@@ -66,6 +77,8 @@ where
     // 3. Read response (NSS low -> read with NOPs -> NSS high)
     // The first byte of the response is Stat1, followed by the actual data.
     pub async fn read(&mut self, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<(), RadioError> {
+        self.check_device_ready().await?;
+
         // Step 1: Write command in separate transaction
         if !write_buffer.is_empty() {
             self.spi.write(write_buffer).await.map_err(|_| SPI)?;
@@ -94,6 +107,8 @@ where
     // Request a read with status, filling the provided buffer and returning the status.
     // For LR11xx: Same two-step protocol as read(), but returns the Stat1 byte.
     pub async fn read_with_status(&mut self, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<u8, RadioError> {
+        self.check_device_ready().await?;
+
         // Step 1: Write command in separate transaction
         if !write_buffer.is_empty() {
             self.spi.write(write_buffer).await.map_err(|_| SPI)?;
@@ -123,8 +138,7 @@ where
     // For LR11xx: This is used by lr11xx_system_get_status to read stat1+stat2+irq_status.
     // Unlike read(), this does NOT skip any bytes - all bytes read are returned.
     pub async fn direct_read(&mut self, read_buffer: &mut [u8]) -> Result<(), RadioError> {
-        // Wait for BUSY to go low
-        self.iv.wait_on_busy().await?;
+        self.check_device_ready().await?;
 
         // Read directly - no stat1 skipping
         self.spi.read(read_buffer).await.map_err(|_| SPI)?;

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -339,8 +339,11 @@ where
     async fn ensure_ready(&mut self, mode: RadioMode) -> Result<(), RadioError> {
         match mode {
             RadioMode::Sleep | RadioMode::Receive(RxMode::DutyCycle(_)) => {
+                // Wake-from-sleep pulse: pass is_sleep_command=true to skip both
+                // BUSY waits, which would otherwise deadlock on the asleep chip.
+                // The next SPI op's pre-command wait absorbs the wake latency.
                 let op_code_and_null = [OpCode::GetStatus.value(), 0x00u8];
-                self.intf.write(&op_code_and_null, false).await?;
+                self.intf.write(&op_code_and_null, true).await?;
             }
             _ => self.intf.iv.wait_on_busy().await?,
         }


### PR DESCRIPTION
## Problem

`SpiInterface` / `Lr1110SpiInterface` wait on BUSY only _after_ each SPI op. SX1261/2 DS §8.3.1 and the LR1121 user manual §3 require waiting for BUSY low _before_ each command too — otherwise, on fast MCUs, the next command can race into the chip during the BUSY-assertion window and be silently dropped.

## Fix

Add `check_device_ready()` — a pre-command BUSY wait — at the start of each read/write method, bracketing each op with the existing post-op `wait_on_busy()`. `is_sleep_command` gates both waits; `ensure_ready`'s wake-from-sleep `GetStatus` pulse passes `is_sleep_command=true` so the pre-wait can't deadlock on the asleep chip.

SX127x has no BUSY pin — `wait_on_busy` is a no-op there, so this is a no-op for SX127x. No public API changes.

Prior art for the pre-command wait: LoRaMac-node, STM32WL HAL, RadioLib, TinyGo sx126x.

## Test

- `cargo clippy -p lora-phy --features defmt-03 -- -D warnings` clean.
- `cargo fmt -p lora-phy --check` clean (no fmt changes).
- Hardware: Seeed Wio Tracker L1 (nRF52840 + SX1262), 20 consecutive clean-boot TX cycles → 20/20 (vs ~50% before).