### PR TITLE
phy: sx127x: clear stale IRQ flags before mode changes

### DIFF
--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -382,9 +382,10 @@ where
 
         self.write_register(Register::RegFifoAddrPtr, 0x00u8).await?;
 
-        // Clear stale IRQ flags before entering Rx. RegIrqFlags is W1C with no
-        // auto-clear on mode change (SX1276 DS §4.1.2.4); covers the listen()
-        // path, which does not call set_irq_params.
+        // Interrupt flags stay latched until the host clears them by writing a 1
+        // (SX1276 DS §4.1.2.4); entering Rx does not reset them. Clear here so a
+        // flag left over from an earlier operation can't read as a result of this
+        // one; this also covers listen(), which never calls set_irq_params.
         self.clear_irq_status().await?;
 
         self.write_register(Register::RegOpMode, mode.value()).await
@@ -461,10 +462,12 @@ where
     // enable interrupts on DIO pins (sx127x has multiple),
     // and allow interrupts.
     async fn set_irq_params(&mut self, radio_mode: Option<RadioMode>) -> Result<(), RadioError> {
-        // Clear stale IRQ flags before remapping DIO. RegIrqFlags is W1C with no
-        // auto-clear on mode change (SX1276 DS §4.1.2.4); clearing first keeps
-        // it away from a caller's adjacent RegOpMode write.
-        self.write_register(Register::RegIrqFlags, 0xffu8).await?;
+        // Interrupt flags stay latched until the host clears them by writing a 1
+        // (SX1276 DS §4.1.2.4); mode changes do not reset them. Clear before the
+        // DIO remap so a leftover flag can't sit on a freshly mapped DIO line,
+        // where the MCU's edge-triggered interrupt would either fire on the stale
+        // flag or never see an edge for the next real one.
+        self.clear_irq_status().await?;
 
         match radio_mode {
             Some(RadioMode::Transmit) => {

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -382,6 +382,11 @@ where
 
         self.write_register(Register::RegFifoAddrPtr, 0x00u8).await?;
 
+        // Clear stale IRQ flags before entering Rx. RegIrqFlags is W1C with no
+        // auto-clear on mode change (SX1276 DS §4.1.2.4); covers the listen()
+        // path, which does not call set_irq_params.
+        self.clear_irq_status().await?;
+
         self.write_register(Register::RegOpMode, mode.value()).await
     }
 
@@ -456,6 +461,11 @@ where
     // enable interrupts on DIO pins (sx127x has multiple),
     // and allow interrupts.
     async fn set_irq_params(&mut self, radio_mode: Option<RadioMode>) -> Result<(), RadioError> {
+        // Clear stale IRQ flags before remapping DIO. RegIrqFlags is W1C with no
+        // auto-clear on mode change (SX1276 DS §4.1.2.4); clearing first keeps
+        // it away from a caller's adjacent RegOpMode write.
+        self.write_register(Register::RegIrqFlags, 0xffu8).await?;
+
         match radio_mode {
             Some(RadioMode::Transmit) => {
                 self.write_register(
@@ -512,9 +522,6 @@ where
                 self.write_register(Register::RegDioMapping1, dio_mapping_1).await?;
             }
         }
-
-        // clear all active IRQ flags
-        self.write_register(Register::RegIrqFlags, 0xffu8).await?;
 
         Ok(())
     }

--- a/lora-phy/src/sx127x/test/mod.rs
+++ b/lora-phy/src/sx127x/test/mod.rs
@@ -540,9 +540,6 @@ async fn test_emulated_rx_end_to_end() {
 }
 
 #[tokio::test]
-#[ignore = "documents a known bug: do_rx does not clear stale IRQ flags, so a \
-            restarted receive reports the abandoned session's RxDone as a fresh \
-            packet. Un-ignore when the stale-flag clear lands."]
 async fn test_restarted_rx_ignores_stale_flags() {
     // RegIrqFlags stays latched until the host clears it by writing a 1 —
     // mode changes don't reset it — so a receive that was started but never


### PR DESCRIPTION
## Problem

`RegIrqFlags` is W1C with no auto-clear on `RegOpMode` transitions (SX1276 DS §4.1.2.4). A stale flag keeps DIO0 latched "active" across a mode change, so the host's edge-triggered `wait_for_irq` fires early or misses the next real edge.

## Fix

- `set_irq_params`: move the `RegIrqFlags = 0xFF` clear from the end of the function to the start — cleared before the DIO remap, never adjacent to a caller's `RegOpMode` write.
- `do_rx`: clear flags before entering Rx — covers the `listen()` path, which never calls `set_irq_params`.

Matches RadioLib's `stageMode` discipline (CLEAR → CONFIG → MODE_CHANGE). No public API changes.

Consolidates #431 (the `do_rx` clear) with this PR's `set_irq_params` reorder; #431 is closed in favour of this.

## Test

- `cargo clippy -p lora-phy --features defmt-03 -- -D warnings` clean.
- `cargo fmt -p lora-phy --check` clean (no fmt changes).
- Hardware: LilyGo T-Beam classic (ESP32 + SX1276), donglora downstream firmware. Pre-fix (with the companion `do_rx` clear applied but the trailing-clear ordering preserved): sustained TX-spam workload wedges the chip within seconds — RETRY storms fill the host log, the OLED reverts to splash mode, ai-bot eventually disconnects. Post-fix: same workload runs indefinitely without wedge across many minutes of sustained traffic.
- SX1262 boards (Heltec V3 USB, LilyGo T-Beam Supreme) verified compile-clean — change only touches `sx127x/mod.rs`.