### PR TITLE
phy: sx126x: sync host state around CAD

### DIFF
--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -460,7 +460,13 @@ where
                 .process_irq_event(self.radio_mode, Some(&mut cad_activity_detected), true)
                 .await
             {
-                Ok(Some(IrqState::Done)) => Ok(cad_activity_detected),
+                Ok(Some(IrqState::Done)) => {
+                    // CAD_ONLY exit returns the chip to STDBY_RC on its own; sync
+                    // radio_mode so the next operation starts from a known state.
+                    self.radio_kind.set_standby().await?;
+                    self.radio_mode = RadioMode::Standby;
+                    Ok(cad_activity_detected)
+                }
                 Err(err) => {
                     self.radio_kind.ensure_ready(self.radio_mode).await?;
                     self.radio_kind.set_standby().await?;

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -674,6 +674,9 @@ where
     }
 
     async fn do_cad(&mut self, mdltn_params: &ModulationParams) -> Result<(), RadioError> {
+        // Enter CAD from a known Standby state.
+        self.set_standby().await?;
+
         self.intf.iv.enable_rf_switch_rx().await?;
 
         let mut rx_gain_final = 0x94u8;
@@ -683,6 +686,11 @@ where
         }
 
         self.reg_w_8(Register::RxGain, rx_gain_final).await?;
+
+        // Clear stale IRQ flags before SetCadParams/SetCAD. IRQ status bits are
+        // latched and DIO1 is the OR of masked bits (SX1261/2 DS §8.5), so a
+        // leftover bit can suppress the next CadDone edge. Defensive.
+        self.clear_irq_status().await?;
 
         // See:
         //  https://lora-developers.semtech.com/documentation/tech-papers-and-guides/channel-activity-detection-ensuring-your-lora-packets-are-sent/how-to-ensure-your-lora-packets-are-sent-properly

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -674,9 +674,6 @@ where
     }
 
     async fn do_cad(&mut self, mdltn_params: &ModulationParams) -> Result<(), RadioError> {
-        // Enter CAD from a known Standby state.
-        self.set_standby().await?;
-
         self.intf.iv.enable_rf_switch_rx().await?;
 
         let mut rx_gain_final = 0x94u8;
@@ -686,11 +683,6 @@ where
         }
 
         self.reg_w_8(Register::RxGain, rx_gain_final).await?;
-
-        // Clear stale IRQ flags before SetCadParams/SetCAD. IRQ status bits are
-        // latched and DIO1 is the OR of masked bits (SX1261/2 DS §8.5), so a
-        // leftover bit can suppress the next CadDone edge. Defensive.
-        self.clear_irq_status().await?;
 
         // See:
         //  https://lora-developers.semtech.com/documentation/tech-papers-and-guides/channel-activity-detection-ensuring-your-lora-packets-are-sent/how-to-ensure-your-lora-packets-are-sent-properly

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -652,6 +652,14 @@ async fn test_emulated_cad_end_to_end() {
     chip.with_model(|m| m.cad_activity = true);
     lora.prepare_for_cad(&mdltn_params).await.unwrap();
     assert!(lora.cad(&mdltn_params).await.unwrap());
+
+    // CAD completion returns the chip to standby and the wrapper's cached
+    // mode follows, so another cad() requires a fresh prepare_for_cad
+    chip.with_model(|m| assert_eq!(m.mode, Mode::Standby));
+    assert!(matches!(
+        lora.cad(&mdltn_params).await,
+        Err(crate::mod_params::RadioError::InvalidRadioMode)
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

After a CAD_ONLY operation the SX126x auto-returns to STDBY_RC, but `LoRa::cad()` left `radio_mode` reading `ChannelActivityDetection` — the next `prepare_for_tx`/`prepare_for_rx` then started from an unknown host-side state (cf. RadioLib issue #1085).

## Fix

- `cad()`: explicit `SetStandby` + `radio_mode` sync on the CAD success path, matching what the error path already does.
- `do_cad()`: `SetStandby` at entry, and a defensive IRQ-flag clear before `SetCadParams`/`SetCAD` (SX1261/2 DS §8.5 — IRQ status bits are latched).

No public API changes. Pairs with #428 (pre-command BUSY check); best merged after it, though it does not depend on it to build.

## Test

clippy (`-p lora-phy --features defmt-03 -- -D warnings`) and fmt clean.