### PR TITLE
phy: lr1110: propagate CMD_FAIL/CMD_PERR from Stat1 in read()

### DIFF
--- a/lora-phy/src/lr1110_interface.rs
+++ b/lora-phy/src/lr1110_interface.rs
@@ -75,18 +75,28 @@ where
         self.iv.wait_on_busy().await?;
 
         // Step 3: Read response in separate transaction
-        // First byte is Stat1 (discarded), followed by actual data
-        // Read stat1 and data in a single SPI transaction using transfer
+        // First byte is Stat1, followed by actual data.
         let mut stat1 = [0u8; 1];
         let mut ops = [Operation::Read(&mut stat1), Operation::Read(read_buffer)];
         self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
 
         trace!(
-            "read: addr={=[u8]:02x}, len={}, data={=[u8]:02x}",
+            "read: addr={=[u8]:02x}, len={}, stat1={:02x}, data={=[u8]:02x}",
             write_buffer,
             read_buffer.len(),
+            stat1[0],
             read_buffer
         );
+
+        // Stat1 bits[3:1] encode the command status:
+        //   0 = CMD_FAIL  (command could not be executed)
+        //   1 = CMD_PERR  (wrong opcode or arguments)
+        //   2 = CMD_OK    (success)
+        //   3 = CMD_DAT   (success, data available)
+        // Anything below CMD_OK means the response data is invalid.
+        if (stat1[0] >> 1) & 0x07 < 2 {
+            return Err(RadioError::OpError(stat1[0]));
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

The LR11xx SPI read protocol always starts the response with a **Stat1** byte whose bits[3:1] encode the command execution status:

| bits[3:1] | Meaning |
|-----------|---------|
| 0 | `CMD_FAIL` — command could not be executed |
| 1 | `CMD_PERR` — wrong opcode or arguments |
| 2 | `CMD_OK` — success |
| 3 | `CMD_DAT` — success, data available |

`Lr1110SpiInterface::read()` was already reading Stat1 off the wire (correctly, to advance the SPI position before the data bytes), but it immediately discarded the byte without checking it. A `CMD_FAIL` or `CMD_PERR` response from the chip was therefore silently swallowed, and callers received stale or undefined data while `execute_command_with_response` returned `Ok(())`.

## Change

- Check bits[3:1] of Stat1 after the SPI transaction in `read()` and return `RadioError::OpError(stat1)` for any status below `CMD_OK`.
- Include `stat1` in the `trace!` log so failures are visible when tracing is enabled.
- `read_with_status()` is **unchanged** — callers of that path already receive the raw Stat1 byte and handle it themselves.