### PR TITLE
impl From for ease of access

### DIFF
--- a/lora-phy/src/mod_params.rs
+++ b/lora-phy/src/mod_params.rs
@@ -1,3 +1,4 @@
+use lora_modulation::BaseBandModulationParams;
 pub use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 
 /// Errors types reported during LoRa physical layer processing
@@ -95,6 +96,12 @@ pub struct ModulationParams {
     pub low_data_rate_optimize: u8,
     /// Channel frequency in Hertz
     pub frequency_in_hz: u32,
+}
+
+impl From<ModulationParams> for BaseBandModulationParams {
+    fn from(value: ModulationParams) -> Self {
+        Self::new(value.spreading_factor, value.bandwidth, value.coding_rate)
+    }
 }
 
 /// Packet parameters for a send or receive communication channel


### PR DESCRIPTION
So this is mostly what I meant by #435  (I enjoyed vacation a bit more than anticipated, so it took a month for me to spend 3 minutes on this)

I needed an internal method to get the Baseband modulation from the already allocated SF, BW and CR, but without spending the extra place keeping them in a separate place, so this would have done nicely for me. What I ended up doing in my project was creating the BB mod params in the start, and keeping it in RAM, not great ...

I am curious about #358, which I would be happy to try and tackle, should i place it in a separate dir like the sx126x and sx127x, or is there an already good place for it?