### PR TITLE
phy: mock radio kind impl

### DIFF
--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -23,6 +23,8 @@ pub mod iv;
 pub mod lr1110;
 /// LR11xx-specific SPI interface (different protocol than SX126x/SX127x)
 pub(crate) mod lr1110_interface;
+/// Mock radio to be used for unit testing
+pub mod mock;
 /// Parameters used across the lora-phy crate to support various use cases
 pub mod mod_params;
 /// Traits implemented externally or internally to support control of LoRa chips

--- a/lora-phy/src/mock/mod.rs
+++ b/lora-phy/src/mock/mod.rs
@@ -54,7 +54,10 @@ impl Default for MockRadio {
 }
 
 impl RadioKind for MockRadio {
-    async fn init_lora(&mut self, _sync_word: u8) -> Result<(), crate::mod_params::RadioError> {
+    async fn init_lora(&mut self, _sync_word: u16) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+    async fn set_lora_sync_word(&mut self, _sync_word: u16) -> Result<(), RadioError> {
         Ok(())
     }
 

--- a/lora-phy/src/mock/mod.rs
+++ b/lora-phy/src/mock/mod.rs
@@ -1,0 +1,279 @@
+mod radio_kind_params;
+
+use crate::{
+    mock::radio_kind_params::IrqMask,
+    mod_params::{ModulationParams, PacketParams, PacketStatus, RadioError, RadioMode},
+    mod_traits::{IrqState, RadioKind},
+};
+
+/// Use to check whether the radio has been set in correct state
+pub enum MockState {
+    /// No Op
+    Standby,
+    /// When set to sleep
+    Sleeping,
+    /// When transmitting
+    Tx,
+    /// When receiving
+    Rx,
+    /// When warm transmit
+    WarmTx,
+    /// When warm receiving
+    WarmRx,
+}
+
+/// Struct to be used for unit testing
+pub struct MockRadio {
+    /// The internal state of what state the radio should be in
+    pub state: MockState,
+    warm_start: bool,
+    irq_flags: u16,
+}
+
+impl MockRadio {
+    /// Sets internal flag, to be used for checking different failure states
+    pub fn set_irq_flags(&mut self, flag: u16) {
+        self.irq_flags = flag;
+    }
+}
+
+impl RadioKind for MockRadio {
+    async fn init_lora(&mut self, _sync_word: u8) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+
+    fn create_modulation_params(
+        &self,
+        spreading_factor: lora_modulation::SpreadingFactor,
+        bandwidth: lora_modulation::Bandwidth,
+        coding_rate: lora_modulation::CodingRate,
+        frequency_in_hz: u32,
+    ) -> Result<crate::mod_params::ModulationParams, crate::mod_params::RadioError> {
+        Ok(ModulationParams {
+            spreading_factor,
+            bandwidth,
+            coding_rate,
+            low_data_rate_optimize: 0_u8,
+            frequency_in_hz,
+        })
+    }
+
+    fn create_packet_params(
+        &self,
+        preamble_length: u16,
+        implicit_header: bool,
+        payload_length: u8,
+        crc_on: bool,
+        iq_inverted: bool,
+        _modulation_params: &crate::mod_params::ModulationParams,
+    ) -> Result<crate::mod_params::PacketParams, crate::mod_params::RadioError> {
+        Ok(PacketParams {
+            preamble_length,
+            implicit_header,
+            payload_length,
+            crc_on,
+            iq_inverted,
+        })
+    }
+
+    async fn reset(
+        &mut self,
+        delay: &mut impl embedded_hal_async::delay::DelayNs,
+    ) -> Result<(), crate::mod_params::RadioError> {
+        delay.delay_ns(10).await;
+        self.irq_flags = IrqMask::None.value();
+        Ok(())
+    }
+
+    async fn ensure_ready(&mut self, _mode: crate::mod_params::RadioMode) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+
+    async fn set_standby(&mut self) -> Result<(), crate::mod_params::RadioError> {
+        self.state = MockState::Standby;
+        Ok(())
+    }
+
+    async fn set_sleep(
+        &mut self,
+        warm_start_if_possible: bool,
+        delay: &mut impl embedded_hal_async::delay::DelayNs,
+    ) -> Result<(), crate::mod_params::RadioError> {
+        delay.delay_ns(10).await;
+        self.state = MockState::Sleeping;
+        self.warm_start = warm_start_if_possible;
+
+        Ok(())
+    }
+
+    async fn set_tx_rx_buffer_base_address(
+        &mut self,
+        _tx_base_addr: usize,
+        _rx_base_addr: usize,
+    ) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+
+    async fn set_tx_power_and_ramp_time(
+        &mut self,
+        _output_power: i32,
+        _mdltn_params: Option<&crate::mod_params::ModulationParams>,
+        _is_tx_prep: bool,
+    ) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+
+    async fn set_modulation_params(
+        &mut self,
+        _mdltn_params: &ModulationParams,
+    ) -> Result<(), crate::mod_params::RadioError> {
+        // let spreading_factor_val = spreading_factor_value(mdltn_params.spreading_factor)?;
+        // let bandwidth_val = bandwidth_value(mdltn_params.bandwidth)?;
+        // let coding_rate_val = coding_rate_value(mdltn_params.coding_rate?;
+        // self.mod_params = mdltn_params;
+        Ok(())
+    }
+
+    async fn set_packet_params(&mut self, _pkt_params: &PacketParams) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+
+    async fn calibrate_image(&mut self, _frequency_in_hz: u32) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+
+    async fn set_channel(&mut self, _frequency_in_hz: u32) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+
+    async fn set_payload(&mut self, _payload: &[u8]) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+
+    async fn do_tx(&mut self) -> Result<(), crate::mod_params::RadioError> {
+        self.state = if self.warm_start {
+            MockState::WarmTx
+        } else {
+            MockState::Tx
+        };
+        Ok(())
+    }
+
+    async fn do_rx(&mut self, _rx_mode: crate::RxMode) -> Result<(), crate::mod_params::RadioError> {
+        self.state = if self.warm_start {
+            MockState::WarmRx
+        } else {
+            MockState::Rx
+        };
+        Ok(())
+    }
+
+    async fn get_rx_payload(
+        &mut self,
+        rx_pkt_params: &PacketParams,
+        _receiving_buffer: &mut [u8],
+    ) -> Result<u8, crate::mod_params::RadioError> {
+        Ok(rx_pkt_params.payload_length)
+    }
+
+    async fn get_rx_packet_status(&mut self) -> Result<crate::mod_params::PacketStatus, crate::mod_params::RadioError> {
+        Ok(PacketStatus { rssi: 0, snr: 0 })
+    }
+
+    async fn get_rssi(&mut self) -> Result<i16, crate::mod_params::RadioError> {
+        Ok(0)
+    }
+
+    async fn do_cad(&mut self, _mdltn_params: &ModulationParams) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+
+    async fn set_irq_params(
+        &mut self,
+        radio_mode: Option<crate::mod_params::RadioMode>,
+    ) -> Result<(), crate::mod_params::RadioError> {
+        let irq_mask = match radio_mode {
+            Some(RadioMode::Standby) => IrqMask::All.value(),
+            Some(RadioMode::Transmit) => IrqMask::TxDone.value() | IrqMask::RxTxTimeout.value(),
+            Some(RadioMode::Receive(_)) => IrqMask::All.value(),
+            Some(RadioMode::ChannelActivityDetection) => {
+                IrqMask::CADDone.value() | IrqMask::CADActivityDetected.value()
+            }
+            _ => self.irq_flags,
+        };
+        self.irq_flags = irq_mask;
+
+        Ok(())
+    }
+
+    async fn set_tx_continuous_wave_mode(&mut self) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+
+    async fn await_irq(&mut self) -> Result<(), crate::mod_params::RadioError> {
+        Ok(())
+    }
+
+    async fn process_irq_event(
+        &mut self,
+        radio_mode: crate::mod_params::RadioMode,
+        cad_activity_detected: Option<&mut bool>,
+        _clear_interrupts: bool,
+    ) -> Result<Option<crate::mod_traits::IrqState>, crate::mod_params::RadioError> {
+        self.get_irq_state(radio_mode, cad_activity_detected).await
+    }
+
+    async fn get_irq_state(
+        &mut self,
+        radio_mode: crate::mod_params::RadioMode,
+        cad_activity_detected: Option<&mut bool>,
+    ) -> Result<Option<crate::mod_traits::IrqState>, crate::mod_params::RadioError> {
+        let irq_flags = self.irq_flags;
+        match radio_mode {
+            RadioMode::Transmit => {
+                if IrqMask::TxDone.is_set(irq_flags) {
+                    return Ok(Some(IrqState::Done));
+                }
+                if IrqMask::RxTxTimeout.is_set(irq_flags) {
+                    return Err(RadioError::TransmitTimeout);
+                }
+                if irq_flags == 0 {
+                    return Ok(Some(IrqState::Done));
+                }
+            }
+            RadioMode::Receive(_) => {
+                if IrqMask::CRCError.is_set(irq_flags) || IrqMask::HeaderError.is_set(irq_flags) {
+                    debug!("CRC or Header error");
+                }
+                if IrqMask::RxDone.is_set(irq_flags) {
+                    return Ok(Some(IrqState::Done));
+                }
+                if IrqMask::RxTxTimeout.is_set(irq_flags) {
+                    return Err(RadioError::ReceiveTimeout);
+                }
+                if IrqMask::PreambleDetected.is_set(irq_flags) || IrqMask::SyncwordValid.is_set(irq_flags) {
+                    return Ok(Some(IrqState::PreambleReceived));
+                }
+            }
+            RadioMode::ChannelActivityDetection => {
+                if IrqMask::CADDone.is_set(irq_flags) {
+                    if let Some(detected) = cad_activity_detected {
+                        *detected = IrqMask::CADActivityDetected.is_set(irq_flags);
+                    }
+                    return Ok(Some(IrqState::Done));
+                }
+            }
+            RadioMode::Sleep | RadioMode::Standby | RadioMode::Listen => {
+                warn!("IRQ during sleep/standby/listen?");
+            }
+            RadioMode::FrequencySynthesis => {}
+        }
+
+        Ok(None)
+    }
+
+    async fn clear_irq_status(&mut self) -> Result<(), crate::mod_params::RadioError> {
+        self.irq_flags = IrqMask::None.value();
+        Ok(())
+    }
+}

--- a/lora-phy/src/mock/mod.rs
+++ b/lora-phy/src/mock/mod.rs
@@ -1,4 +1,5 @@
-mod radio_kind_params;
+/// The IRQ flags available for mock impl
+pub mod radio_kind_params;
 
 use crate::{
     mock::radio_kind_params::IrqMask,
@@ -31,9 +32,24 @@ pub struct MockRadio {
 }
 
 impl MockRadio {
+    /// Create empty mock radio
+    pub fn new() -> Self {
+        Self {
+            state: MockState::Standby,
+            warm_start: false,
+            irq_flags: IrqMask::None.value(),
+        }
+    }
+
     /// Sets internal flag, to be used for checking different failure states
     pub fn set_irq_flags(&mut self, flag: u16) {
         self.irq_flags = flag;
+    }
+}
+
+impl Default for MockRadio {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -127,10 +143,6 @@ impl RadioKind for MockRadio {
         &mut self,
         _mdltn_params: &ModulationParams,
     ) -> Result<(), crate::mod_params::RadioError> {
-        // let spreading_factor_val = spreading_factor_value(mdltn_params.spreading_factor)?;
-        // let bandwidth_val = bandwidth_value(mdltn_params.bandwidth)?;
-        // let coding_rate_val = coding_rate_value(mdltn_params.coding_rate?;
-        // self.mod_params = mdltn_params;
         Ok(())
     }
 

--- a/lora-phy/src/mock/radio_kind_params.rs
+++ b/lora-phy/src/mock/radio_kind_params.rs
@@ -1,24 +1,37 @@
+/// The possible IRQ set for mock radio
 #[derive(Clone, Copy)]
 pub enum IrqMask {
+    /// Default
     None = 0x0000,
+    /// When Tx is done
     TxDone = 0x0001,
+    /// When Rx is done
     RxDone = 0x0002,
+    /// For Rx check
     PreambleDetected = 0x0004,
+    /// For Rx check
     SyncwordValid = 0x0008,
-    HeaderValid = 0x0010,
+    /// For Rx check
     HeaderError = 0x0020,
+    /// For Rx check
     CRCError = 0x0040,
+    /// CAD is done
     CADDone = 0x0080,
+    /// CAD detected activity
     CADActivityDetected = 0x0100,
+    /// Timeout
     RxTxTimeout = 0x0200,
+    /// All of the above flags
     All = 0xFFFF,
 }
 
 impl IrqMask {
+    /// Get enum value
     pub fn value(self) -> u16 {
         self as u16
     }
 
+    /// To check if a flag is set
     pub fn is_set(self, mask: u16) -> bool {
         self.value() & mask == self.value()
     }

--- a/lora-phy/src/mock/radio_kind_params.rs
+++ b/lora-phy/src/mock/radio_kind_params.rs
@@ -1,0 +1,25 @@
+#[derive(Clone, Copy)]
+pub enum IrqMask {
+    None = 0x0000,
+    TxDone = 0x0001,
+    RxDone = 0x0002,
+    PreambleDetected = 0x0004,
+    SyncwordValid = 0x0008,
+    HeaderValid = 0x0010,
+    HeaderError = 0x0020,
+    CRCError = 0x0040,
+    CADDone = 0x0080,
+    CADActivityDetected = 0x0100,
+    RxTxTimeout = 0x0200,
+    All = 0xFFFF,
+}
+
+impl IrqMask {
+    pub fn value(self) -> u16 {
+        self as u16
+    }
+
+    pub fn is_set(self, mask: u16) -> bool {
+        self.value() & mask == self.value()
+    }
+}


### PR DESCRIPTION
## Attempts to implement a mock radio to be used for tests with the lora-phy `RadioKind` trait.

I have tried to expose the IRQ flags such that the state and errors can be set manually when unit testing, but this runs into issues when the `RadioKind` is consumed by `LoRa::new(*)`.

So I might need some guidance on what would be ideal here, I've tried to test it with a project of mine, which mainly used `LoRa.get_irq_state()` so the irq mask being public seems to me to be wasteful, but I might not understand the lib structure properly, or API usage.

I'm prepared for doc comments being horrible since they are mostly placeholders, and I will improve those when the proper components have been decided.