### PR TITLE
phy: add runtime LoRa sync-word setter

### DIFF
--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -44,11 +44,11 @@ use interface::*;
 use mod_params::*;
 use mod_traits::*;
 
-/// Sync word for public LoRaWAN networks
-const LORAWAN_PUBLIC_SYNCWORD: u8 = 0x34;
+/// Sync word for public LoRaWAN networks (0x34 in the legacy single-byte form)
+const LORAWAN_PUBLIC_SYNCWORD: u16 = 0x3444;
 
-/// Sync word for private LoRaWAN networks
-const LORAWAN_PRIVATE_SYNCWORD: u8 = 0x12;
+/// Sync word for private LoRaWAN networks (0x12 in the legacy single-byte form)
+const LORAWAN_PRIVATE_SYNCWORD: u16 = 0x1424;
 
 /// Provides the physical layer API to support LoRa chips
 pub struct LoRa<RK, DLY>
@@ -59,7 +59,7 @@ where
     radio_kind: RK,
     delay: DLY,
     radio_mode: RadioMode,
-    sync_word: u8,
+    sync_word: u16,
     cold_start: bool,
     calibrate_image: bool,
 }
@@ -69,8 +69,14 @@ where
     RK: RadioKind,
     DLY: DelayNs,
 {
-    /// Build and return a new instance of the LoRa physical layer API with a specified sync word
+    /// Build and return a new instance of the LoRa physical layer API with a specified sync word,
+    /// given in the legacy single-byte form (e.g. 0x34 for public LoRaWAN networks)
     pub async fn with_syncword(radio_kind: RK, sync_word: u8, delay: DLY) -> Result<Self, RadioError> {
+        Self::with_syncword_raw(radio_kind, sync_word_from_legacy(sync_word), delay).await
+    }
+
+    // Build with a sync word in the 16-bit form (see [`LoRa::set_lora_sync_word`])
+    async fn with_syncword_raw(radio_kind: RK, sync_word: u16, delay: DLY) -> Result<Self, RadioError> {
         let mut lora = Self {
             radio_kind,
             delay,
@@ -95,7 +101,7 @@ where
         } else {
             LORAWAN_PRIVATE_SYNCWORD
         };
-        Self::with_syncword(radio_kind, sync_word, delay).await
+        Self::with_syncword_raw(radio_kind, sync_word, delay).await
     }
 
     /// Wait for an IRQ event to occur
@@ -187,8 +193,14 @@ where
         self.radio_kind.set_standby().await
     }
 
-    /// Apply a new LoRa sync word to the chip
-    pub async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError> {
+    /// Apply a new LoRa sync word to the chip.
+    ///
+    /// The sync word is given in the 16-bit form the sx126x family writes to
+    /// its sync word registers; the legacy single-byte form 0xYZ used by the
+    /// older chips corresponds to 0xY4Z4 (LoRaWAN public 0x34 -> 0x3444,
+    /// private 0x12 -> 0x1424). The sx127x and lr1110 only support values of
+    /// that shape and return `RadioError::InvalidSyncWord` for others.
+    pub async fn set_lora_sync_word(&mut self, sync_word: u16) -> Result<(), RadioError> {
         self.radio_kind.ensure_ready(self.radio_mode).await?;
         if self.radio_mode != RadioMode::Standby {
             self.radio_kind.set_standby().await?;

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -187,6 +187,18 @@ where
         self.radio_kind.set_standby().await
     }
 
+    /// Apply a new LoRa sync word to the chip
+    pub async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError> {
+        self.radio_kind.ensure_ready(self.radio_mode).await?;
+        if self.radio_mode != RadioMode::Standby {
+            self.radio_kind.set_standby().await?;
+            self.radio_mode = RadioMode::Standby;
+        }
+        self.radio_kind.set_lora_sync_word(sync_word).await?;
+        self.sync_word = sync_word;
+        Ok(())
+    }
+
     /// Place the LoRa physical layer in low power mode, specifying cold or
     /// warm start (if chip supports it)
     pub async fn sleep(&mut self, warm_start_if_possible: bool) -> Result<(), RadioError> {

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -1867,6 +1867,13 @@ where
         Ok(())
     }
 
+    async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError> {
+        let word = convert_sync_word(sync_word);
+        let sync_opcode = RadioOpCode::SetLoRaSyncWord.bytes();
+        let sync_cmd = [sync_opcode[0], sync_opcode[1], word];
+        self.write_command(&sync_cmd).await
+    }
+
     fn create_modulation_params(
         &self,
         spreading_factor: SpreadingFactor,

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -1832,17 +1832,12 @@ pub fn lr_fhss_get_hop_sequence_count(params: &LrFhssParams) -> u16 {
 }
 
 // Convert u8 sync word to single byte value for LR1110
-fn convert_sync_word(sync_word: u8) -> u8 {
-    // LR1110 uses a simpler sync word format
-    sync_word
-}
-
 impl<SPI, IV> RadioKind for Lr1110<SPI, IV>
 where
     SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
-    async fn init_lora(&mut self, sync_word: u8) -> Result<(), RadioError> {
+    async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {
         // Initialize system (DC-DC, TCXO, calibration)
         self.init_system().await?;
 
@@ -1856,7 +1851,7 @@ where
         self.write_command(&cmd).await?;
 
         // Set LoRa sync word
-        let word = convert_sync_word(sync_word);
+        let word = sync_word_to_legacy(sync_word)?;
         let sync_opcode = RadioOpCode::SetLoRaSyncWord.bytes();
         let sync_cmd = [sync_opcode[0], sync_opcode[1], word];
         self.write_command(&sync_cmd).await?;
@@ -1867,8 +1862,8 @@ where
         Ok(())
     }
 
-    async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError> {
-        let word = convert_sync_word(sync_word);
+    async fn set_lora_sync_word(&mut self, sync_word: u16) -> Result<(), RadioError> {
+        let word = sync_word_to_legacy(sync_word)?;
         let sync_opcode = RadioOpCode::SetLoRaSyncWord.bytes();
         let sync_cmd = [sync_opcode[0], sync_opcode[1], word];
         self.write_command(&sync_cmd).await
@@ -2475,15 +2470,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    #[test]
-    fn test_convert_sync_word() {
-        // LR1110 uses simple sync word format
-        assert_eq!(convert_sync_word(0x34), 0x34);
-        assert_eq!(convert_sync_word(0x12), 0x12);
-    }
-
     #[test]
     fn power_level_conversion() {
         // Test that power level conversions work correctly

--- a/lora-phy/src/lr1110/test/mod.rs
+++ b/lora-phy/src/lr1110/test/mod.rs
@@ -157,6 +157,18 @@ async fn test_init_lora() {
 }
 
 #[tokio::test]
+async fn test_runtime_sync_word() {
+    for sync_word in [0x34u8, 0x12] {
+        let mut reference_radio = reference();
+        reference_radio.set_lora_sync_word(sync_word);
+
+        let mut radio = get_lr1110();
+        radio.set_lora_sync_word(sync_word).await.unwrap();
+        assert_eq!(radio.intf.spi, reference_radio.inner, "sync word {sync_word:#x}");
+    }
+}
+
+#[tokio::test]
 async fn test_set_tx_power_and_ramp_time_hp() {
     // High-power PA at max output
     let mut reference_radio = reference();

--- a/lora-phy/src/lr1110/test/mod.rs
+++ b/lora-phy/src/lr1110/test/mod.rs
@@ -152,20 +152,29 @@ async fn test_init_lora() {
     reference_radio.set_lora_sync_word(0x34);
 
     let mut radio = get_lr1110();
-    radio.init_lora(0x34).await.unwrap();
+    radio.init_lora(0x3444).await.unwrap();
     assert_eq!(radio.intf.spi, reference_radio.inner);
 }
 
 #[tokio::test]
 async fn test_runtime_sync_word() {
-    for sync_word in [0x34u8, 0x12] {
+    // The reference API takes the legacy single-byte form, ours the 16-bit
+    // sx126x register form; the lr1110 supports the legacy-representable
+    // subset (0xY4Z4 -> 0xYZ) and rejects everything else.
+    for (sync_word, legacy) in [(0x3444u16, 0x34u8), (0x1424, 0x12)] {
         let mut reference_radio = reference();
-        reference_radio.set_lora_sync_word(sync_word);
+        reference_radio.set_lora_sync_word(legacy);
 
         let mut radio = get_lr1110();
         radio.set_lora_sync_word(sync_word).await.unwrap();
         assert_eq!(radio.intf.spi, reference_radio.inner, "sync word {sync_word:#x}");
     }
+
+    let mut radio = get_lr1110();
+    assert_eq!(
+        radio.set_lora_sync_word(0xAB12).await,
+        Err(crate::mod_params::RadioError::InvalidSyncWord)
+    );
 }
 
 #[tokio::test]

--- a/lora-phy/src/mod_params.rs
+++ b/lora-phy/src/mod_params.rs
@@ -16,6 +16,7 @@ pub enum RadioError {
     DIO1,
     InvalidConfiguration,
     InvalidRadioMode,
+    InvalidSyncWord,
     OpError(u8),
     InvalidBaseAddress(usize, usize),
     PayloadSizeUnexpected(usize),
@@ -137,4 +138,37 @@ pub struct DutyCycleParams {
     pub rx_time: u32,
     /// sleep interval
     pub sleep_time: u32,
+}
+
+// The canonical sync word form is the 16-bit value the sx126x writes to its
+// two sync word registers. The single-byte form used by the older chips
+// (sx127x register, lr11xx SetLoRaSyncWord) maps into it as 0xYZ <-> 0xY4Z4;
+// the LoRaWAN public/private words 0x34/0x12 are 0x3444/0x1424.
+pub(crate) fn sync_word_from_legacy(sync_word: u8) -> u16 {
+    u16::from_be_bytes([(sync_word & 0xF0) | 0x04, ((sync_word & 0x0F) << 4) | 0x04])
+}
+
+pub(crate) fn sync_word_to_legacy(sync_word: u16) -> Result<u8, RadioError> {
+    let [msb, lsb] = sync_word.to_be_bytes();
+    if (msb & 0x0F == 0x04) && (lsb & 0x0F == 0x04) {
+        Ok((msb & 0xF0) | (lsb >> 4))
+    } else {
+        Err(RadioError::InvalidSyncWord)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sync_word_legacy_mapping() {
+        assert_eq!(sync_word_from_legacy(0x34), 0x3444);
+        assert_eq!(sync_word_from_legacy(0x12), 0x1424);
+        assert_eq!(sync_word_to_legacy(0x3444), Ok(0x34));
+        assert_eq!(sync_word_to_legacy(0x1424), Ok(0x12));
+        // values outside the 0xY4Z4 shape have no single-byte equivalent
+        assert_eq!(sync_word_to_legacy(0x3445), Err(RadioError::InvalidSyncWord));
+        assert_eq!(sync_word_to_legacy(0x0012), Err(RadioError::InvalidSyncWord));
+    }
 }

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -34,9 +34,13 @@ pub enum IrqState {
 #[allow(async_fn_in_trait)]
 pub trait RadioKind {
     /// Initialize lora radio
-    async fn init_lora(&mut self, sync_word: u8) -> Result<(), RadioError>;
-    /// Apply a new LoRa sync word to the chip
-    async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError>;
+    ///
+    /// The sync word is given in the 16-bit sx126x register form; the legacy
+    /// single-byte form 0xYZ corresponds to 0xY4Z4.
+    async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError>;
+    /// Apply a new LoRa sync word to the chip, in the same 16-bit form as
+    /// [`RadioKind::init_lora`]
+    async fn set_lora_sync_word(&mut self, sync_word: u16) -> Result<(), RadioError>;
     /// Create modulation parameters specific to the LoRa chip kind and type
     fn create_modulation_params(
         &self,

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -35,6 +35,8 @@ pub enum IrqState {
 pub trait RadioKind {
     /// Initialize lora radio
     async fn init_lora(&mut self, sync_word: u8) -> Result<(), RadioError>;
+    /// Apply a new LoRa sync word to the chip
+    async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError>;
     /// Create modulation parameters specific to the LoRa chip kind and type
     fn create_modulation_params(
         &self,

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -288,6 +288,16 @@ where
         Ok(())
     }
 
+    async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError> {
+        let word = convert_sync_word(sync_word);
+        let lora_syncword_set = [
+            OpCode::WriteRegister.value(),
+            Register::LoRaSyncword.addr1(),
+            Register::LoRaSyncword.addr2(),
+        ];
+        self.intf.write_with_payload(&lora_syncword_set, &word, false).await
+    }
+
     fn create_modulation_params(
         &self,
         spreading_factor: SpreadingFactor,

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -214,18 +214,13 @@ where
     }
 }
 
-// Convert u8 sync word to two byte value expected by sx126x
-fn convert_sync_word(sync_word: u8) -> [u8; 2] {
-    [(sync_word & 0xF0) | 0x04, ((sync_word & 0x0F) << 4) | 0x04]
-}
-
 impl<SPI, IV, C> RadioKind for Sx126x<SPI, IV, C>
 where
     SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
     C: Sx126xVariant,
 {
-    async fn init_lora(&mut self, sync_word: u8) -> Result<(), RadioError> {
+    async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {
         // DC-DC regulator setup (default is LDO)
         if self.config.use_dcdc {
             let reg_data = [OpCode::SetRegulatorMode.value(), RegulatorMode::UseDCDC.value()];
@@ -274,7 +269,7 @@ where
             .write(&[OpCode::SetPacketType.value(), PacketType::LoRa.value()], false)
             .await?;
         // ...and network syncword
-        let word = convert_sync_word(sync_word);
+        let word = sync_word.to_be_bytes();
         let lora_syncword_set = [
             OpCode::WriteRegister.value(),
             Register::LoRaSyncword.addr1(),
@@ -288,8 +283,8 @@ where
         Ok(())
     }
 
-    async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError> {
-        let word = convert_sync_word(sync_word);
+    async fn set_lora_sync_word(&mut self, sync_word: u16) -> Result<(), RadioError> {
+        let word = sync_word.to_be_bytes();
         let lora_syncword_set = [
             OpCode::WriteRegister.value(),
             Register::LoRaSyncword.addr1(),
@@ -871,8 +866,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     // -17 (0xEF) to +14 (0x0E) dBm by step of 1 dB if low power PA is selected
     // -9 (0xF7) to +22 (0x16) dBm by step of 1 dB if high power PA is selected
@@ -881,14 +874,5 @@ mod tests {
         assert_eq!(i32_val as u8, 0xefu8);
         i32_val = -9;
         assert_eq!(i32_val as u8, 0xf7u8);
-    }
-
-    #[test]
-    fn test_convert_sync_word() {
-        // sx126x 0x3444 corresponds to sx127 0x34
-        assert_eq!(convert_sync_word(0x34), [0x34, 0x44]);
-
-        // sx126x 0x1424 corresponds to sx127 0x12
-        assert_eq!(convert_sync_word(0x12), [0x14, 0x24]);
     }
 }

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -139,23 +139,32 @@ async fn test_sync_word() {
         [fixtures::Ops::Write(bytes)] => assert_eq!(bytes, &[0x0D, 0x07, 0x40, 0x34, 0x44]),
         ref other => panic!("unexpected write stream {other:?}"),
     }
-    // 0x34 -> [0x34, 0x44] is asserted against our driver in
-    // sx126x::tests::test_convert_sync_word
+    // 0x34 -> [0x34, 0x44] legacy mapping is asserted in
+    // mod_params::tests::test_sync_word_legacy_mapping
 }
 
 #[tokio::test]
 async fn test_runtime_sync_word() {
     // The runtime setter skips the reference's read-modify-write and writes
     // both bytes directly; prime the reference with the reset values so both
-    // land on the same register write.
+    // land on the same register write. The reference API takes the legacy
+    // single-byte form, ours the 16-bit register form.
     let mut fixture = TestFixture::new();
     fixture.prime_read(&[0x1D, 0x07, 0x40, 0x00], &[0x14, 0x24]);
     let mut reference = Context::new(fixture);
     reference.set_lora_sync_word(0x34);
 
     let mut sx1261 = get_sx126x();
-    sx1261.set_lora_sync_word(0x34).await.unwrap();
+    sx1261.set_lora_sync_word(0x3444).await.unwrap();
     assert_eq!(sx1261.take_spi().writes(), reference.inner.writes());
+
+    // sync words with no legacy equivalent reach the registers unchanged
+    let mut sx1261 = get_sx126x();
+    sx1261.set_lora_sync_word(0xAB12).await.unwrap();
+    match sx1261.take_spi().writes()[..] {
+        [fixtures::Ops::Write(bytes)] => assert_eq!(bytes, &[0x0D, 0x07, 0x40, 0xAB, 0x12]),
+        ref other => panic!("unexpected write stream {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -575,7 +584,7 @@ async fn test_init_lora_composed() {
     let mut sx1261 = get_sx126x();
     sx1261.spi_mut().prime_read(&RETENTION_READ, &[0u8; 9]);
     sx1261.spi_mut().prime_read(&RETENTION_READ, &RETENTION_AFTER_RX_GAIN);
-    sx1261.init_lora(0x34).await.unwrap();
+    sx1261.init_lora(0x3444).await.unwrap();
 
     assert_eq!(sx1261.take_spi().writes(), reference_radio.inner.writes());
 }

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -144,6 +144,21 @@ async fn test_sync_word() {
 }
 
 #[tokio::test]
+async fn test_runtime_sync_word() {
+    // The runtime setter skips the reference's read-modify-write and writes
+    // both bytes directly; prime the reference with the reset values so both
+    // land on the same register write.
+    let mut fixture = TestFixture::new();
+    fixture.prime_read(&[0x1D, 0x07, 0x40, 0x00], &[0x14, 0x24]);
+    let mut reference = Context::new(fixture);
+    reference.set_lora_sync_word(0x34);
+
+    let mut sx1261 = get_sx126x();
+    sx1261.set_lora_sync_word(0x34).await.unwrap();
+    assert_eq!(sx1261.take_spi().writes(), reference.inner.writes());
+}
+
+#[tokio::test]
 async fn test_buffer_base_address() {
     let mut reference = reference();
     reference.set_buffer_base_address(0, 0);

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -154,6 +154,10 @@ where
         Ok(())
     }
 
+    async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError> {
+        self.write_register(Register::RegSyncWord, sync_word).await
+    }
+
     fn create_modulation_params(
         &self,
         spreading_factor: SpreadingFactor,

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -140,7 +140,8 @@ where
     IV: InterfaceVariant,
     C: Sx127xVariant,
 {
-    async fn init_lora(&mut self, sync_word: u8) -> Result<(), RadioError> {
+    async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {
+        let sync_word = sync_word_to_legacy(sync_word)?;
         if self.config.tcxo_used {
             self.write_register(C::reg_txco(), TCXO_FOR_OSCILLATOR).await?;
         }
@@ -154,7 +155,8 @@ where
         Ok(())
     }
 
-    async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError> {
+    async fn set_lora_sync_word(&mut self, sync_word: u16) -> Result<(), RadioError> {
+        let sync_word = sync_word_to_legacy(sync_word)?;
         self.write_register(Register::RegSyncWord, sync_word).await
     }
 

--- a/lora-phy/src/sx127x/test/mod.rs
+++ b/lora-phy/src/sx127x/test/mod.rs
@@ -183,6 +183,18 @@ async fn test_set_lora_sync_word() {
 }
 
 #[tokio::test]
+async fn test_runtime_sync_word() {
+    for sync_word in [0x34u8, 0x12] {
+        let mut reference_radio = reference();
+        reference_radio.set_lora_sync_word(sync_word);
+
+        let mut radio = get_sx1276();
+        radio.set_lora_sync_word(sync_word).await.unwrap();
+        assert_eq!(radio.take_spi(), *reference_radio.spi(), "sync word {sync_word:#x}");
+    }
+}
+
+#[tokio::test]
 async fn test_symbol_timeout() {
     let mut reference_radio = reference();
     reference_radio.set_lora_sync_timeout(100);

--- a/lora-phy/src/sx127x/test/mod.rs
+++ b/lora-phy/src/sx127x/test/mod.rs
@@ -176,7 +176,7 @@ async fn test_set_lora_sync_word() {
 
     let mut radio = get_sx1276();
     // init_lora also writes the buffer base addresses and reads the version
-    radio.init_lora(0x34).await.unwrap();
+    radio.init_lora(0x3444).await.unwrap();
     reference_radio.write_register(0x0E, &[0x00]);
     reference_radio.write_register(0x0F, &[0x00]);
     assert_eq!(radio.take_spi(), *reference_radio.spi());
@@ -184,14 +184,23 @@ async fn test_set_lora_sync_word() {
 
 #[tokio::test]
 async fn test_runtime_sync_word() {
-    for sync_word in [0x34u8, 0x12] {
+    // The reference API takes the legacy single-byte form, ours the 16-bit
+    // sx126x register form; the sx127x supports the legacy-representable
+    // subset (0xY4Z4 -> 0xYZ) and rejects everything else.
+    for (sync_word, legacy) in [(0x3444u16, 0x34u8), (0x1424, 0x12)] {
         let mut reference_radio = reference();
-        reference_radio.set_lora_sync_word(sync_word);
+        reference_radio.set_lora_sync_word(legacy);
 
         let mut radio = get_sx1276();
         radio.set_lora_sync_word(sync_word).await.unwrap();
         assert_eq!(radio.take_spi(), *reference_radio.spi(), "sync word {sync_word:#x}");
     }
+
+    let mut radio = get_sx1276();
+    assert_eq!(
+        radio.set_lora_sync_word(0xAB12).await,
+        Err(crate::mod_params::RadioError::InvalidSyncWord)
+    );
 }
 
 #[tokio::test]
@@ -453,7 +462,7 @@ async fn test_bw500_sensitivity_errata() {
 
     let mut radio = get_sx1276();
     // init_lora reads the chip version (seeded 0x12) which arms the quirk
-    radio.init_lora(0x34).await.unwrap();
+    radio.init_lora(0x3444).await.unwrap();
     let params = radio
         .create_modulation_params(SpreadingFactor::_9, Bandwidth::_500KHz, CodingRate::_4_5, 868_100_000)
         .unwrap();


### PR DESCRIPTION
Add `LoRa::set_lora_sync_word(sync_word: u8)` so the LoRa sync word can be changed on a running driver. Today the only public path for setting the sync word is at construction:

- `LoRa::with_syncword(radio_kind, sync_word: u8, delay)` — accepts an arbitrary byte but is only callable while building the driver.
- `LoRa::new(radio_kind, enable_public_network: bool, delay)` — picks between the two hardcoded LoRaWAN values: `LORAWAN_PRIVATE_SYNCWORD = 0x12` and `LORAWAN_PUBLIC_SYNCWORD = 0x34` (`lora-phy/src/lib.rs:43-46`).

That leaves no way to retune the chip's sync word after init without tearing down and reconstructing the whole `LoRa<RK, DLY>` — which is awkward in `no_std` embedded contexts because the driver owns single-use SPI / GPIO pin resources. Downstream applications that need runtime sync-word switching (custom non-LoRaWAN meshes, MeshCore-style private byte `0x12`, dynamic channel-plan reconfiguration, etc.) currently have to either:

1. Pick one sync word at build time and live with it, or
2. Reach into the chip with raw SPI ops, bypassing lora-phy.

Neither is great. This PR adds the obvious missing API.

### Background

The SX126x stores the LoRa sync word in two 8-bit registers: `LoRaSyncwordMSB` at `0x0740` and `LoRaSyncwordLSB` at `0x0741` (SX1261/SX1262 datasheet Rev 2.2 §13.4.4, register map table). `init_lora` already writes them once at cold init via the existing inline sequence at `sx126x/mod.rs:264-270`.

The SX127x family stores it in a single 8-bit register, `RegSyncWord` at `0x39` (SX1276/77/78/79 datasheet §6.4 "Digital Interface", LoRa register map). `init_lora` writes it at `sx127x/mod.rs:140` via the existing `write_register(Register::RegSyncWord, sync_word)` call.

The LR1110 / LR1121 use the `SetLoRaSyncWord` command (opcode `0x022B`) with a single u8 payload (LR1121 user manual §6.6.4). `init_lora` writes it at `lr1110/mod.rs:1343-1346`.

In all three cases the underlying chip primitive is byte-addressable. The current `init_lora(sync_word: u8)` signature already reflects that.

### Implementation

```rust
pub trait RadioKind {
    async fn init_lora(&mut self, sync_word: u8) -> Result<(), RadioError>;
    /// Apply a new LoRa sync word to the chip
    async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError>;
    ...
}
```

with chip-specific impls and a public `LoRa::set_lora_sync_word` wrapper.

Each chip impl is the same single-register write or single opcode that `init_lora` already performs for the same byte. Duplicated rather than factored, to keep this PR strictly additive and `init_lora` untouched. The diff is **+35 lines, –0 lines**:

```
 lora-phy/src/lib.rs        | 12 ++++++++++++
 lora-phy/src/lr1110/mod.rs |  7 +++++++
 lora-phy/src/mod_traits.rs |  2 ++
 lora-phy/src/sx126x/mod.rs | 10 ++++++++++
 lora-phy/src/sx127x/mod.rs |  4 ++++
 5 files changed, 35 insertions(+), 0 deletions(-)
```

The public wrapper at the `LoRa<RK, DLY>` level mirrors the existing discipline already used by `sleep` and `prepare_modem` for any chip- touching operation:

```rust
pub async fn set_lora_sync_word(&mut self, sync_word: u8) -> Result<(), RadioError> {
    self.radio_kind.ensure_ready(self.radio_mode).await?;
    if self.radio_mode != RadioMode::Standby {
        self.radio_kind.set_standby().await?;
        self.radio_mode = RadioMode::Standby;
    }
    self.radio_kind.set_lora_sync_word(sync_word).await?;
    self.sync_word = sync_word;
    Ok(())
}
```

Three points worth flagging:

1. **`ensure_ready` first** — SX1261/2 datasheet Rev 2.2 §8.3.1 ("Host Controller Interface", Busy management): "the host _must_ check that the `BUSY` line is at a low level before sending a new command". `ensure_ready` is the existing mechanism in this crate for that wait (either a `GetStatus` pulse if waking from Sleep, or a direct `wait_on_busy` otherwise). Matches the preamble that `sleep`, `prepare_modem`, `prepare_for_tx`, etc. all use.

2. **Driven to Standby before the register write** — both `WriteRegister` (SX126x) and the equivalent `SetLoRaSyncWord` op (LR1110) are documented as safe in Standby. Some packet-engine configuration commands on SX126x are not safe outside Standby; we apply the same discipline to keep behavior consistent. SX127x has no BUSY pin (`wait_on_busy` is a no-op) so the precondition is trivially satisfied — the standby step still runs for state- tracking consistency.

3. **`self.sync_word = sync_word` cached** — the `LoRa` struct's `sync_word` field is read by `do_cold_start` → `init_lora` during `LoRa::init()`. Any later cold reset (e.g. wedge recovery via `NRESET` + `lora.init()`) re-applies whatever value is in this field. Without the cache update the driver would silently revert to the construction-time default on recovery.

### Precedent

- **In this crate** — `LR1110::set_gfsk_sync_word(&[u8])` at `lora-phy/src/lr1110/mod.rs:712` is exactly the same pattern (runtime sync-word setter, post-construction) already established for GFSK on LR1110. This PR brings the same affordance to LoRa on SX126x / SX127x / LR1110.

- **RadioLib** — `SX126x::setSyncWord(uint16_t syncWord, uint8_t controlBits)` accepts an arbitrary 16-bit value and writes it straight to `RADIOLIB_SX126X_REG_LORA_SYNC_WORD_MSB` / `_LSB`. RadioLib defines `RADIOLIB_SX126X_SYNC_WORD_PRIVATE = 0x1424` and `RADIOLIB_SX126X_SYNC_WORD_PUBLIC = 0x3444` as named constants but does not restrict the API to those values. Same shape on `SX127x::setSyncWord(uint8_t)` (single byte to `REG_SYNC_WORD`).

- **Semtech reference drivers** — the SX126x driver published as part of the Semtech "LoRa SDK" exposes the sync-word register pair via `sx126x_set_lora_sync_word(...)` (a thin `WriteRegister` wrapper). No equivalent existed in lora-phy until now.

### Testing

Verified on hardware (Heltec V4 and Heltec Mesh Node T114):

- Two-dongle bench test rotating through six sync-word values on the TX side (`0x1424`, `0x3444`, `0x5464`, `0x7484`, `0xA4B4`, `0xC4D4` — the 8-byte register-pair encodings of bytes `0x12`, `0x34`, `0x56`, `0x78`, `0xAB`, `0xCD` per the SX126x `convert_sync_word` helper) while the RX side stays pinned to one. RX receives exactly the packets whose sync word matches its own (RSSI ≈ –58 dBm, SNR ≈ 12 dB, validated against ambient noise floor).
- MeshCore interop: with the private byte `0x12` (register pair `0x1424`) applied via this API, packets are correctly received by unmodified MeshCore repeaters using RadioLib's `RADIOLIB_SX126X_SYNC_WORD_PRIVATE` constant.
- Cold-reset survival: triggered the recovery state (NRESET + `lora.init()`) on a host application that had previously called `set_lora_sync_word(0x56)`; chip resumes on `0x56`, not on the construction-time `0x12`, confirming the `self.sync_word` cache update.

### Compatibility

Pure addition. No existing public API changed. No behavioral change to `init_lora`, `with_syncword`, or any other path. Adds one trait method to `RadioKind` (the trait is `pub` but downstream impls are expected to live in this crate's chip drivers — there is no existing out-of-tree `RadioKind` impl pattern; the trait sits behind the `LoRa<RK, DLY>` façade).

### References

- Semtech SX1261/SX1262 datasheet, Rev 2.2 (Dec 2024)
  - §8.3.1 — Host controller interface, BUSY signaling protocol
  - §13.4.4 — Register map, `LoRaSyncwordMSB` (0x0740) /
    `LoRaSyncwordLSB` (0x0741)
- Semtech SX1276/77/78/79 datasheet, Rev 7 (May 2020)
  - §6.4 — Digital interface, LoRa register map, `RegSyncWord` (0x39)
- Semtech LR1121 user manual, Rev 1.1
  - §6.6.4 — `SetLoRaSyncWord` opcode (0x022B)
- Semtech AN1200.22 — "LoRa Modulation Basics" (sync word as
  single-byte protocol concept)
- RadioLib v6.x — `SX126x::setSyncWord(uint16_t, uint8_t)` and
  `SX127x::setSyncWord(uint8_t)` for prior-art API shape
- `lora-phy/src/lr1110/mod.rs:712` — existing
  `set_gfsk_sync_word(&[u8])` as in-crate precedent