### PR TITLE
phy: sx127x: clear stale IRQ flags in do_rx before mode change

### DIFF
--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -374,6 +374,17 @@ where
 
         self.write_register(Register::RegFifoAddrPtr, 0x00u8).await?;
 
+        // Clear stale IRQ flags before entering RxContinuous / RxSingle.
+        // RegIrqFlags is W1C with no auto-clear on mode transitions
+        // (SX1276/77/78/79 datasheet §4.1.2.4); a flag left over from
+        // a prior op (RxDone, RxTimeout, CRCError, ValidHeader) keeps
+        // DIO0 latched at "active" the moment do_rx switches RegOpMode,
+        // so the host-side IRQ wait either fires on the stale edge or
+        // never sees the next real edge. Matches the existing do_cad
+        // hygiene in this driver and RadioLib's universal stageMode
+        // pattern (CLEAR → CONFIG → MODE_CHANGE) for SX127x.
+        self.clear_irq_status().await?;
+
         self.write_register(Register::RegOpMode, mode.value()).await
     }
 


### PR DESCRIPTION
## Problem

While bringing up SX1276 on a downstream project (donglora) on LilyGo T-Beam classic (ESP32 + SX1276), I hit a regression where cold-boot `RX_START` deterministically timed out with no chip reply. Bisecting inside lora-phy pinned the trigger to a small SPI-timing change in an unrelated commit (RSSI integer-math linearization, e2871647), but the underlying race in `do_rx` was always there — that commit just shifted timing across the threshold where it
became reproducible.

**Details:**

`Sx127x::do_rx` (`lora-phy/src/sx127x/mod.rs`) writes `RegOpMode = RxContinuous` (or `RxSingle`) without first clearing `RegIrqFlags`. Per SX1276 datasheet §4.1.2.4 every flag in that register is W1C and **no flag auto-clears on a mode-change**. A stale `RxDone`, `RxTimeout`, `CRCError`, or `ValidHeader` flag — left over from a prior op or boot ROM state — keeps DIO0
latched at "active" the moment `do_rx` switches mode.

The host's edge-triggered `wait_for_irq` (or level-triggered `wait_for_high`) either fires on the stale edge before any real packet arrives, or never observes the next real edge because the line never went low. In my application, every cold-boot `RX_START` after the unrelated timing shift hung on `wait_for_irq` until the host's 2 s tag-correlation timeout fired.

## Authority

- [SX1276/77/78/79 datasheet](https://cdn.sparkfun.com/assets/7/7/3/2/2/SX1276_Datasheet.pdf) §4.1.2.4 ("RegIrqFlags") — every bit is W1C; nothing auto-clears on `RegOpMode` writes.
- [RadioLib](https://github.com/jgromes/RadioLib/blob/master/src/modules/SX127x/SX127x.cpp) `SX127x::stageMode` follows `STANDBY → CLEAR_IRQ_FLAGS → CONFIG → MODE_CHANGE` for every mode entry on this chip family.
- This driver's existing `do_cad` already clears flags before the mode-change write; `do_rx` was simply not part of that earlier hygiene fix.

## Fix

**Add** a single `self.clear_irq_status().await?;` between the existing `RegFifoAddrPtr = 0` write and the `RegOpMode = mode` write in `Sx127x::do_rx`. The other intermediate writes (`RegLna`, `RegFifoAddrPtr`) provide enough SPI-bus separation between this clear and the eventual mode write that there's no clear-immediately-before-mode hazard (the kind that empirically broke TX entry — see related PR for the `set_irq_params` reorder).

No public API signature changes. No trait changes. SX1272 also benefits — `do_rx` is shared across the SX127x driver.

## Test

- `cargo clippy -p lora-phy --features defmt-03 -- -D warnings` clean.
- `cargo fmt -p lora-phy --check` clean (no fmt changes).
- Hardware: LilyGo T-Beam classic (ESP32 + SX1276), donglora downstream firmware. Pre-fix: cold-boot first `RX_START` deterministically times out, no reply, never sends ADVERT. Post-fix: cold-boot `RX_START` succeeds reliably across many cold-boot cycles; ADVERT goes out, RX delivers packets normally.
- SX1262 boards (Heltec V3 USB, LilyGo T-Beam Supreme) unaffected — they don't compile this file.