### PR TITLE
device: bind RX windows to the uplink at TX time instead of recalling channel state

### DIFF
--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -310,7 +310,7 @@ where
     pub async fn join(&mut self, join_mode: &JoinMode) -> Result<JoinResponse, Error<R::PhyError>> {
         match join_mode {
             JoinMode::OTAA { deveui, appeui, appkey } => {
-                let (tx_config, _) = self.mac.join_otaa::<G, N>(
+                let (tx_config, rx_windows, _) = self.mac.join_otaa::<G, N>(
                     &mut self.rng,
                     NetworkCredentials::new(*appeui, *deveui, *appkey),
                     &mut self.radio_buffer,
@@ -325,7 +325,7 @@ where
 
                 // Receive join response within RX window
                 self.timer.reset();
-                Ok(self.rx_downlink(&Frame::Join, ms).await?.into())
+                Ok(self.rx_downlink(&Frame::Join, ms, &rx_windows).await?.into())
             }
             JoinMode::ABP { nwkskey, appskey, devaddr } => {
                 self.mac.join_abp(*nwkskey, *appskey, *devaddr);
@@ -351,7 +351,7 @@ where
         confirmed: bool,
     ) -> Result<SendResponse, Error<R::PhyError>> {
         // Prepare transmission buffer
-        let (tx_config, _fcnt_up) = self.mac.send::<G, N>(
+        let (tx_config, rx_windows, _fcnt_up) = self.mac.send::<G, N>(
             &mut self.rng,
             &mut self.radio_buffer,
             &SendData { data, fport, confirmed },
@@ -365,7 +365,7 @@ where
 
         // Wait for received data within window
         self.timer.reset();
-        Ok(self.rx_downlink(&Frame::Data, ms).await?.into())
+        Ok(self.rx_downlink(&Frame::Data, ms, &rx_windows).await?.into())
     }
 
     /// Take the downlink data from the device. This is typically called after a
@@ -512,6 +512,7 @@ where
         &mut self,
         frame: &Frame,
         window_delay: u32,
+        rx_windows: &mac::RxWindows,
     ) -> Result<mac::Response, Error<R::PhyError>> {
         self.radio_buffer.clear();
 
@@ -523,8 +524,7 @@ where
         let _ = self.between_windows(rx1_start_delay).await?;
 
         // RX1
-        let rx_config =
-            self.mac.get_rx_config(self.radio.get_rx_window_buffer(), frame, &Window::_1);
+        let rx_config = rx_windows.rx_config(self.radio.get_rx_window_buffer(), &Window::_1);
         debug!("Configuring RX1 window with config {}.", rx_config);
         self.radio.setup_rx(rx_config).await.map_err(Error::Radio)?;
 
@@ -540,8 +540,7 @@ where
         let _ = self.between_windows(rx2_start_delay).await?;
 
         // RX2
-        let rx_config =
-            self.mac.get_rx_config(self.radio.get_rx_window_buffer(), frame, &Window::_2);
+        let rx_config = rx_windows.rx_config(self.radio.get_rx_window_buffer(), &Window::_2);
         debug!("Configuring RX2 window with config {}.", rx_config);
         self.radio.setup_rx(rx_config).await.map_err(Error::Radio)?;
 

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -45,6 +45,30 @@ pub(crate) enum Window {
     _2,
 }
 
+/// RF configurations for the RX1 and RX2 windows of an uplink, derived at TX time from the
+/// channel and datarate actually used for the transmission. Binding the windows to the uplink by
+/// value (instead of recalling the TX channel from region state at RX time) guarantees the
+/// windows match the transmission even if MAC state changes in between.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+pub(crate) struct RxWindows {
+    pub(crate) rx1: RfConfig,
+    pub(crate) rx2: RfConfig,
+}
+
+impl RxWindows {
+    pub(crate) fn get(&self, window: &Window) -> RfConfig {
+        match window {
+            Window::_1 => self.rx1,
+            Window::_2 => self.rx2,
+        }
+    }
+
+    pub(crate) fn rx_config(&self, buffer_ms: u32, window: &Window) -> RxConfig {
+        RxConfig { rf: self.get(window), mode: RxMode::Single { ms: buffer_ms } }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 /// LoRaWAN Session and Network Configurations
@@ -124,20 +148,20 @@ impl Mac {
     }
 
     /// Prepare the radio buffer with transmitting a join request frame and provides the radio
-    /// configuration for the transmission.
+    /// configuration for the transmission along with the RX window configurations bound to it.
     pub(crate) fn join_otaa<RNG: RngCore, const N: usize>(
         &mut self,
         rng: &mut RNG,
         credentials: NetworkCredentials,
         buf: &mut RadioBuffer<N>,
-    ) -> (radio::TxConfig, u16) {
+    ) -> (radio::TxConfig, RxWindows, u16) {
         let mut otaa = otaa::Otaa::new(credentials);
         let dev_nonce = otaa.prepare_buffer::<RNG, N>(rng, buf);
         self.state = State::Otaa(otaa);
-        let mut tx_config =
+        let (mut tx_config, tx_channel) =
             self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Join);
         tx_config.adjust_power(self.board_eirp.max_power, self.board_eirp.antenna_gain);
-        (tx_config, dev_nonce)
+        (tx_config, self.rx_windows(&tx_channel), dev_nonce)
     }
 
     /// Join via ABP. This does not transmit a join request frame, but instead sets the session.
@@ -162,19 +186,19 @@ impl Mac {
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
         send_data: &SendData<'_>,
-    ) -> Result<(radio::TxConfig, FcntUp)> {
+    ) -> Result<(radio::TxConfig, RxWindows, FcntUp)> {
         let fcnt = match &mut self.state {
             State::Joined(ref mut session) => Ok(session.prepare_buffer::<N>(send_data, buf)),
             State::Otaa(_) => Err(Error::NotJoined),
             State::Unjoined => Err(Error::NotJoined),
         }?;
-        let mut tx_config =
+        let (mut tx_config, tx_channel) =
             self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Data);
         tx_config.adjust_power(
             self.configuration.tx_power.unwrap_or(self.board_eirp.max_power),
             self.board_eirp.antenna_gain,
         );
-        Ok((tx_config, fcnt))
+        Ok((tx_config, self.rx_windows(&tx_channel), fcnt))
     }
 
     pub(crate) fn add_uplink<M: SerializableMacCommand>(&mut self, cmd: M) -> Result<()> {
@@ -196,7 +220,8 @@ impl Mac {
         buf: &mut RadioBuffer<N>,
     ) -> Result<(radio::TxConfig, FcntUp)> {
         self.multicast.setup_send::<N>(&mut self.state, buf).map(|fcnt_up| {
-            let mut tx_config =
+            // No RX windows follow this uplink; the caller re-arms the RXC window.
+            let (mut tx_config, _) =
                 self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Data);
             tx_config.adjust_power(
                 self.configuration.tx_power.unwrap_or(self.board_eirp.max_power),
@@ -213,7 +238,8 @@ impl Mac {
         buf: &mut RadioBuffer<N>,
     ) -> Result<(radio::TxConfig, FcntUp)> {
         self.certification.setup_send::<N>(&mut self.state, buf).map(|fcnt_up| {
-            let mut tx_config =
+            // No RX windows follow this uplink; the caller completes with rx2_complete().
+            let (mut tx_config, _) =
                 self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Data);
             tx_config.adjust_power(self.board_eirp.max_power, self.board_eirp.antenna_gain);
             (tx_config, fcnt_up)
@@ -340,47 +366,16 @@ impl Mac {
         }
     }
 
-    /// Build RfConfig for given `Frame` and `Window` and apply
-    /// network-specific overrides.
-    pub(crate) fn get_rf_config(&self, frame: &Frame, window: &Window) -> RfConfig {
-        let (frequency, dr) = match window {
-            Window::_1 => (
-                self.region.get_rx_frequency(frame, window),
-                self.region.get_rx_datarate(
-                    self.configuration.data_rate,
-                    self.configuration.rx1_dr_offset,
-                    window,
-                ),
-            ),
-            Window::_2 => {
-                (
-                    // RX2 frequency override
-                    self.configuration
-                        .rx2_frequency
-                        .unwrap_or_else(|| self.region.get_rx_frequency(frame, window)),
-                    // RX2 datarate override
-                    self.configuration.rx2_data_rate.unwrap_or_else(|| {
-                        self.region.get_rx_datarate(
-                            self.configuration.data_rate,
-                            self.configuration.rx1_dr_offset,
-                            window,
-                        )
-                    }),
-                )
-            }
-        };
-
-        // Handle possibly unsupported datarates by falling back to RX2 datarate
+    /// Build the RfConfig for a window given its frequency and datarate, handling possibly
+    /// unsupported datarates by falling back to the RX2 datarate.
+    fn build_rf_config(&self, frequency: u32, dr: DR, tx_dr: DR, window: &Window) -> RfConfig {
         let datarate = match self.region.get_datarate(dr as u8) {
             Some(d) => d,
             None => {
-                warn!(
-                    "Unsupported DR: {:?} (TX DR: {:?}, Window: {:?})",
-                    dr, self.configuration.data_rate, window
-                );
+                warn!("Unsupported DR: {:?} (TX DR: {:?}, Window: {:?})", dr, tx_dr, window);
                 self.region
                     .get_datarate(self.region.get_rx_datarate(
-                        self.configuration.data_rate,
+                        tx_dr,
                         self.configuration.rx1_dr_offset,
                         &Window::_2,
                     ) as u8)
@@ -399,13 +394,35 @@ impl Mac {
         }
     }
 
-    pub(crate) fn get_rx_config(&self, buffer_ms: u32, frame: &Frame, window: &Window) -> RxConfig {
-        RxConfig { rf: self.get_rf_config(frame, window), mode: RxMode::Single { ms: buffer_ms } }
+    /// Build the RX2 RfConfig, applying network-specific overrides.
+    fn rx2_rf_config(&self, tx_dr: DR) -> RfConfig {
+        // RX2 frequency override
+        let frequency =
+            self.configuration.rx2_frequency.unwrap_or_else(|| self.region.get_rx2_frequency());
+        // RX2 datarate override
+        let dr = self.configuration.rx2_data_rate.unwrap_or_else(|| {
+            self.region.get_rx_datarate(tx_dr, self.configuration.rx1_dr_offset, &Window::_2)
+        });
+        self.build_rf_config(frequency, dr, tx_dr, &Window::_2)
+    }
+
+    /// Derive the RX1/RX2 window configurations for an uplink from the channel selection actually
+    /// used to transmit it.
+    fn rx_windows(&self, tx_channel: &region::TxChannel) -> RxWindows {
+        let rx1_dr = self.region.get_rx_datarate(
+            tx_channel.dr,
+            self.configuration.rx1_dr_offset,
+            &Window::_1,
+        );
+        RxWindows {
+            rx1: self.build_rf_config(tx_channel.rx1_frequency, rx1_dr, tx_channel.dr, &Window::_1),
+            rx2: self.rx2_rf_config(tx_channel.dr),
+        }
     }
 
     #[cfg(feature = "class-c")]
     pub(crate) fn get_rxc_config(&self) -> RxConfig {
-        RxConfig { rf: self.get_rf_config(&Frame::Data, &Window::_2), mode: RxMode::Continuous }
+        RxConfig { rf: self.rx2_rf_config(self.configuration.data_rate), mode: RxMode::Continuous }
     }
 }
 

--- a/lorawan-device/src/nb_device/state.rs
+++ b/lorawan-device/src/nb_device/state.rs
@@ -40,7 +40,7 @@ else(Ready)║ ╚═════════════╝   ║              
  */
 use super::super::*;
 use super::{
-    mac::{Frame, Mac, Window},
+    mac::{Frame, Mac, RxWindows, Window},
     radio, Event, RadioBuffer, Response, Timings,
 };
 
@@ -137,15 +137,20 @@ impl Idle {
         event: Event<'_, R>,
     ) -> (State, Result<Response, super::Error<R>>) {
         enum IntermediateResponse<R: radio::PhyRxTx> {
-            RadioTx((Frame, radio::TxConfig, u32)),
+            RadioTx((Frame, radio::TxConfig, RxWindows, u32)),
             EarlyReturn(Result<Response, super::Error<R>>),
         }
 
         let response = match event {
             // tolerate unexpected timeout
             Event::Join(creds) => {
-                let (tx_config, dev_nonce) = mac.join_otaa::<RNG, N>(rng, creds, buf);
-                IntermediateResponse::RadioTx((Frame::Join, tx_config, dev_nonce as u32))
+                let (tx_config, rx_windows, dev_nonce) = mac.join_otaa::<RNG, N>(rng, creds, buf);
+                IntermediateResponse::RadioTx((
+                    Frame::Join,
+                    tx_config,
+                    rx_windows,
+                    dev_nonce as u32,
+                ))
             }
             Event::TimeoutFired => IntermediateResponse::EarlyReturn(Ok(Response::NoUpdate)),
             Event::RadioEvent(_radio_event) => {
@@ -155,15 +160,15 @@ impl Idle {
                 let tx_config = mac.send::<RNG, N>(rng, buf, &send_data);
                 match tx_config {
                     Err(e) => IntermediateResponse::EarlyReturn(Err(e.into())),
-                    Ok((tx_config, fcnt_up)) => {
-                        IntermediateResponse::RadioTx((Frame::Data, tx_config, fcnt_up))
+                    Ok((tx_config, rx_windows, fcnt_up)) => {
+                        IntermediateResponse::RadioTx((Frame::Data, tx_config, rx_windows, fcnt_up))
                     }
                 }
             }
         };
         match response {
             IntermediateResponse::EarlyReturn(response) => (State::Idle(self), response),
-            IntermediateResponse::RadioTx((frame, tx_config, fcnt_up)) => {
+            IntermediateResponse::RadioTx((frame, tx_config, rx_windows, fcnt_up)) => {
                 let event: radio::Event<'_, R> =
                     radio::Event::TxRequest(tx_config, buf.as_ref_for_read());
                 match radio.handle_event(event) {
@@ -172,13 +177,13 @@ impl Idle {
                             // intermediate state where we wait for Join to complete sending
                             // allows for asynchronous sending
                             radio::Response::Txing => (
-                                State::SendingData(SendingData { frame }),
+                                State::SendingData(SendingData { frame, rx_windows }),
                                 Ok(Response::UplinkSending(fcnt_up)),
                             ),
                             // directly jump to waiting for RxWindow
                             // allows for synchronous sending
                             radio::Response::TxDone(ms) => {
-                                data_rxwindow1_timeout::<R, N>(frame, mac, radio, ms)
+                                data_rxwindow1_timeout::<R, N>(frame, rx_windows, mac, radio, ms)
                             }
                             _ => (State::Idle(self), Err(Error::UnexpectedRadioResponse.into())),
                         }
@@ -193,6 +198,7 @@ impl Idle {
 #[derive(Copy, Clone)]
 pub struct SendingData {
     frame: Frame,
+    rx_windows: RxWindows,
 }
 
 impl SendingData {
@@ -210,9 +216,13 @@ impl SendingData {
                     Ok(response) => {
                         match response {
                             // expect a complete transmit
-                            radio::Response::TxDone(ms) => {
-                                data_rxwindow1_timeout::<R, N>(self.frame, mac, radio, ms)
-                            }
+                            radio::Response::TxDone(ms) => data_rxwindow1_timeout::<R, N>(
+                                self.frame,
+                                self.rx_windows,
+                                mac,
+                                radio,
+                                ms,
+                            ),
                             // anything other than TxComplete is unexpected
                             _ => {
                                 panic!("SendingData: Unexpected radio response");
@@ -235,6 +245,7 @@ impl SendingData {
 #[derive(Copy, Clone)]
 pub struct WaitingForRxWindow {
     frame: Frame,
+    rx_windows: RxWindows,
     window: Rx,
 }
 
@@ -248,7 +259,7 @@ impl WaitingForRxWindow {
         match event {
             // we are waiting for a Timeout
             Event::TimeoutFired => {
-                let rf_config = mac.get_rf_config(&self.frame, &self.window.into());
+                let rf_config = self.rx_windows.get(&self.window.into());
                 let window_start = mac.get_rx_delay(&self.frame, &self.window.into());
                 // configure the radio for the RX
                 match radio.handle_event(radio::Event::RxRequest(rf_config)) {
@@ -270,6 +281,7 @@ impl WaitingForRxWindow {
                         (
                             State::WaitingForRx(WaitingForRx {
                                 frame: self.frame,
+                                rx_windows: self.rx_windows,
                                 window: self.window,
                                 rf_config,
                             }),
@@ -298,6 +310,7 @@ impl WaitingForRxWindow {
 #[derive(Copy, Clone)]
 pub struct WaitingForRx {
     frame: Frame,
+    rx_windows: RxWindows,
     window: Rx,
     rf_config: radio::RfConfig,
 }
@@ -356,6 +369,7 @@ impl WaitingForRx {
                         (
                             State::WaitingForRxWindow(WaitingForRxWindow {
                                 frame: self.frame,
+                                rx_windows: self.rx_windows,
                                 window: Rx::_2(t2),
                             }),
                             Ok(Response::TimeoutRequest(t2)),
@@ -386,6 +400,7 @@ enum Rx {
 
 fn data_rxwindow1_timeout<R: radio::PhyRxTx + Timings, const N: usize>(
     frame: Frame,
+    rx_windows: RxWindows,
     mac: &mut Mac,
     radio: &mut R,
     timestamp_ms: u32,
@@ -393,7 +408,7 @@ fn data_rxwindow1_timeout<R: radio::PhyRxTx + Timings, const N: usize>(
     let delay = mac.get_rx_delay(&frame, &Window::_1);
     let t1 = (delay as i32 + timestamp_ms as i32 + radio.get_rx_window_offset_ms()) as u32;
     (
-        State::WaitingForRxWindow(WaitingForRxWindow { frame, window: Rx::_1(t1) }),
+        State::WaitingForRxWindow(WaitingForRxWindow { frame, rx_windows, window: Rx::_1(t1) }),
         Ok(Response::TimeoutRequest(t1)),
     )
 }

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -63,7 +63,6 @@ type ChannelPlan = [Option<Channel>; NUM_CHANNELS_DYNAMIC as usize];
 pub(crate) struct DynamicChannelPlan<R: DynamicChannelRegion> {
     channels: ChannelPlan,
     channel_mask: ChannelMask<9>,
-    last_tx_channel: u8,
     _dynamic_channel_region: PhantomData<R>,
     frequency_valid: fn(u32) -> bool,
 }
@@ -76,7 +75,6 @@ impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
         Self {
             channels,
             channel_mask: Default::default(),
-            last_tx_channel: Default::default(),
             _dynamic_channel_region: Default::default(),
             frequency_valid: freq_fn,
         }
@@ -197,12 +195,12 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
         R::datarates()[dr as usize].as_ref()
     }
 
-    fn get_tx_dr_and_frequency<RNG: RngCore>(
+    fn select_tx_channel<RNG: RngCore>(
         &mut self,
         rng: &mut RNG,
         datarate: DR,
         frame: &Frame,
-    ) -> (Datarate, u32) {
+    ) -> TxChannel {
         match frame {
             Frame::Join => {
                 // There are at most 3 join channels in dynamic regions,
@@ -211,22 +209,27 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
                 while index >= R::NUM_JOIN_CHANNELS {
                     index = (rng.next_u32() & 0b11) as u8;
                 }
-                self.last_tx_channel = index;
 
                 // SAFETY: Join channels SHALL be always present
                 let channel = self.channels[index as usize].unwrap();
-                (R::datarates()[datarate as usize].clone().unwrap(), channel.frequency)
+                TxChannel {
+                    datarate: R::datarates()[datarate as usize].clone().unwrap(),
+                    dr: datarate,
+                    frequency: channel.ul_frequency(),
+                    rx1_frequency: channel.rx1_frequency(),
+                }
             }
             Frame::Data => {
                 let mut channel = self.get_random_in_range(rng);
                 loop {
                     if self.channel_mask.is_enabled(channel).unwrap() {
                         if let Some(ch) = self.channels[channel] {
-                            self.last_tx_channel = channel as u8;
-                            return (
-                                R::datarates()[datarate as usize].clone().unwrap(),
-                                ch.ul_frequency(),
-                            );
+                            return TxChannel {
+                                datarate: R::datarates()[datarate as usize].clone().unwrap(),
+                                dr: datarate,
+                                frequency: ch.ul_frequency(),
+                                rx1_frequency: ch.rx1_frequency(),
+                            };
                         }
                     }
                     channel = self.get_random_in_range(rng)
@@ -235,12 +238,8 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
         }
     }
 
-    fn get_rx_frequency(&self, _frame: &Frame, window: &Window) -> u32 {
-        match window {
-            // SAFETY: self.last_tx_channel will be populated after correct channel is chosen
-            Window::_1 => self.channels[self.last_tx_channel as usize].unwrap().rx1_frequency(),
-            Window::_2 => R::DEFAULT_RX2_FREQ,
-        }
+    fn get_rx2_frequency(&self) -> u32 {
+        R::DEFAULT_RX2_FREQ
     }
 
     fn get_rx_datarate(&self, tx_datarate: DR, rx1_dr_offset: u8, window: &Window) -> DR {

--- a/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
@@ -292,6 +292,48 @@ mod test {
         }
     }
 
+    /// A standard (unbiased) US915 join walk hits the 500 kHz bank (channels 64-71) once every
+    /// 9 attempts, where the join is forced to DR4. RX1 must then be derived from DR4 (=> DR13),
+    /// not from the device's configured data rate.
+    #[test]
+    fn test_join_rx1_datarate_follows_forced_join_dr() {
+        use lora_modulation::{Bandwidth, SpreadingFactor};
+
+        let mut rng = rand_core::OsRng;
+        let mut mac = Mac::new(US915::new().into(), 21, 2);
+        let mut buf: RadioBuffer<255> = RadioBuffer::new();
+        let credentials = NetworkCredentials::new(
+            AppEui::from([0x0; 8]),
+            DevEui::from([0x0; 8]),
+            AppKey::from(get_key()),
+        );
+
+        let mut checked_fat_bank = false;
+        for _ in 0..9 {
+            let (tx_config, rx_windows, _) =
+                mac.join_otaa::<_, 255>(&mut rng, credentials.clone(), &mut buf);
+            if tx_config.rf.bb.bw == Bandwidth::_500KHz {
+                // Join on the fat bank is forced to DR4 (SF8/500kHz)...
+                assert_eq!(tx_config.rf.bb.sf, SpreadingFactor::_8);
+                // ...so RX1 must open at DR13 (SF7/500kHz), not at the DR derived from the
+                // device's configured data rate (DR0 => RX1 DR10, SF10/500kHz).
+                assert_eq!(rx_windows.rx1.bb.bw, Bandwidth::_500KHz);
+                assert_eq!(rx_windows.rx1.bb.sf, SpreadingFactor::_7);
+                checked_fat_bank = true;
+            } else {
+                // Joins on 125 kHz channels are forced to DR0 => RX1 at DR10 (SF10/500kHz)
+                assert_eq!(tx_config.rf.bb.sf, SpreadingFactor::_10);
+                assert_eq!(rx_windows.rx1.bb.bw, Bandwidth::_500KHz);
+                assert_eq!(rx_windows.rx1.bb.sf, SpreadingFactor::_10);
+            }
+            // RX2 is always DR8 (SF12/500kHz) at 923.3 MHz for US915
+            assert_eq!(rx_windows.rx2.frequency, 923_300_000);
+            assert_eq!(rx_windows.rx2.bb.sf, SpreadingFactor::_12);
+            mac.rx2_complete();
+        }
+        assert!(checked_fat_bank, "9 join attempts must include one 500 kHz channel");
+    }
+
     #[test]
     fn test_full_mac_compliant_bias() {
         let mut us915 = US915::new();
@@ -299,7 +341,7 @@ mod test {
         let mut mac = Mac::new(us915.into(), 21, 2);
 
         let mut buf: RadioBuffer<255> = RadioBuffer::new();
-        let (tx_config, _len) = mac.join_otaa::<_, 255>(
+        let (tx_config, rx_windows, _dev_nonce) = mac.join_otaa::<_, 255>(
             &mut rand::rngs::OsRng,
             NetworkCredentials::new(
                 AppEui::from([0x0; 8]),
@@ -329,13 +371,12 @@ mod test {
         buf.clear();
         buf.extend_from_slice(&rx_buf[..len]).unwrap();
 
-        let rx_config = mac.get_rx_config(0, &Frame::Data, &Window::_1);
-        let response = mac.handle_rx::<255, 3>(&mut buf, &mut downlinks, 0, &rx_config.rf);
+        let response = mac.handle_rx::<255, 3>(&mut buf, &mut downlinks, 0, &rx_windows.rx1);
         if let Response::JoinSuccess = response {
         } else {
             panic!("Did not receive join success");
         }
-        let (tx_config, _len) = mac
+        let (tx_config, _rx_windows, _fcnt) = mac
             .send::<_, 255>(
                 &mut rand::rngs::OsRng,
                 &mut buf,
@@ -362,7 +403,7 @@ mod test {
         let mut mac = Mac::new(us915.into(), 21, 2);
 
         let mut buf: RadioBuffer<255> = RadioBuffer::new();
-        let (tx_config, _len) = mac.join_otaa::<_, 255>(
+        let (tx_config, rx_windows, _dev_nonce) = mac.join_otaa::<_, 255>(
             &mut rand::rngs::OsRng,
             NetworkCredentials::new(
                 AppEui::from([0x0; 8]),
@@ -391,14 +432,13 @@ mod test {
         let len = handle_join_request::<0>(Some(uplink), tx_config.rf, &mut rx_buf);
         buf.clear();
         buf.extend_from_slice(&rx_buf[..len]).unwrap();
-        let rx_config = mac.get_rx_config(0, &Frame::Data, &Window::_1);
-        let response = mac.handle_rx::<255, 3>(&mut buf, &mut downlinks, 0, &rx_config.rf);
+        let response = mac.handle_rx::<255, 3>(&mut buf, &mut downlinks, 0, &rx_windows.rx1);
         if let Response::JoinSuccess = response {
         } else {
             panic!("Did not receive JoinSuccess")
         }
         for _ in 0..8 {
-            let (tx_config, _len) = mac
+            let (tx_config, _rx_windows, _fcnt) = mac
                 .send::<_, 255>(
                     &mut rand::rngs::OsRng,
                     &mut buf,

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -40,7 +40,6 @@ impl From<Subband> for usize {
 
 #[derive(Clone)]
 pub(crate) struct FixedChannelPlan<F: FixedChannelRegion> {
-    last_tx_channel: u8,
     channel_mask: ChannelMask<9>,
     _fixed_channel_region: PhantomData<F>,
     join_channels: JoinChannels,
@@ -51,7 +50,6 @@ pub(crate) struct FixedChannelPlan<F: FixedChannelRegion> {
 impl<F: FixedChannelRegion> FixedChannelPlan<F> {
     pub fn new(freq_fn: fn(u32) -> bool) -> Self {
         Self {
-            last_tx_channel: Default::default(),
             channel_mask: Default::default(),
             _fixed_channel_region: Default::default(),
             join_channels: Default::default(),
@@ -172,13 +170,13 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
         F::datarates()[dr as usize].as_ref()
     }
 
-    fn get_tx_dr_and_frequency<RNG: RngCore>(
+    fn select_tx_channel<RNG: RngCore>(
         &mut self,
         rng: &mut RNG,
         datarate: DR,
         frame: &Frame,
-    ) -> (Datarate, u32) {
-        match frame {
+    ) -> TxChannel {
+        let (dr, channel) = match frame {
             Frame::Join => {
                 let channel = self.join_channels.get_next_channel(rng);
                 let dr = if channel < 64 {
@@ -186,33 +184,31 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
                 } else {
                     DR::_4
                 };
-                self.last_tx_channel = channel;
-                let data_rate = F::datarates()[dr as usize].clone().unwrap();
-                (data_rate, F::uplink_channels()[channel as usize])
+                (dr, channel)
             }
             Frame::Data => {
                 // The join bias gets reset after receiving CFList in Join Frame
                 // or ChannelMask in the LinkADRReq in Data Frame.
                 // If it has not been reset yet, we continue to use the bias for the data frames.
                 // We hope to acquire ChannelMask via LinkADRReq.
-                let (data_rate, channel) = if self.join_channels.has_bias_and_not_exhausted() {
+                if self.join_channels.has_bias_and_not_exhausted() {
                     let channel = self.join_channels.get_next_channel(rng);
                     let dr = if channel < 64 {
                         DR::_0
                     } else {
                         DR::_4
                     };
-                    (F::datarates()[dr as usize].clone().unwrap(), channel)
+                    (dr, channel)
                 // Alternatively, we will ask JoinChannel logic to determine a channel from the
                 // subband that  the join succeeded on.
                 } else if let Some(channel) = self.join_channels.first_data_channel(rng) {
-                    (F::datarates()[datarate as usize].clone().unwrap(), channel)
+                    (datarate, channel)
                 } else {
                     // For the data frame, the datarate impacts which channel sets we can choose
                     // from. If the datarate bandwidth is 500 kHz, we must use
                     // channels 64..=71. Else, we must use 0-63
-                    let datarate = F::datarates()[datarate as usize].clone().unwrap();
-                    if datarate.bandwidth == Bandwidth::_500KHz {
+                    let bandwidth = F::datarates()[datarate as usize].as_ref().unwrap().bandwidth;
+                    if bandwidth == Bandwidth::_500KHz {
                         let mut channel = (rng.next_u32() & 0b111) as u8;
                         // keep selecting a random channel until we find one that is enabled
                         while !self.channel_mask.is_enabled((channel + 64).into()).unwrap() {
@@ -227,19 +223,19 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
                         }
                         (datarate, channel)
                     }
-                };
-                self.last_tx_channel = channel;
-                (data_rate, F::uplink_channels()[channel as usize])
+                }
             }
+        };
+        TxChannel {
+            datarate: F::datarates()[dr as usize].clone().unwrap(),
+            dr,
+            frequency: F::uplink_channels()[channel as usize],
+            rx1_frequency: F::downlink_channels()[(channel % 8) as usize],
         }
     }
 
-    fn get_rx_frequency(&self, _frame: &Frame, window: &Window) -> u32 {
-        let channel = self.last_tx_channel % 8;
-        match window {
-            Window::_1 => F::downlink_channels()[channel as usize],
-            Window::_2 => F::DEFAULT_RX2_FREQ,
-        }
+    fn get_rx2_frequency(&self) -> u32 {
+        F::DEFAULT_RX2_FREQ
     }
 
     fn get_rx_datarate(&self, tx_dr: DR, rx1_dr_offset: u8, window: &Window) -> DR {

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -201,6 +201,17 @@ pub(crate) struct Datarate {
     pub(crate) max_mac_payload_size: u8,
     max_mac_payload_size_with_dwell_time: u8,
 }
+
+/// The result of TX channel selection. Carries the DR actually used for the uplink (which may
+/// differ from the requested DR, eg: fixed-plan join frames force DR0/DR4 by channel) and the
+/// RX1 frequency paired with the selected channel, so RX windows can be derived from the
+/// transmission itself rather than recalled from region state at RX time.
+pub(crate) struct TxChannel {
+    pub(crate) datarate: Datarate,
+    pub(crate) dr: DR,
+    pub(crate) frequency: u32,
+    pub(crate) rx1_frequency: u32,
+}
 macro_rules! mut_region_dispatch {
   ($s:expr, $t:tt) => {
       match &mut $s.state {
@@ -371,21 +382,22 @@ impl Configuration {
         rng: &mut RNG,
         datarate: DR,
         frame: &Frame,
-    ) -> TxConfig {
-        let (dr, frequency) = self.get_tx_dr_and_frequency(rng, datarate, frame);
-        TxConfig {
+    ) -> (TxConfig, TxChannel) {
+        let tx_channel = self.select_tx_channel(rng, datarate, frame);
+        let tx_config = TxConfig {
             // We can do this safely, as default output power will be positive
             pw: self.check_tx_power(0).unwrap().unwrap() as i8,
             rf: RfConfig {
-                frequency,
+                frequency: tx_channel.frequency,
                 bb: BaseBandModulationParams::new(
-                    dr.spreading_factor,
-                    dr.bandwidth,
+                    tx_channel.datarate.spreading_factor,
+                    tx_channel.datarate.bandwidth,
                     self.get_coding_rate(),
                 ),
-                max_payload_len: dr.max_mac_payload_size,
+                max_payload_len: tx_channel.datarate.max_mac_payload_size,
             },
-        }
+        };
+        (tx_config, tx_channel)
     }
 
     pub(crate) fn get_datarate(&self, dr: u8) -> Option<&Datarate> {
@@ -396,13 +408,13 @@ impl Configuration {
         region_dispatch!(self, check_tx_power, tx_power).map(Some)
     }
 
-    fn get_tx_dr_and_frequency<RNG: RngCore>(
+    fn select_tx_channel<RNG: RngCore>(
         &mut self,
         rng: &mut RNG,
         datarate: DR,
         frame: &Frame,
-    ) -> (Datarate, u32) {
-        mut_region_dispatch!(self, get_tx_dr_and_frequency, rng, datarate, frame)
+    ) -> TxChannel {
+        mut_region_dispatch!(self, select_tx_channel, rng, datarate, frame)
     }
 
     pub(crate) fn process_join_accept<T: AsRef<[u8]>>(
@@ -441,8 +453,8 @@ impl Configuration {
         region_dispatch!(self, get_rx_datarate, tx_dr, rx1_dr_offset, window)
     }
 
-    pub(crate) fn get_rx_frequency(&self, frame: &Frame, window: &Window) -> u32 {
-        region_dispatch!(self, get_rx_frequency, frame, window)
+    pub(crate) fn get_rx2_frequency(&self) -> u32 {
+        region_dispatch!(self, get_rx2_frequency)
     }
 
     pub(crate) fn get_default_datarate(&self) -> DR {
@@ -546,15 +558,15 @@ pub(crate) trait RegionHandler {
         DR::_0
     }
 
-    fn get_tx_dr_and_frequency<RNG: RngCore>(
+    fn select_tx_channel<RNG: RngCore>(
         &mut self,
         rng: &mut RNG,
         datarate: DR,
         frame: &Frame,
-    ) -> (Datarate, u32);
+    ) -> TxChannel;
 
     fn get_rx_datarate(&self, datarate: DR, rx1_dr_offset: u8, window: &Window) -> DR;
-    fn get_rx_frequency(&self, frame: &Frame, window: &Window) -> u32;
+    fn get_rx2_frequency(&self) -> u32;
     fn get_coding_rate(&self) -> CodingRate {
         DEFAULT_CODING_RATE
     }


### PR DESCRIPTION
## Motivation

The region layer stored `last_tx_channel` as a side effect of TX channel selection and reconstructed RX1 parameters from it (plus the `Mac`'s *current* `data_rate`) when the RX windows opened, seconds later. Any state change in between — an interleaved certification/multicast uplink, a MAC command processed from a class C RXC frame, a channel plan mutation — could desynchronize the RX windows from the transmission they belong to. The `Frame` enum also had to be threaded through the entire RX path just so the region could guess what kind of TX it was recalling.

## Bug fixed

The recall mis-derived the RX1 datarate for fixed-plan join frames: the join TX DR is forced to DR0/DR4 by channel, but RX1 was computed from the configured data rate. A US915/AU915 join on the 500 kHz bank (one in nine attempts of the standard join walk) transmitted at DR4 while the device opened RX1 at DR10 (derived from the default DR0) instead of DR13 — a dead RX1 window; only RX2 could save the attempt. Regression test included (`test_join_rx1_datarate_follows_forced_join_dr`).

## Design

- Region TX selection (`select_tx_channel`, formerly `get_tx_dr_and_frequency`) returns a `TxChannel` carrying the DR **actually used** and the RX1 frequency paired with the selected channel.
- `Mac::join_otaa`/`send` derive an `RxWindows` (RX1+RX2 `RfConfig`) from it at TX time and hand it to the caller by value alongside the `TxConfig`.
- `async_device` keeps it as a local across the TX→RX1→RX2 sequence, so the recall's lifetime is exactly the transaction's lifetime, enforced by the borrow checker. The `nb_device` state machine carries it through its states.
- `last_tx_channel`, `get_rx_frequency(frame, window)`, and the comment-justified `unwrap` on the recalled channel in the dynamic plan are gone. Class C's RXC config remains a live query of current MAC state (via a shared `rx2_rf_config` helper), which is correct for a standing window.

## Behavior change to note (class C edge case)

RX2 parameters (RxParamSetup frequency/DR overrides) are now snapshotted at TX time. In class A this is observationally identical: a successful RX1 means RX2 never opens, so nothing can legitimately change RX2 params between TX and RX2. In class C, a MAC command processed from an RXC frame *mid-cycle* used to affect that same cycle's RX2; now it takes effect from the next uplink. Arguably more correct — the server can't assume a device applied a command it hasn't yet acknowledged — but it is a change.

## Breaking changes

None to the public API: everything touched is `pub(crate)` (`Mac`, `RegionHandler`, `TxChannel`/`RxWindows`, `nb_device::state`). `PhyRxTx`, `RfConfig`/`RxConfig`/`TxConfig`, `Device`, and the region-configuration API are unchanged.

## Testing

- New regression test for the fat-bank join RX1 datarate.
- Full suite passes including `certification` + `multicast` features (55 tests); fmt/clippy clean vs base.