### PR TITLE
Test radio drivers against Semtech's reference implementation (SWL2001)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      # Needed to build the smtc-modem-cores bindings used by lora-phy tests
+      - name: Setup apt packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends cmake llvm-dev clang libclang-dev
+
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -87,6 +91,10 @@ jobs:
         uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
+
+      # Needed to build the smtc-modem-cores bindings used by lora-phy tests
+      - name: Setup apt packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends cmake llvm-dev clang libclang-dev
 
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -35,5 +35,5 @@ lorawan-radio = ["dep:lorawan-device"]
 lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
-smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "70c6e87" }
+smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "42d8559" }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -35,5 +35,5 @@ lorawan-radio = ["dep:lorawan-device"]
 lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
-smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "1949152" }
+smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "f2b684b" }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -36,4 +36,6 @@ lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
 smtc-modem-cores = "0.2.1"
+# Derive `OpCode::from_repr` for the sx126x behavioral emulator (test-only)
+strum = { version = "0.28", default-features = false, features = ["derive"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -35,5 +35,5 @@ lorawan-radio = ["dep:lorawan-device"]
 lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
-smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "b31ab4a" }
+smtc-modem-cores = "0.1.0"
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -35,5 +35,5 @@ lorawan-radio = ["dep:lorawan-device"]
 lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
-smtc-modem-cores = "0.1.0"
+smtc-modem-cores = "0.2.1"
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -35,5 +35,5 @@ lorawan-radio = ["dep:lorawan-device"]
 lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
-smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "f2b684b" }
+smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "209f855" }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -35,5 +35,5 @@ lorawan-radio = ["dep:lorawan-device"]
 lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
-smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "a48bbea" }
+smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "4c9c346" }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -35,5 +35,5 @@ lorawan-radio = ["dep:lorawan-device"]
 lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
-smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "42d8559" }
+smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "a48bbea" }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -35,5 +35,5 @@ lorawan-radio = ["dep:lorawan-device"]
 lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
-smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "209f855" }
+smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "e666762" }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -33,3 +33,7 @@ lorawan-radio = ["dep:lorawan-device"]
 [dev-dependencies]
 # Include lorawan-device unconditionally so all regions are enabled for tests
 lorawan-device = { path = "../lorawan-device" }
+# Bindings to Semtech's reference driver (SWL2001), used to test our
+# implementation against the vendor's SPI byte stream
+smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "1949152" }
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -35,5 +35,5 @@ lorawan-radio = ["dep:lorawan-device"]
 lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
-smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "4c9c346" }
+smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "b31ab4a" }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -35,5 +35,5 @@ lorawan-radio = ["dep:lorawan-device"]
 lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
-smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "e666762" }
+smtc-modem-cores = { git = "https://github.com/lora-rs/smtc-modem-cores", rev = "70c6e87" }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -1,4 +1,6 @@
-#![no_std]
+// std is allowed under test so the sx126x tests can compare against the
+// reference driver bindings, which are std-only
+#![cfg_attr(not(test), no_std)]
 #![deny(rust_2018_idioms)]
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -1,6 +1,4 @@
-// std is allowed under test so the sx126x tests can compare against the
-// reference driver bindings, which are std-only
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 #![deny(rust_2018_idioms)]
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -33,6 +31,9 @@ pub mod mod_traits;
 pub mod sx126x;
 /// Specific implementation to support Semtech Sx127x chips
 pub mod sx127x;
+#[cfg(test)]
+#[macro_use]
+extern crate std;
 #[cfg(test)]
 pub(crate) mod test_fixtures;
 

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -33,6 +33,8 @@ pub mod mod_traits;
 pub mod sx126x;
 /// Specific implementation to support Semtech Sx127x chips
 pub mod sx127x;
+#[cfg(test)]
+pub(crate) mod test_fixtures;
 
 pub use crate::mod_params::RxMode;
 

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -66,6 +66,535 @@ const LR1110_MAX_LORA_SYMB_NUM_TIMEOUT: u8 = 248;
 // SetRx timeout argument for enabling continuous mode
 const RX_CONTINUOUS_TIMEOUT: u32 = 0xFFFFFF;
 
+/// One entry of a PA power table: the vendor's calibrated SetPaConfig /
+/// SetTxParams values for a single requested dBm.
+struct PaCfg {
+    /// Power commanded via SetTxParams (may be remapped up or down from the
+    /// requested dBm); negative on the LP and HF PAs.
+    configured_power: i8,
+    /// SetPaConfig paDutyCycle
+    pa_duty_cycle: u8,
+    /// SetPaConfig paHPSel
+    pa_hp_sel: u8,
+}
+
+// PA power tables transcribed from Semtech's SWL2001 reference BSP
+// (lbm_examples/radio_hal/lr11xx_pa_pwr_cfg.h: LR11XX_PA_LP_LF_CFG_TABLE,
+// LR11XX_PA_HP_LF_CFG_TABLE, LR11XX_PA_HF_CFG_TABLE). Each table is indexed by
+// (clamped_requested_dBm - MIN). Power bounds and the Vreg/Vbat switch come
+// from lbm_examples/radio_hal/ral_lr11xx_bsp.c. The LR1110 v2.1 datasheet
+// (July 2025) confirms the sub-GHz LP PA reaches +15 dBm.
+
+// LP PA output-power bounds [dBm]
+const LP_MIN: i8 = -17;
+const LP_MAX: i8 = 15;
+// HP PA output-power bounds [dBm]
+const HP_MIN: i8 = -9;
+const HP_MAX: i8 = 22;
+// HF PA output-power bounds [dBm]
+const HF_MIN: i8 = -18;
+const HF_MAX: i8 = 13;
+// At or below this requested power the HP PA runs from the regulator (Vreg)
+// for better efficiency; above it, from the battery (Vbat).
+const HP_VREG_VBAT_SWITCH: i8 = 8;
+
+/// LP sub-GHz PA, requests -17..=+15 dBm (33 entries)
+const LR11XX_PA_LP_LF_CFG_TABLE: [PaCfg; (LP_MAX - LP_MIN + 1) as usize] = [
+    PaCfg {
+        configured_power: -15,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, // -17 dBm
+    PaCfg {
+        configured_power: -14,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, // -16 dBm
+    PaCfg {
+        configured_power: -13,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, // -15 dBm
+    PaCfg {
+        configured_power: -12,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, // -14 dBm
+    PaCfg {
+        configured_power: -11,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, // -13 dBm
+    PaCfg {
+        configured_power: -9,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, // -12 dBm
+    PaCfg {
+        configured_power: -8,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, // -11 dBm
+    PaCfg {
+        configured_power: -7,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, // -10 dBm
+    PaCfg {
+        configured_power: -6,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -9 dBm
+    PaCfg {
+        configured_power: -5,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -8 dBm
+    PaCfg {
+        configured_power: -4,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -7 dBm
+    PaCfg {
+        configured_power: -3,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -6 dBm
+    PaCfg {
+        configured_power: -2,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -5 dBm
+    PaCfg {
+        configured_power: -1,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -4 dBm
+    PaCfg {
+        configured_power: 0,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -3 dBm
+    PaCfg {
+        configured_power: 1,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -2 dBm
+    PaCfg {
+        configured_power: 2,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -1 dBm
+    PaCfg {
+        configured_power: 3,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //   0 dBm
+    PaCfg {
+        configured_power: 3,
+        pa_duty_cycle: 0x01,
+        pa_hp_sel: 0x00,
+    }, //   1 dBm
+    PaCfg {
+        configured_power: 4,
+        pa_duty_cycle: 0x01,
+        pa_hp_sel: 0x00,
+    }, //   2 dBm
+    PaCfg {
+        configured_power: 7,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //   3 dBm
+    PaCfg {
+        configured_power: 8,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //   4 dBm
+    PaCfg {
+        configured_power: 9,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //   5 dBm
+    PaCfg {
+        configured_power: 10,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //   6 dBm
+    PaCfg {
+        configured_power: 12,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //   7 dBm
+    PaCfg {
+        configured_power: 13,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //   8 dBm
+    PaCfg {
+        configured_power: 14,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //   9 dBm
+    PaCfg {
+        configured_power: 13,
+        pa_duty_cycle: 0x01,
+        pa_hp_sel: 0x00,
+    }, //  10 dBm
+    PaCfg {
+        configured_power: 13,
+        pa_duty_cycle: 0x02,
+        pa_hp_sel: 0x00,
+    }, //  11 dBm
+    PaCfg {
+        configured_power: 14,
+        pa_duty_cycle: 0x02,
+        pa_hp_sel: 0x00,
+    }, //  12 dBm
+    PaCfg {
+        configured_power: 14,
+        pa_duty_cycle: 0x03,
+        pa_hp_sel: 0x00,
+    }, //  13 dBm
+    PaCfg {
+        configured_power: 14,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  14 dBm
+    PaCfg {
+        configured_power: 14,
+        pa_duty_cycle: 0x07,
+        pa_hp_sel: 0x00,
+    }, //  15 dBm
+];
+
+/// HP sub-GHz PA, requests -9..=+22 dBm (32 entries)
+const LR11XX_PA_HP_LF_CFG_TABLE: [PaCfg; (HP_MAX - HP_MIN + 1) as usize] = [
+    PaCfg {
+        configured_power: 9,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -9 dBm
+    PaCfg {
+        configured_power: 10,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -8 dBm
+    PaCfg {
+        configured_power: 11,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -7 dBm
+    PaCfg {
+        configured_power: 12,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -6 dBm
+    PaCfg {
+        configured_power: 13,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  -5 dBm
+    PaCfg {
+        configured_power: 13,
+        pa_duty_cycle: 0x01,
+        pa_hp_sel: 0x00,
+    }, //  -4 dBm
+    PaCfg {
+        configured_power: 13,
+        pa_duty_cycle: 0x02,
+        pa_hp_sel: 0x00,
+    }, //  -3 dBm
+    PaCfg {
+        configured_power: 17,
+        pa_duty_cycle: 0x02,
+        pa_hp_sel: 0x00,
+    }, //  -2 dBm
+    PaCfg {
+        configured_power: 14,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  -1 dBm
+    PaCfg {
+        configured_power: 12,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x01,
+    }, //   0 dBm
+    PaCfg {
+        configured_power: 13,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x01,
+    }, //   1 dBm
+    PaCfg {
+        configured_power: 13,
+        pa_duty_cycle: 0x01,
+        pa_hp_sel: 0x01,
+    }, //   2 dBm
+    PaCfg {
+        configured_power: 13,
+        pa_duty_cycle: 0x02,
+        pa_hp_sel: 0x01,
+    }, //   3 dBm
+    PaCfg {
+        configured_power: 15,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x02,
+    }, //   4 dBm
+    PaCfg {
+        configured_power: 15,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x01,
+    }, //   5 dBm
+    PaCfg {
+        configured_power: 14,
+        pa_duty_cycle: 0x02,
+        pa_hp_sel: 0x02,
+    }, //   6 dBm
+    PaCfg {
+        configured_power: 14,
+        pa_duty_cycle: 0x01,
+        pa_hp_sel: 0x03,
+    }, //   7 dBm
+    PaCfg {
+        configured_power: 17,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x02,
+    }, //   8 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x01,
+    }, //   9 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x01,
+        pa_hp_sel: 0x01,
+    }, //  10 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x02,
+        pa_hp_sel: 0x01,
+    }, //  11 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x03,
+        pa_hp_sel: 0x01,
+    }, //  12 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x03,
+    }, //  13 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x01,
+        pa_hp_sel: 0x03,
+    }, //  14 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x02,
+    }, //  15 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x01,
+        pa_hp_sel: 0x04,
+    }, //  16 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x02,
+        pa_hp_sel: 0x04,
+    }, //  17 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x01,
+        pa_hp_sel: 0x06,
+    }, //  18 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x03,
+        pa_hp_sel: 0x05,
+    }, //  19 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x03,
+        pa_hp_sel: 0x07,
+    }, //  20 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x06,
+    }, //  21 dBm
+    PaCfg {
+        configured_power: 22,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x07,
+    }, //  22 dBm
+];
+
+/// HF (2.4 GHz) PA, requests -18..=+13 dBm (32 entries)
+const LR11XX_PA_HF_CFG_TABLE: [PaCfg; (HF_MAX - HF_MIN + 1) as usize] = [
+    PaCfg {
+        configured_power: -18,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, // -18 dBm
+    PaCfg {
+        configured_power: -18,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, // -17 dBm
+    PaCfg {
+        configured_power: -17,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, // -16 dBm
+    PaCfg {
+        configured_power: -16,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, // -15 dBm
+    PaCfg {
+        configured_power: -15,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, // -14 dBm
+    PaCfg {
+        configured_power: -14,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, // -13 dBm
+    PaCfg {
+        configured_power: -14,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, // -12 dBm
+    PaCfg {
+        configured_power: -12,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, // -11 dBm
+    PaCfg {
+        configured_power: -10,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, // -10 dBm
+    PaCfg {
+        configured_power: -9,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  -9 dBm
+    PaCfg {
+        configured_power: -8,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  -8 dBm
+    PaCfg {
+        configured_power: -7,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  -7 dBm
+    PaCfg {
+        configured_power: -6,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  -6 dBm
+    PaCfg {
+        configured_power: -5,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  -5 dBm
+    PaCfg {
+        configured_power: -4,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  -4 dBm
+    PaCfg {
+        configured_power: -3,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  -3 dBm
+    PaCfg {
+        configured_power: -2,
+        pa_duty_cycle: 0x03,
+        pa_hp_sel: 0x00,
+    }, //  -2 dBm
+    PaCfg {
+        configured_power: -1,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  -1 dBm
+    PaCfg {
+        configured_power: 0,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //   0 dBm
+    PaCfg {
+        configured_power: 1,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //   1 dBm
+    PaCfg {
+        configured_power: 2,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //   2 dBm
+    PaCfg {
+        configured_power: 4,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //   3 dBm
+    PaCfg {
+        configured_power: 5,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //   4 dBm
+    PaCfg {
+        configured_power: 6,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //   5 dBm
+    PaCfg {
+        configured_power: 7,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //   6 dBm
+    PaCfg {
+        configured_power: 8,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //   7 dBm
+    PaCfg {
+        configured_power: 9,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //   8 dBm
+    PaCfg {
+        configured_power: 10,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //   9 dBm
+    PaCfg {
+        configured_power: 11,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  10 dBm
+    PaCfg {
+        configured_power: 12,
+        pa_duty_cycle: 0x03,
+        pa_hp_sel: 0x00,
+    }, //  11 dBm
+    PaCfg {
+        configured_power: 13,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    }, //  12 dBm
+    PaCfg {
+        configured_power: 13,
+        pa_duty_cycle: 0x00,
+        pa_hp_sel: 0x00,
+    }, //  13 dBm
+];
+
 /// Configuration for LR1110-based boards
 pub struct Config {
     /// Which power amplifier to use: LP up to +14 dBm, HP up to +22 dBm, HF for the 2.4 GHz band
@@ -1462,23 +1991,19 @@ where
         let ramp_time = RampTime::Ramp208Us;
 
         let pa_selection = self.config.pa_selection;
-        // Per LR1110 User Manual Tables 9-1 and 9-2 and the SWL2001 reference BSP
-        // (ral_lr11xx_bsp.c, lr11xx_get_tx_cfg): the LP and HF PAs run from the
-        // internal regulator (Vreg), only the HP PA draws from VBAT.
-        let pa_supply = match pa_selection {
-            PaSelection::Lp | PaSelection::Hf => PaRegSupply::Vreg,
-            PaSelection::Hp => PaRegSupply::Vbat,
-        };
 
-        let (tx_power, pa_duty_cycle, pa_hp_sel) = match pa_selection {
+        // Look up the PA config for the requested power. The tables (below)
+        // are the vendor's per-dBm calibration: each entry remaps the request
+        // to a configured chip power and its paDutyCycle / paHPSel.
+        let (tx_power, pa_duty_cycle, pa_hp_sel, pa_supply) = match pa_selection {
             PaSelection::Lp => {
-                // Low Power PA: -17 to +14 dBm
-                const LP_MIN: i32 = -17;
-                const LP_MAX: i32 = 14;
-                let txp = output_power.clamp(LP_MIN, LP_MAX);
+                let clamped = output_power.clamp(LP_MIN as i32, LP_MAX as i32);
+                let entry = &LR11XX_PA_LP_LF_CFG_TABLE[(clamped - LP_MIN as i32) as usize];
 
-                // Validate frequency constraint for max power
-                if txp == LP_MAX {
+                // Duty cycles above 0x04 are not allowed below 400 MHz per the
+                // LR1110 User Manual. With the vendor table only the +15 dBm
+                // entry (duty 0x07) trips this.
+                if entry.pa_duty_cycle > 0x04 {
                     if let Some(m_p) = mdltn_params {
                         if m_p.frequency_in_hz < 400_000_000 {
                             return Err(RadioError::InvalidOutputPowerForFrequency);
@@ -1486,40 +2011,45 @@ where
                     }
                 }
 
-                // PA configuration for LP PA
-                // Per LR1110 User Manual Table 9-1 and SWDM001 demo:
-                // LP PA uses paDutyCycle = 0x04, paHPSel = 0x00
-                let (duty_cycle, hp_sel, power) = (0x04, 0x00, txp as u8);
-                (power, duty_cycle, hp_sel)
+                // LP PA always runs from the internal regulator.
+                (
+                    entry.configured_power as u8,
+                    entry.pa_duty_cycle,
+                    entry.pa_hp_sel,
+                    PaRegSupply::Vreg,
+                )
             }
             PaSelection::Hp => {
-                // High Power PA: -9 to +22 dBm
-                const HP_MIN: i32 = -9;
-                const HP_MAX: i32 = 22;
-                let txp = output_power.clamp(HP_MIN, HP_MAX);
+                let clamped = output_power.clamp(HP_MIN as i32, HP_MAX as i32);
+                let entry = &LR11XX_PA_HP_LF_CFG_TABLE[(clamped - HP_MIN as i32) as usize];
 
-                let (duty_cycle, hp_sel, power) = match txp {
-                    22 => (0x04, 0x07, 22),
-                    18..=21 => (0x03, 0x05, txp as u8),
-                    15..=17 => (0x02, 0x03, txp as u8),
-                    HP_MIN..=14 => (0x02, 0x02, txp as u8),
-                    _ => unreachable!(),
+                // Efficiency switch from the vendor BSP (ral_lr11xx_bsp.c,
+                // LR11XX_PWR_VREG_VBAT_SWITCH = 8): at or below 8 dBm the HP PA
+                // runs from the regulator, above it from the battery.
+                let supply = if clamped <= HP_VREG_VBAT_SWITCH as i32 {
+                    PaRegSupply::Vreg
+                } else {
+                    PaRegSupply::Vbat
                 };
-                (power, duty_cycle, hp_sel)
+
+                (
+                    entry.configured_power as u8,
+                    entry.pa_duty_cycle,
+                    entry.pa_hp_sel,
+                    supply,
+                )
             }
             PaSelection::Hf => {
-                // High Frequency PA (2.4 GHz): -18 to +13 dBm
-                const HF_MIN: i32 = -18;
-                const HF_MAX: i32 = 13;
-                let txp = output_power.clamp(HF_MIN, HF_MAX);
+                let clamped = output_power.clamp(HF_MIN as i32, HF_MAX as i32);
+                let entry = &LR11XX_PA_HF_CFG_TABLE[(clamped - HF_MIN as i32) as usize];
 
-                let (duty_cycle, hp_sel, power) = match txp {
-                    13 => (0x04, 0x00, 13),
-                    10..=12 => (0x02, 0x00, txp as u8),
-                    HF_MIN..=9 => (0x01, 0x00, txp as u8),
-                    _ => unreachable!(),
-                };
-                (power, duty_cycle, hp_sel)
+                // HF PA always runs from the internal regulator.
+                (
+                    entry.configured_power as u8,
+                    entry.pa_duty_cycle,
+                    entry.pa_hp_sel,
+                    PaRegSupply::Vreg,
+                )
             }
         };
 

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -5,6 +5,8 @@
 #![allow(missing_docs)]
 
 pub mod radio_kind_params;
+#[cfg(test)]
+mod test;
 
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::*;

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -164,33 +164,29 @@ where
         self.intf.read_with_status(write_data, read_buffer).await
     }
 
-    /// Write data to the TX buffer
-    async fn write_buffer(&mut self, offset: u8, data: &[u8]) -> Result<(), RadioError> {
+    /// Write data to the TX buffer. Unlike the SX126x command, WriteBuffer8
+    /// takes no offset — data always lands at the write pointer.
+    async fn write_buffer(&mut self, data: &[u8]) -> Result<(), RadioError> {
         let opcode = RegMemOpCode::WriteBuffer8.bytes();
-        let header = [opcode[0], opcode[1], offset];
+        let header = [opcode[0], opcode[1]];
         self.intf.write_with_payload(&header, data, false).await
     }
 
     /// Read data from the RX buffer
     async fn read_buffer(&mut self, offset: u8, length: u8, buffer: &mut [u8]) -> Result<(), RadioError> {
         let opcode = RegMemOpCode::ReadBuffer8.bytes();
-        let header = [opcode[0], opcode[1], offset, 0x00];
+        let header = [opcode[0], opcode[1], offset, length];
         self.intf.read(&header, &mut buffer[..length as usize]).await
     }
 
-    /// Set the number of symbols the radio will wait to detect a reception
+    /// Set the number of symbols the radio will wait to detect a reception.
+    /// Values up to 255 go on the wire as the raw symbol count; the SX126x
+    /// mantissa/exponent encoding only exists in an extended form of this
+    /// command for larger values, which the capped range never needs.
     async fn set_lora_symbol_num_timeout(&mut self, symbol_num: u16) -> Result<(), RadioError> {
-        let mut exp = 0u8;
-        let mut mant = ((symbol_num.min(LR1110_MAX_LORA_SYMB_NUM_TIMEOUT.into()) + 1) >> 1) as u8;
-
-        while mant > 31 {
-            mant = (mant + 3) >> 2;
-            exp += 1;
-        }
-
-        let timeout_value = exp + (mant << 3);
+        let symbol_num = symbol_num.min(LR1110_MAX_LORA_SYMB_NUM_TIMEOUT.into()) as u8;
         let opcode = RadioOpCode::SetLoRaSyncTimeout.bytes();
-        let cmd = [opcode[0], opcode[1], timeout_value];
+        let cmd = [opcode[0], opcode[1], symbol_num];
         self.write_command(&cmd).await
     }
 
@@ -647,10 +643,10 @@ where
     /// # Arguments
     /// * `params` - GFSK modulation parameters (bitrate, pulse shape, bandwidth, frequency deviation)
     pub async fn set_gfsk_mod_params(&mut self, params: &GfskModulationParams) -> Result<(), RadioError> {
-        // Convert bitrate to chip format: (32 * 32000000) / bitrate
-        let br = ((32u64 * LR1110_XTAL_FREQ as u64) / params.bitrate_bps as u64) as u32;
-        // Convert frequency deviation to chip format: (fdev * 2^25) / 32000000
-        let fdev = ((params.freq_dev_hz as u64) << 25) / (LR1110_XTAL_FREQ as u64);
+        // Unlike the SX126x, the LR11xx takes the bitrate in raw bps and the
+        // frequency deviation in raw Hz — no chip-format conversion
+        let br = params.bitrate_bps;
+        let fdev = params.freq_dev_hz;
 
         let opcode = RadioOpCode::SetModulationParam.bytes();
         let cmd = [
@@ -707,13 +703,16 @@ where
             ));
         }
 
+        // The command always carries 8 sync word bytes; shorter words are
+        // zero-padded (sync_word_length_bits in the packet params decides
+        // how many bits the chip matches)
         let opcode = RadioOpCode::SetGfskSyncWord.bytes();
         let mut cmd = [0u8; 10]; // 2 opcode + 8 sync word
         cmd[0] = opcode[0];
         cmd[1] = opcode[1];
         cmd[2..2 + sync_word.len()].copy_from_slice(sync_word);
 
-        self.write_command(&cmd[..2 + sync_word.len()]).await
+        self.write_command(&cmd).await
     }
 
     /// Set GFSK CRC parameters
@@ -770,11 +769,11 @@ where
         let mut rbuffer = [0u8; 4];
         self.read_command(&cmd, &mut rbuffer).await?;
 
-        // Parse RSSI values (raw values are unsigned, convert to dBm)
-        let rssi_sync_dbm = -((rbuffer[1] as i16) / 2);
-        let rssi_avg_dbm = -((rbuffer[2] as i16) / 2);
+        // Response layout: rssi_sync, rssi_avg, rx_len, status bits
+        let rssi_sync_dbm = -((rbuffer[0] as i16) / 2);
+        let rssi_avg_dbm = -((rbuffer[1] as i16) / 2);
 
-        Ok((rbuffer[0], rssi_sync_dbm, rssi_avg_dbm))
+        Ok((rbuffer[2], rssi_sync_dbm, rssi_avg_dbm))
     }
 
     // =========================================================================
@@ -884,7 +883,14 @@ where
     ///
     /// # Arguments
     /// * `delay_rtc` - Delay between RX and TX (or TX and RX) in RTC steps
-    pub async fn set_auto_tx_rx(&mut self, delay_rtc: u32) -> Result<(), RadioError> {
+    /// * `intermediary_mode` - Mode the chip waits in during the delay
+    /// * `timeout_rtc` - Timeout of the second activity in RTC steps
+    pub async fn set_auto_tx_rx(
+        &mut self,
+        delay_rtc: u32,
+        intermediary_mode: IntermediaryMode,
+        timeout_rtc: u32,
+    ) -> Result<(), RadioError> {
         let opcode = RadioOpCode::AutoTxRx.bytes();
         let cmd = [
             opcode[0],
@@ -892,6 +898,10 @@ where
             ((delay_rtc >> 16) & 0xFF) as u8,
             ((delay_rtc >> 8) & 0xFF) as u8,
             (delay_rtc & 0xFF) as u8,
+            intermediary_mode.value(),
+            ((timeout_rtc >> 16) & 0xFF) as u8,
+            ((timeout_rtc >> 8) & 0xFF) as u8,
+            (timeout_rtc & 0xFF) as u8,
         ];
         self.write_command(&cmd).await
     }
@@ -1607,7 +1617,7 @@ where
     }
 
     async fn set_payload(&mut self, payload: &[u8]) -> Result<(), RadioError> {
-        self.write_buffer(0x00, payload).await
+        self.write_buffer(payload).await
     }
 
     async fn do_tx(&mut self) -> Result<(), RadioError> {
@@ -1632,6 +1642,10 @@ where
             ];
             self.write_command(&tcxo_cmd).await?;
         }
+
+        // The reference driver applies the high-ACP workaround on every
+        // SetTx/SetRx/SetCad (harmless register write on unaffected firmware)
+        self.apply_high_acp_workaround().await?;
 
         // Disable timeout (0 = no timeout)
         let opcode = RadioOpCode::SetTx.bytes();
@@ -1693,6 +1707,10 @@ where
                 } else {
                     0
                 };
+
+                // Reference driver behavior; RX duty cycle notably does NOT
+                // get the workaround there
+                self.apply_high_acp_workaround().await?;
 
                 let opcode = RadioOpCode::SetRx.bytes();
                 let cmd = [
@@ -1784,7 +1802,9 @@ where
         ];
         self.write_command(&cad_cmd).await?;
 
-        // Start CAD
+        // Start CAD (reference driver applies the high-ACP workaround here
+        // too)
+        self.apply_high_acp_workaround().await?;
         let start_opcode = RadioOpCode::SetCad.bytes();
         let start_cmd = [start_opcode[0], start_opcode[1]];
         self.write_command(&start_cmd).await

--- a/lora-phy/src/lr1110/radio_kind_params.rs
+++ b/lora-phy/src/lr1110/radio_kind_params.rs
@@ -419,6 +419,21 @@ impl FallbackMode {
     }
 }
 
+/// Mode the chip waits in between the two activities of AutoTxRx
+#[derive(Clone, Copy)]
+pub enum IntermediaryMode {
+    Sleep = 0x00,
+    StandbyRc = 0x01,
+    StandbyXosc = 0x02,
+    Fs = 0x03,
+}
+
+impl IntermediaryMode {
+    pub fn value(self) -> u8 {
+        self as u8
+    }
+}
+
 // =============================================================================
 // GFSK Types and Constants (from SWDR001 lr11xx_radio.c/h)
 // =============================================================================
@@ -709,12 +724,14 @@ pub struct SleepParams {
 
 impl SleepParams {
     pub fn value(self) -> u8 {
+        // LR11xx SetSleep config: bit 0 = warm start (retention), bit 1 =
+        // wake-up on RTC timeout — not the SX126x bit layout
         let mut val = 0u8;
         if self.warm_start {
-            val |= 0x04;
+            val |= 0x01;
         }
         if self.rtc_wakeup {
-            val |= 0x01;
+            val |= 0x02;
         }
         val
     }

--- a/lora-phy/src/lr1110/test/fixtures.rs
+++ b/lora-phy/src/lr1110/test/fixtures.rs
@@ -177,6 +177,21 @@ pub fn get_lr1110_lp() -> Lr1110<TestFixture, DummyVariant> {
     )
 }
 
+/// HF-PA variant for the 2.4 GHz high-frequency TX path
+pub fn get_lr1110_hf() -> Lr1110<TestFixture, DummyVariant> {
+    Lr1110::new(
+        TestFixture::new(),
+        DummyVariant,
+        Config {
+            pa_selection: PaSelection::Hf,
+            dio_as_rf_switch: Some(Default::default()),
+            tcxo_ctrl: None,
+            use_dcdc: false,
+            rx_boost: false,
+        },
+    )
+}
+
 /// TCXO + DC-DC board, for the init_system and TCXO-before-TX paths
 pub fn get_lr1110_dcdc_tcxo() -> Lr1110<TestFixture, DummyVariant> {
     Lr1110::new(

--- a/lora-phy/src/lr1110/test/fixtures.rs
+++ b/lora-phy/src/lr1110/test/fixtures.rs
@@ -1,9 +1,7 @@
 use crate::lr1110::radio_kind_params::PaSelection;
 use crate::lr1110::{Config, Lr1110};
-use crate::mod_params::RadioError;
-use crate::mod_traits::InterfaceVariant;
-use embedded_hal::spi::{ErrorKind, Operation};
-use embedded_hal_async::delay::DelayNs;
+pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
+use embedded_hal::spi::Operation;
 use embedded_hal_async::spi::SpiDevice;
 use std::collections::{HashMap, VecDeque};
 
@@ -105,15 +103,8 @@ impl TestFixture {
     }
 }
 
-#[derive(Debug)]
-pub enum Error {}
-impl embedded_hal::spi::Error for Error {
-    fn kind(&self) -> ErrorKind {
-        todo!()
-    }
-}
 impl embedded_hal::spi::ErrorType for TestFixture {
-    type Error = Error;
+    type Error = SpiError;
 }
 
 impl embedded_hal::spi::SpiDevice for TestFixture {
@@ -209,32 +200,4 @@ pub fn get_lr1110_boosted() -> Lr1110<TestFixture, DummyVariant> {
             rx_boost: true,
         },
     )
-}
-
-pub struct Delayer;
-impl DelayNs for Delayer {
-    async fn delay_ns(&mut self, _ns: u32) {}
-}
-
-pub struct DummyVariant;
-
-impl InterfaceVariant for DummyVariant {
-    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn await_irq(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
 }

--- a/lora-phy/src/lr1110/test/fixtures.rs
+++ b/lora-phy/src/lr1110/test/fixtures.rs
@@ -26,6 +26,9 @@ pub struct TestFixture {
     read_responses: HashMap<Vec<u8>, Vec<u8>>,
     direct_read_responses: VecDeque<Vec<u8>>,
     last_cmd: Vec<u8>,
+    /// Stat1 byte prepended to every command-response read. Defaults to
+    /// CMD_DAT (bits[3:1] = 3) as real hardware returns on success.
+    pub stat1: u8,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -42,12 +45,13 @@ impl TestFixture {
             read_responses: HashMap::new(),
             direct_read_responses: VecDeque::new(),
             last_cmd: vec![],
+            stat1: 0x06, // CMD_DAT
         }
     }
 
     /// Canned response for the read phase of the command identified by its
-    /// full command bytes. Covers the data only — the leading status byte
-    /// both drivers discard always reads 0.
+    /// full command bytes. Covers the data only — the leading Stat1 byte
+    /// reads as `self.stat1`.
     pub fn prime_read(&mut self, command: &[u8], response: &[u8]) {
         self.read_responses.insert(command.to_vec(), response.to_vec());
     }
@@ -88,7 +92,7 @@ impl TestFixture {
         } else {
             let data = self.read_responses.get(&self.last_cmd).cloned().unwrap_or_default();
             // status byte first, then the data
-            let mut full = vec![0u8];
+            let mut full = vec![self.stat1];
             full.extend_from_slice(&data);
             full
         };

--- a/lora-phy/src/lr1110/test/fixtures.rs
+++ b/lora-phy/src/lr1110/test/fixtures.rs
@@ -4,6 +4,7 @@ pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
 use embedded_hal::spi::Operation;
 use embedded_hal_async::spi::SpiDevice;
 use std::collections::{HashMap, VecDeque};
+use std::vec::Vec;
 
 /// Records every SPI transaction so the byte stream of our driver can be
 /// compared against the byte stream of Semtech's reference driver. Implements

--- a/lora-phy/src/lr1110/test/fixtures.rs
+++ b/lora-phy/src/lr1110/test/fixtures.rs
@@ -1,0 +1,240 @@
+use crate::lr1110::radio_kind_params::PaSelection;
+use crate::lr1110::{Config, Lr1110};
+use crate::mod_params::RadioError;
+use crate::mod_traits::InterfaceVariant;
+use embedded_hal::spi::{ErrorKind, Operation};
+use embedded_hal_async::delay::DelayNs;
+use embedded_hal_async::spi::SpiDevice;
+use std::collections::{HashMap, VecDeque};
+
+/// Records every SPI transaction so the byte stream of our driver can be
+/// compared against the byte stream of Semtech's reference driver. Implements
+/// both the blocking `SpiDevice` (for the reference driver, via
+/// smtc-modem-cores) and the async one (for lora-phy).
+///
+/// Unlike the sx126x, the lr11xx read protocol is identical in both drivers —
+/// a command-write transaction, then a separate read transaction clocking one
+/// discarded status byte plus the data — so transactions compare exactly with
+/// no wire canonicalization.
+///
+/// A read transaction carries no command bytes, so canned responses are keyed
+/// by the most recent command write (`prime_read`). Command-less direct reads
+/// (single-`Read` transactions) consume from a FIFO primed with
+/// `prime_direct_read`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TestFixture {
+    pub ops: Vec<Ops>,
+    read_responses: HashMap<Vec<u8>, Vec<u8>>,
+    direct_read_responses: VecDeque<Vec<u8>>,
+    last_cmd: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Ops {
+    Write(Vec<u8>),
+    /// Total bytes clocked during a read transaction (MOSI idles at NOP)
+    Read(usize),
+}
+
+impl TestFixture {
+    pub fn new() -> Self {
+        Self {
+            ops: vec![],
+            read_responses: HashMap::new(),
+            direct_read_responses: VecDeque::new(),
+            last_cmd: vec![],
+        }
+    }
+
+    /// Canned response for the read phase of the command identified by its
+    /// full command bytes. Covers the data only — the leading status byte
+    /// both drivers discard always reads 0.
+    pub fn prime_read(&mut self, command: &[u8], response: &[u8]) {
+        self.read_responses.insert(command.to_vec(), response.to_vec());
+    }
+
+    /// Canned response for the next command-less direct read (all bytes,
+    /// starting with Stat1)
+    #[allow(dead_code)]
+    pub fn prime_direct_read(&mut self, response: &[u8]) {
+        self.direct_read_responses.push_back(response.to_vec());
+    }
+
+    fn record(&mut self, operations: &mut [Operation<'_, u8>]) {
+        let mut cmd = Vec::new();
+        let mut read_ops = 0;
+        let mut read_len = 0;
+        for op in operations.iter() {
+            match op {
+                Operation::Write(buf) => cmd.extend_from_slice(buf),
+                Operation::Read(buf) => {
+                    read_ops += 1;
+                    read_len += buf.len();
+                }
+                _ => todo!(),
+            }
+        }
+        if read_ops == 0 {
+            self.last_cmd = cmd.clone();
+            self.ops.push(Ops::Write(cmd));
+            return;
+        }
+        // the lr11xx protocol never mixes writes and reads in one transaction
+        assert!(cmd.is_empty(), "unexpected mixed write+read SPI transaction");
+
+        // Two read ops = the response phase of a command (discarded status
+        // byte + data); one read op = a direct read.
+        let response = if read_ops == 1 {
+            self.direct_read_responses.pop_front().unwrap_or_default()
+        } else {
+            let data = self.read_responses.get(&self.last_cmd).cloned().unwrap_or_default();
+            // status byte first, then the data
+            let mut full = vec![0u8];
+            full.extend_from_slice(&data);
+            full
+        };
+        let mut cursor = response.iter().copied();
+        for op in operations.iter_mut() {
+            if let Operation::Read(buf) = op {
+                for b in buf.iter_mut() {
+                    *b = cursor.next().unwrap_or(0);
+                }
+            }
+        }
+        self.ops.push(Ops::Read(read_len));
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {}
+impl embedded_hal::spi::Error for Error {
+    fn kind(&self) -> ErrorKind {
+        todo!()
+    }
+}
+impl embedded_hal::spi::ErrorType for TestFixture {
+    type Error = Error;
+}
+
+impl embedded_hal::spi::SpiDevice for TestFixture {
+    fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        self.record(operations);
+        Ok(())
+    }
+}
+
+impl SpiDevice<u8> for TestFixture {
+    async fn write(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        self.last_cmd = buf.to_vec();
+        self.ops.push(Ops::Write(buf.to_vec()));
+        Ok(())
+    }
+
+    async fn read(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        let mut ops = [Operation::Read(buf)];
+        self.record(&mut ops);
+        Ok(())
+    }
+
+    async fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        self.record(operations);
+        Ok(())
+    }
+
+    async fn transfer(&mut self, _read: &mut [u8], _write: &[u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transfer_in_place(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+}
+
+/// HP-PA LR1110, no TCXO, no DC-DC, no RX boost — the plainest config so
+/// individual commands compare 1:1
+pub fn get_lr1110() -> Lr1110<TestFixture, DummyVariant> {
+    Lr1110::new(
+        TestFixture::new(),
+        DummyVariant,
+        Config {
+            pa_selection: PaSelection::Hp,
+            dio_as_rf_switch: Some(Default::default()),
+            tcxo_ctrl: None,
+            use_dcdc: false,
+            rx_boost: false,
+        },
+    )
+}
+
+/// LP-PA variant for the low-power TX path
+pub fn get_lr1110_lp() -> Lr1110<TestFixture, DummyVariant> {
+    Lr1110::new(
+        TestFixture::new(),
+        DummyVariant,
+        Config {
+            pa_selection: PaSelection::Lp,
+            dio_as_rf_switch: Some(Default::default()),
+            tcxo_ctrl: None,
+            use_dcdc: false,
+            rx_boost: false,
+        },
+    )
+}
+
+/// TCXO + DC-DC board, for the init_system and TCXO-before-TX paths
+pub fn get_lr1110_dcdc_tcxo() -> Lr1110<TestFixture, DummyVariant> {
+    Lr1110::new(
+        TestFixture::new(),
+        DummyVariant,
+        Config {
+            pa_selection: PaSelection::Hp,
+            dio_as_rf_switch: Some(Default::default()),
+            tcxo_ctrl: Some(crate::lr1110::TcxoCtrlVoltage::Ctrl1V8),
+            use_dcdc: true,
+            rx_boost: false,
+        },
+    )
+}
+
+/// RX-boosted config for the boosted do_rx path
+pub fn get_lr1110_boosted() -> Lr1110<TestFixture, DummyVariant> {
+    Lr1110::new(
+        TestFixture::new(),
+        DummyVariant,
+        Config {
+            pa_selection: PaSelection::Hp,
+            dio_as_rf_switch: Some(Default::default()),
+            tcxo_ctrl: None,
+            use_dcdc: false,
+            rx_boost: true,
+        },
+    )
+}
+
+pub struct Delayer;
+impl DelayNs for Delayer {
+    async fn delay_ns(&mut self, _ns: u32) {}
+}
+
+pub struct DummyVariant;
+
+impl InterfaceVariant for DummyVariant {
+    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn await_irq(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+}

--- a/lora-phy/src/lr1110/test/mod.rs
+++ b/lora-phy/src/lr1110/test/mod.rs
@@ -1,0 +1,824 @@
+//! Compare this driver's SPI byte stream against Semtech's reference lr11xx
+//! driver (SWL2001, via the smtc-modem-cores bindings).
+//!
+//! Both drivers implement the same lr11xx HAL shape — command-write
+//! transaction, then a separate read transaction clocking a discarded status
+//! byte plus data — so transactions are compared exactly.
+mod fixtures;
+use fixtures::{get_lr1110, get_lr1110_boosted, get_lr1110_dcdc_tcxo, get_lr1110_lp, Delayer, TestFixture};
+
+use crate::mod_params::{RadioMode, RxMode};
+use crate::mod_traits::RadioKind;
+use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
+use smtc_modem_cores::lr11xx::Context;
+use smtc_modem_cores::sys;
+
+fn reference() -> Context<TestFixture> {
+    Context::new(TestFixture::new())
+}
+
+#[tokio::test]
+async fn test_set_standby() {
+    let mut reference_radio = reference();
+    reference_radio.set_standby(sys::lr11xx_system_standby_cfg_t_LR11XX_SYSTEM_STANDBY_CFG_RC);
+
+    let mut radio = get_lr1110();
+    radio.set_standby().await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_sleep_warm_start() {
+    let mut reference_radio = reference();
+    reference_radio.set_sleep(
+        sys::lr11xx_system_sleep_cfg_t {
+            is_warm_start: true,
+            is_rtc_timeout: false,
+        },
+        0,
+    );
+
+    let mut radio = get_lr1110();
+    radio.set_sleep(true, &mut Delayer).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_sleep_cold_start() {
+    let mut reference_radio = reference();
+    reference_radio.set_sleep(
+        sys::lr11xx_system_sleep_cfg_t {
+            is_warm_start: false,
+            is_rtc_timeout: false,
+        },
+        0,
+    );
+
+    let mut radio = get_lr1110();
+    radio.set_sleep(false, &mut Delayer).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_rf_freq() {
+    for freq in [433_000_000u32, 868_100_000, 915_000_000, 2_400_000_000] {
+        let mut reference_radio = reference();
+        reference_radio.set_rf_freq(freq);
+
+        let mut radio = get_lr1110();
+        radio.set_channel(freq).await.unwrap();
+        assert_eq!(radio.intf.spi, reference_radio.inner, "freq {freq}");
+    }
+}
+
+#[tokio::test]
+async fn test_set_lora_mod_params() {
+    let mut reference_radio = reference();
+    reference_radio.set_lora_mod_params(&sys::lr11xx_radio_mod_params_lora_t {
+        sf: sys::lr11xx_radio_lora_sf_t_LR11XX_RADIO_LORA_SF10,
+        bw: sys::lr11xx_radio_lora_bw_t_LR11XX_RADIO_LORA_BW_125,
+        cr: sys::lr11xx_radio_lora_cr_t_LR11XX_RADIO_LORA_CR_4_5,
+        ldro: 0,
+    });
+
+    let mut radio = get_lr1110();
+    let params = radio
+        .create_modulation_params(SpreadingFactor::_10, Bandwidth::_125KHz, CodingRate::_4_5, 915_000_000)
+        .unwrap();
+    radio.set_modulation_params(&params).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_lora_mod_params_ldro() {
+    // SF12 @ 125 kHz forces the low-data-rate optimization on
+    let mut reference_radio = reference();
+    reference_radio.set_lora_mod_params(&sys::lr11xx_radio_mod_params_lora_t {
+        sf: sys::lr11xx_radio_lora_sf_t_LR11XX_RADIO_LORA_SF12,
+        bw: sys::lr11xx_radio_lora_bw_t_LR11XX_RADIO_LORA_BW_125,
+        cr: sys::lr11xx_radio_lora_cr_t_LR11XX_RADIO_LORA_CR_4_8,
+        ldro: 1,
+    });
+
+    let mut radio = get_lr1110();
+    let params = radio
+        .create_modulation_params(SpreadingFactor::_12, Bandwidth::_125KHz, CodingRate::_4_8, 868_100_000)
+        .unwrap();
+    radio.set_modulation_params(&params).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_lora_pkt_params() {
+    let mut reference_radio = reference();
+    reference_radio.set_lora_pkt_params(&sys::lr11xx_radio_pkt_params_lora_t {
+        preamble_len_in_symb: 8,
+        header_type: sys::lr11xx_radio_lora_pkt_len_modes_t_LR11XX_RADIO_LORA_PKT_EXPLICIT,
+        pld_len_in_bytes: 32,
+        crc: sys::lr11xx_radio_lora_crc_t_LR11XX_RADIO_LORA_CRC_ON,
+        iq: sys::lr11xx_radio_lora_iq_t_LR11XX_RADIO_LORA_IQ_STANDARD,
+    });
+
+    let mut radio = get_lr1110();
+    let mod_params = radio
+        .create_modulation_params(SpreadingFactor::_10, Bandwidth::_125KHz, CodingRate::_4_5, 915_000_000)
+        .unwrap();
+    let params = radio
+        .create_packet_params(8, false, 32, true, false, &mod_params)
+        .unwrap();
+    radio.set_packet_params(&params).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_init_lora() {
+    // With no TCXO and no DC-DC in the test config, init_lora reduces to the
+    // RF-switch DIO setup, packet type, sync word (buffer base addresses do
+    // not exist on lr11xx)
+    let mut reference_radio = reference();
+    reference_radio.set_dio_as_rf_switch(&sys::lr11xx_system_rfswitch_cfg_t {
+        enable: 0x01,
+        standby: 0x00,
+        rx: 0x01,
+        tx: 0x02,
+        tx_hp: 0x02,
+        tx_hf: 0x00,
+        gnss: 0x00,
+        wifi: 0x00,
+    });
+    reference_radio.set_pkt_type(sys::lr11xx_radio_pkt_type_t_LR11XX_RADIO_PKT_TYPE_LORA);
+    reference_radio.set_lora_sync_word(0x34);
+
+    let mut radio = get_lr1110();
+    radio.init_lora(0x34).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_tx_power_and_ramp_time_hp() {
+    // High-power PA at max output
+    let mut reference_radio = reference();
+    reference_radio.set_pa_cfg(&sys::lr11xx_radio_pa_cfg_t {
+        pa_sel: sys::lr11xx_radio_pa_selection_t_LR11XX_RADIO_PA_SEL_HP,
+        pa_reg_supply: sys::lr11xx_radio_pa_reg_supply_t_LR11XX_RADIO_PA_REG_SUPPLY_VBAT,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x07,
+    });
+    reference_radio.set_tx_params(22, sys::lr11xx_radio_ramp_time_t_LR11XX_RADIO_RAMP_208_US);
+
+    let mut radio = get_lr1110();
+    radio.set_tx_power_and_ramp_time(22, None, true).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+
+    // Above-range power clamps to 22 dBm
+    let mut radio = get_lr1110();
+    radio.set_tx_power_and_ramp_time(30, None, true).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_tx_power_and_ramp_time_lp() {
+    // Low-power PA mid range
+    let mut reference_radio = reference();
+    reference_radio.set_pa_cfg(&sys::lr11xx_radio_pa_cfg_t {
+        pa_sel: sys::lr11xx_radio_pa_selection_t_LR11XX_RADIO_PA_SEL_LP,
+        pa_reg_supply: sys::lr11xx_radio_pa_reg_supply_t_LR11XX_RADIO_PA_REG_SUPPLY_VREG,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    });
+    reference_radio.set_tx_params(10, sys::lr11xx_radio_ramp_time_t_LR11XX_RADIO_RAMP_208_US);
+
+    let mut radio = get_lr1110_lp();
+    radio.set_tx_power_and_ramp_time(10, None, true).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_do_tx() {
+    // do_tx clears all IRQs then starts TX with no timeout
+    let mut reference_radio = reference();
+    reference_radio.clear_irq_status(0xFFFFFFFF);
+    reference_radio.set_tx_with_timeout_in_rtc_step(0);
+
+    let mut radio = get_lr1110();
+    radio.do_tx().await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_do_rx_continuous() {
+    let mut reference_radio = reference();
+    reference_radio.stop_timeout_on_preamble(true);
+    reference_radio.set_lora_sync_timeout(0);
+    reference_radio.set_rx_with_timeout_in_rtc_step(0x00FFFFFF);
+
+    let mut radio = get_lr1110();
+    radio.do_rx(RxMode::Continuous).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_do_rx_single() {
+    let mut reference_radio = reference();
+    reference_radio.stop_timeout_on_preamble(true);
+    reference_radio.set_lora_sync_timeout(8);
+    reference_radio.set_rx_with_timeout_in_rtc_step(0);
+
+    let mut radio = get_lr1110();
+    radio.do_rx(RxMode::Single(8)).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_do_cad() {
+    let mut reference_radio = reference();
+    reference_radio.set_cad_params(&sys::lr11xx_radio_cad_params_t {
+        cad_symb_nb: 0x03, // 8 symbols, log2-coded per UM
+        cad_detect_peak: 0x07 + 13,
+        cad_detect_min: 10,
+        cad_exit_mode: sys::lr11xx_radio_cad_exit_mode_t_LR11XX_RADIO_CAD_EXIT_MODE_STANDBYRC,
+        cad_timeout: 0,
+    });
+    reference_radio.set_cad();
+
+    let mut radio = get_lr1110();
+    let params = radio
+        .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, 915_000_000)
+        .unwrap();
+    radio.do_cad(&params).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_tx_continuous_wave_mode() {
+    let mut reference_radio = reference();
+    reference_radio.set_tx_cw();
+
+    let mut radio = get_lr1110();
+    radio.set_tx_continuous_wave_mode().await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_calibrate_image() {
+    // Our driver uses the same fixed per-band pairs as SWL2001's
+    // ral_lr11xx.c. Note the reference's generic in-MHz helper
+    // (lr11xx_system_calibrate_image_in_mhz, floor/ceil of band edges / 4)
+    // would land on 0xE8 for 928 MHz — one step short of the 0xE9 both
+    // fixed tables use, same story as the sx126x cal_img_in_mhz.
+    let mut reference_radio = reference();
+    reference_radio.calibrate_image(0xE1, 0xE9);
+
+    let mut radio = get_lr1110();
+    radio.calibrate_image(915_000_000).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_irq_params_tx() {
+    use crate::lr1110::IrqMask;
+    let mask = IrqMask::TxDone.value() | IrqMask::Timeout.value();
+    // Our command writes the mask twice: the reference documents the two
+    // 32-bit fields as the DIO9 and DIO11 enable masks (not "global +
+    // DIO1"), so this equals the reference with the same mask on both
+    let mut reference_radio = reference();
+    reference_radio.set_dio_irq_params(mask, mask);
+
+    let mut radio = get_lr1110();
+    radio.set_irq_params(Some(RadioMode::Transmit)).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_clear_irq_status() {
+    let mut reference_radio = reference();
+    reference_radio.clear_irq_status(0xFFFFFFFF);
+
+    let mut radio = get_lr1110();
+    radio.clear_irq_status().await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_get_version() {
+    let mut reference_radio = reference();
+    reference_radio
+        .inner
+        .prime_read(&[0x01, 0x01], &[0x22, 0x01, 0x03, 0x08]);
+    let (_, c_version) = reference_radio.get_version();
+
+    let mut radio = get_lr1110();
+    radio.intf.spi.prime_read(&[0x01, 0x01], &[0x22, 0x01, 0x03, 0x08]);
+    let version = radio.get_version().await.unwrap();
+
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+    assert_eq!(version.hw, c_version.hw);
+    assert_eq!(version.fw, c_version.fw);
+}
+
+#[tokio::test]
+async fn test_get_temp_vbat_errors() {
+    let mut reference_radio = reference();
+    reference_radio.inner.prime_read(&[0x01, 0x1A], &[0x08, 0x50]);
+    let (_, c_temp) = reference_radio.get_temp();
+    reference_radio.inner.prime_read(&[0x01, 0x19], &[0x83]);
+    let (_, c_vbat) = reference_radio.get_vbat();
+    reference_radio.inner.prime_read(&[0x01, 0x0D], &[0x00, 0x10]);
+    let (_, c_errors) = reference_radio.get_errors();
+
+    let mut radio = get_lr1110();
+    radio.intf.spi.prime_read(&[0x01, 0x1A], &[0x08, 0x50]);
+    let temp = radio.get_temp().await.unwrap();
+    radio.intf.spi.prime_read(&[0x01, 0x19], &[0x83]);
+    let vbat = radio.get_vbat().await.unwrap();
+    radio.intf.spi.prime_read(&[0x01, 0x0D], &[0x00, 0x10]);
+    let errors = radio.get_errors().await.unwrap();
+
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+    assert_eq!(temp, c_temp);
+    assert_eq!(vbat, c_vbat);
+    assert_eq!(errors, c_errors);
+}
+
+#[tokio::test]
+async fn test_get_random_number() {
+    let mut reference_radio = reference();
+    reference_radio
+        .inner
+        .prime_read(&[0x01, 0x20], &[0xDE, 0xAD, 0xBE, 0xEF]);
+    let (_, c_random) = reference_radio.get_random_number();
+
+    let mut radio = get_lr1110();
+    radio.intf.spi.prime_read(&[0x01, 0x20], &[0xDE, 0xAD, 0xBE, 0xEF]);
+    let random = radio.get_random_number().await.unwrap();
+
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+    // No value parity here: the reference memcpys the response into a u32,
+    // so its value is host-endian (0xEFBEADDE on little-endian) while we
+    // parse big-endian like every other multi-byte field. Both are equally
+    // random; only the wire bytes are comparable.
+    assert_eq!(random, u32::from_be_bytes([0xDE, 0xAD, 0xBE, 0xEF]));
+    assert_eq!(c_random, u32::from_ne_bytes([0xDE, 0xAD, 0xBE, 0xEF]));
+}
+
+#[tokio::test]
+async fn test_read_uid_and_join_eui() {
+    let uid = [1, 2, 3, 4, 5, 6, 7, 8];
+    let mut reference_radio = reference();
+    reference_radio.inner.prime_read(&[0x01, 0x25], &uid);
+    let (_, c_uid) = reference_radio.read_uid();
+    reference_radio.inner.prime_read(&[0x01, 0x26], &uid);
+    let (_, c_eui) = reference_radio.read_join_eui();
+
+    let mut radio = get_lr1110();
+    radio.intf.spi.prime_read(&[0x01, 0x25], &uid);
+    let our_uid = radio.read_uid().await.unwrap();
+    radio.intf.spi.prime_read(&[0x01, 0x26], &uid);
+    let our_eui = radio.read_join_eui().await.unwrap();
+
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+    assert_eq!(our_uid, c_uid);
+    assert_eq!(our_eui, c_eui);
+}
+
+#[tokio::test]
+async fn test_get_status_direct_read() {
+    // Both drivers read stat1 + stat2 + 4 irq bytes in one command-less
+    // direct read
+    let wire = [0x02, 0x44, 0x00, 0x00, 0x00, 0x14];
+    let mut reference_radio = reference();
+    reference_radio.inner.prime_direct_read(&wire);
+    let (_, _stat1, _stat2, c_irq) = reference_radio.get_status();
+
+    let mut radio = get_lr1110();
+    radio.intf.spi.prime_direct_read(&wire);
+    let irq_flags = radio.get_irq_flags().await.unwrap();
+
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+    assert_eq!(irq_flags, c_irq);
+}
+
+#[tokio::test]
+async fn test_get_rx_packet_status() {
+    let mut reference_radio = reference();
+    reference_radio.inner.prime_read(&[0x02, 0x04], &[80, 20, 82]);
+    let (_, c_status) = reference_radio.get_lora_pkt_status();
+
+    let mut radio = get_lr1110();
+    radio.intf.spi.prime_read(&[0x02, 0x04], &[80, 20, 82]);
+    let status = radio.get_rx_packet_status().await.unwrap();
+
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+    assert_eq!(status.rssi, c_status.rssi_pkt_in_dbm as i16);
+    assert_eq!(status.snr, c_status.snr_pkt_in_db as i16);
+}
+
+#[tokio::test]
+async fn test_get_rssi() {
+    let mut reference_radio = reference();
+    reference_radio.inner.prime_read(&[0x02, 0x05], &[100]);
+    let (_, c_rssi) = reference_radio.get_rssi_inst();
+
+    let mut radio = get_lr1110();
+    radio.intf.spi.prime_read(&[0x02, 0x05], &[100]);
+    let rssi = radio.get_rssi().await.unwrap();
+
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+    assert_eq!(rssi, c_rssi as i16);
+}
+
+#[tokio::test]
+async fn test_set_payload() {
+    let payload = [0xCA, 0xFE, 0xBA, 0xBE, 0x42];
+    let mut reference_radio = reference();
+    reference_radio.regmem_write_buffer8(&payload);
+
+    let mut radio = get_lr1110();
+    radio.set_payload(&payload).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_get_rx_payload() {
+    let data = [0xCA, 0xFE, 0xBA, 0xBE, 0x42];
+    let mut reference_radio = reference();
+    reference_radio.inner.prime_read(&[0x02, 0x03], &[5, 0]);
+    let (_, c_buf_status) = reference_radio.get_rx_buffer_status();
+    reference_radio.inner.prime_read(&[0x01, 0x0A, 0, 5], &data);
+    let mut c_payload = [0u8; 5];
+    reference_radio.regmem_read_buffer8(c_buf_status.buffer_start_pointer, &mut c_payload);
+
+    let mut radio = get_lr1110();
+    radio.intf.spi.prime_read(&[0x02, 0x03], &[5, 0]);
+    radio.intf.spi.prime_read(&[0x01, 0x0A, 0, 5], &data);
+    let mut rx_buffer = [0u8; 16];
+    let pkt_params = {
+        let mod_params = radio
+            .create_modulation_params(SpreadingFactor::_10, Bandwidth::_125KHz, CodingRate::_4_5, 915_000_000)
+            .unwrap();
+        radio
+            .create_packet_params(8, false, 16, true, false, &mod_params)
+            .unwrap()
+    };
+    let len = radio.get_rx_payload(&pkt_params, &mut rx_buffer).await.unwrap();
+
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+    assert_eq!(len, 5);
+    assert_eq!(&rx_buffer[..5], &c_payload);
+    assert_eq!(&rx_buffer[..5], &data);
+}
+
+#[tokio::test]
+async fn test_high_acp_workaround() {
+    let mut reference_radio = reference();
+    reference_radio.apply_high_acp_workaround();
+
+    let mut radio = get_lr1110();
+    radio.apply_high_acp_workaround().await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_init_system_dcdc_tcxo() {
+    // BRD_TCXO_WAKEUP_TIME (10 ms) in RTC steps
+    let tcxo_timeout = 10 * 32768 / 1000;
+    let mut reference_radio = reference();
+    reference_radio.set_reg_mode(sys::lr11xx_system_reg_mode_t_LR11XX_SYSTEM_REG_MODE_DCDC);
+    reference_radio.clear_errors();
+    reference_radio.set_tcxo_mode(
+        sys::lr11xx_system_tcxo_supply_voltage_t_LR11XX_SYSTEM_TCXO_CTRL_1_8V,
+        tcxo_timeout,
+    );
+    reference_radio.calibrate(0b0111_1111);
+
+    let mut radio = get_lr1110_dcdc_tcxo();
+    radio.init_system().await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_do_tx_tcxo() {
+    // With a TCXO the driver re-arms it with a longer timeout before TX
+    let mut reference_radio = reference();
+    reference_radio.clear_irq_status(0xFFFFFFFF);
+    reference_radio.set_tcxo_mode(
+        sys::lr11xx_system_tcxo_supply_voltage_t_LR11XX_SYSTEM_TCXO_CTRL_1_8V,
+        0x000CD0,
+    );
+    reference_radio.set_tx_with_timeout_in_rtc_step(0);
+
+    let mut radio = get_lr1110_dcdc_tcxo();
+    radio.do_tx().await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_do_rx_boosted() {
+    let mut reference_radio = reference();
+    reference_radio.stop_timeout_on_preamble(true);
+    reference_radio.set_lora_sync_timeout(0);
+    reference_radio.cfg_rx_boosted(true);
+    reference_radio.set_rx_with_timeout_in_rtc_step(0x00FFFFFF);
+
+    let mut radio = get_lr1110_boosted();
+    radio.do_rx(RxMode::Continuous).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_do_rx_duty_cycle() {
+    use crate::mod_params::DutyCycleParams;
+    let mut reference_radio = reference();
+    reference_radio.stop_timeout_on_preamble(true);
+    reference_radio.set_lora_sync_timeout(0);
+    // ms-based reference entry point; converts with the same *32768/1000.
+    // Neither driver applies the high-ACP workaround on the duty-cycle path.
+    reference_radio.set_rx_duty_cycle(
+        100,
+        900,
+        sys::lr11xx_radio_rx_duty_cycle_mode_t_LR11XX_RADIO_RX_DUTY_CYCLE_MODE_RX,
+    );
+
+    let mut radio = get_lr1110();
+    radio
+        .do_rx(RxMode::DutyCycle(DutyCycleParams {
+            rx_time: 100,
+            sleep_time: 900,
+        }))
+        .await
+        .unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_auto_tx_rx() {
+    use crate::lr1110::radio_kind_params::IntermediaryMode;
+    let mut reference_radio = reference();
+    reference_radio.auto_tx_rx(
+        1000,
+        sys::lr11xx_radio_intermediary_mode_t_LR11XX_RADIO_MODE_STANDBY_RC,
+        2000,
+    );
+
+    let mut radio = get_lr1110();
+    radio
+        .set_auto_tx_rx(1000, IntermediaryMode::StandbyRc, 2000)
+        .await
+        .unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_rx_tx_fallback_mode() {
+    use crate::lr1110::radio_kind_params::FallbackMode;
+    let mut reference_radio = reference();
+    reference_radio.set_rx_tx_fallback_mode(sys::lr11xx_radio_fallback_modes_t_LR11XX_RADIO_FALLBACK_STDBY_XOSC);
+
+    let mut radio = get_lr1110();
+    radio.set_rx_tx_fallback_mode(FallbackMode::StandbyXosc).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_standby_xosc() {
+    let mut reference_radio = reference();
+    reference_radio.set_standby(sys::lr11xx_system_standby_cfg_t_LR11XX_SYSTEM_STANDBY_CFG_XOSC);
+
+    let mut radio = get_lr1110();
+    radio.set_standby_mode(true).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_gfsk_mod_params() {
+    use crate::lr1110::{GfskBandwidth, GfskModulationParams, GfskPulseShape};
+    // The LR11xx takes bitrate in raw bps and deviation in raw Hz (no
+    // SX126x-style chip-format conversion)
+    let mut reference_radio = reference();
+    reference_radio.set_gfsk_mod_params(&sys::lr11xx_radio_mod_params_gfsk_t {
+        br_in_bps: 50_000,
+        pulse_shape: sys::lr11xx_radio_gfsk_pulse_shape_t_LR11XX_RADIO_GFSK_PULSE_SHAPE_BT_1,
+        bw_dsb_param: sys::lr11xx_radio_gfsk_bw_t_LR11XX_RADIO_GFSK_BW_117300,
+        fdev_in_hz: 25_000,
+    });
+
+    let mut radio = get_lr1110();
+    radio
+        .set_gfsk_mod_params(&GfskModulationParams {
+            bitrate_bps: 50_000,
+            pulse_shape: GfskPulseShape::Bt1,
+            bandwidth: GfskBandwidth::Bw117300,
+            freq_dev_hz: 25_000,
+        })
+        .await
+        .unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_gfsk_pkt_params() {
+    use crate::lr1110::{
+        GfskAddressFiltering, GfskCrcType, GfskDcFree, GfskHeaderType, GfskPacketParams, GfskPreambleDetector,
+    };
+    let mut reference_radio = reference();
+    reference_radio.set_gfsk_pkt_params(&sys::lr11xx_radio_pkt_params_gfsk_t {
+        preamble_len_in_bits: 40,
+        preamble_detector: sys::lr11xx_radio_gfsk_preamble_detector_t_LR11XX_RADIO_GFSK_PREAMBLE_DETECTOR_MIN_16BITS,
+        sync_word_len_in_bits: 24,
+        address_filtering: sys::lr11xx_radio_gfsk_address_filtering_t_LR11XX_RADIO_GFSK_ADDRESS_FILTERING_DISABLE,
+        header_type: sys::lr11xx_radio_gfsk_pkt_len_modes_t_LR11XX_RADIO_GFSK_PKT_VAR_LEN,
+        pld_len_in_bytes: 64,
+        crc_type: sys::lr11xx_radio_gfsk_crc_type_t_LR11XX_RADIO_GFSK_CRC_2_BYTES,
+        dc_free: sys::lr11xx_radio_gfsk_dc_free_t_LR11XX_RADIO_GFSK_DC_FREE_WHITENING,
+    });
+
+    let mut radio = get_lr1110();
+    radio
+        .set_gfsk_pkt_params(&GfskPacketParams {
+            preamble_length: 40,
+            preamble_detector: GfskPreambleDetector::Bits16,
+            sync_word_length_bits: 24,
+            address_filtering: GfskAddressFiltering::Disabled,
+            header_type: GfskHeaderType::Variable,
+            payload_length: 64,
+            crc_type: GfskCrcType::Crc2Bytes,
+            dc_free: GfskDcFree::Whitening,
+        })
+        .await
+        .unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_gfsk_sync_word() {
+    let sync_word = [0x97, 0x23, 0x52, 0x25, 0x56, 0x53, 0x65, 0x64];
+    let mut reference_radio = reference();
+    reference_radio.set_gfsk_sync_word(&sync_word);
+
+    let mut radio = get_lr1110();
+    radio.set_gfsk_sync_word(&sync_word).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+
+    // A shorter sync word still puts 8 (zero-padded) bytes on the wire
+    let mut reference_radio = reference();
+    reference_radio.set_gfsk_sync_word(&[0xC1, 0x94, 0xC1, 0, 0, 0, 0, 0]);
+
+    let mut radio = get_lr1110();
+    radio.set_gfsk_sync_word(&[0xC1, 0x94, 0xC1]).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_gfsk_crc_whitening_address() {
+    let mut reference_radio = reference();
+    reference_radio.set_gfsk_crc_params(0x1D0F_1D0F, 0x1021_1021);
+    reference_radio.set_gfsk_whitening_seed(0x01FF);
+    reference_radio.set_pkt_address(0x42, 0xFF);
+
+    let mut radio = get_lr1110();
+    radio.set_gfsk_crc_params(0x1D0F_1D0F, 0x1021_1021).await.unwrap();
+    radio.set_gfsk_whitening_params(0x01FF).await.unwrap();
+    radio.set_gfsk_pkt_address(0x42, 0xFF).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_get_gfsk_packet_status() {
+    // Response layout: rssi_sync, rssi_avg, rx_len, status bits
+    let mut reference_radio = reference();
+    reference_radio.inner.prime_read(&[0x02, 0x04], &[80, 84, 17, 0x02]);
+    let (_, c_status) = reference_radio.get_gfsk_pkt_status();
+
+    let mut radio = get_lr1110();
+    radio.intf.spi.prime_read(&[0x02, 0x04], &[80, 84, 17, 0x02]);
+    let (rx_len, rssi_sync, rssi_avg) = radio.get_gfsk_packet_status().await.unwrap();
+
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+    assert_eq!(rx_len, c_status.rx_len_in_bytes);
+    assert_eq!(rssi_sync, c_status.rssi_sync_in_dbm as i16);
+    assert_eq!(rssi_avg, c_status.rssi_avg_in_dbm as i16);
+}
+
+#[tokio::test]
+async fn test_stats() {
+    let lora_stats = [0x00, 0x0A, 0x00, 0x02, 0x00, 0x01, 0x00, 0x03];
+    let mut reference_radio = reference();
+    reference_radio.inner.prime_read(&[0x02, 0x01], &lora_stats);
+    let (_, c_stats) = reference_radio.get_lora_stats();
+    reference_radio.reset_stats();
+
+    let mut radio = get_lr1110();
+    radio.intf.spi.prime_read(&[0x02, 0x01], &lora_stats);
+    let stats = radio.get_lora_stats().await.unwrap();
+    radio.reset_stats().await.unwrap();
+
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+    assert_eq!(stats.nb_pkt_received, c_stats.nb_pkt_received);
+    assert_eq!(stats.nb_pkt_crc_error, c_stats.nb_pkt_crc_error);
+    assert_eq!(stats.nb_pkt_header_error, c_stats.nb_pkt_header_error);
+    assert_eq!(stats.nb_pkt_false_sync, c_stats.nb_pkt_falsesync);
+}
+
+#[tokio::test]
+async fn test_lr_fhss_init() {
+    let mut reference_radio = reference();
+    reference_radio.lr_fhss_init();
+
+    let mut radio = get_lr1110();
+    radio.lr_fhss_init().await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_lr_fhss_build_frame() {
+    use crate::lr1110::{
+        LrFhssBandwidth, LrFhssCodingRate, LrFhssGrid, LrFhssModulationType, LrFhssParams, LrFhssV1Params,
+        LR_FHSS_DEFAULT_SYNC_WORD,
+    };
+    let payload = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+
+    let mut reference_radio = reference();
+    reference_radio.lr_fhss_build_frame(
+        &sys::lr11xx_lr_fhss_params_t {
+            lr_fhss_params: sys::lr_fhss_v1_params_t {
+                sync_word: LR_FHSS_DEFAULT_SYNC_WORD.as_ptr(),
+                modulation_type: sys::lr_fhss_v1_modulation_type_e_LR_FHSS_V1_MODULATION_TYPE_GMSK_488,
+                cr: sys::lr_fhss_v1_cr_e_LR_FHSS_V1_CR_2_3,
+                grid: sys::lr_fhss_v1_grid_e_LR_FHSS_V1_GRID_25391_HZ,
+                bw: sys::lr_fhss_v1_bw_e_LR_FHSS_V1_BW_136719_HZ,
+                enable_hopping: true,
+                header_count: 3,
+            },
+            device_offset: 0,
+        },
+        42,
+        &payload,
+    );
+
+    let mut radio = get_lr1110();
+    radio
+        .lr_fhss_build_frame(
+            &LrFhssParams {
+                lr_fhss_params: LrFhssV1Params {
+                    sync_word: LR_FHSS_DEFAULT_SYNC_WORD,
+                    modulation_type: LrFhssModulationType::Gmsk488,
+                    coding_rate: LrFhssCodingRate::Cr2_3,
+                    grid: LrFhssGrid::Grid25391Hz,
+                    enable_hopping: true,
+                    bandwidth: LrFhssBandwidth::Bw136719Hz,
+                    header_count: 3,
+                },
+                device_offset: 0,
+            },
+            42,
+            &payload,
+        )
+        .await
+        .unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_regmem() {
+    let words = [0xDEAD_BEEF_u32, 0xCAFE_BABE];
+    let mem = [0x11, 0x22, 0x33, 0x44];
+
+    let mut reference_radio = reference();
+    reference_radio.regmem_write_regmem32(0x00F3_0054, &words);
+    reference_radio.inner.prime_read(
+        &[0x01, 0x06, 0x00, 0xF3, 0x00, 0x54, 2],
+        &[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE],
+    );
+    let mut c_words = [0u32; 2];
+    reference_radio.regmem_read_regmem32(0x00F3_0054, &mut c_words);
+    reference_radio.regmem_write_mem8(0x0080_0000, &mem);
+    reference_radio
+        .inner
+        .prime_read(&[0x01, 0x08, 0x00, 0x80, 0x00, 0x00, 4], &mem);
+    let mut c_mem = [0u8; 4];
+    reference_radio.regmem_read_mem8(0x0080_0000, &mut c_mem);
+    reference_radio.regmem_clear_rxbuffer();
+
+    let mut radio = get_lr1110();
+    radio.regmem_write_regmem32(0x00F3_0054, &words).await.unwrap();
+    radio.intf.spi.prime_read(
+        &[0x01, 0x06, 0x00, 0xF3, 0x00, 0x54, 2],
+        &[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE],
+    );
+    let mut our_words = [0u32; 2];
+    radio.regmem_read_regmem32(0x00F3_0054, &mut our_words).await.unwrap();
+    radio.regmem_write_mem8(0x0080_0000, &mem).await.unwrap();
+    radio
+        .intf
+        .spi
+        .prime_read(&[0x01, 0x08, 0x00, 0x80, 0x00, 0x00, 4], &mem);
+    let mut our_mem = [0u8; 4];
+    radio.regmem_read_mem8(0x0080_0000, &mut our_mem).await.unwrap();
+    radio.regmem_clear_rxbuffer().await.unwrap();
+
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+    assert_eq!(our_words, c_words);
+    assert_eq!(our_words, words);
+    assert_eq!(our_mem, c_mem);
+    assert_eq!(our_mem, mem);
+}

--- a/lora-phy/src/lr1110/test/mod.rs
+++ b/lora-phy/src/lr1110/test/mod.rs
@@ -5,7 +5,9 @@
 //! transaction, then a separate read transaction clocking a discarded status
 //! byte plus data — so transactions are compared exactly.
 mod fixtures;
-use fixtures::{get_lr1110, get_lr1110_boosted, get_lr1110_dcdc_tcxo, get_lr1110_lp, Delayer, TestFixture};
+use fixtures::{
+    get_lr1110, get_lr1110_boosted, get_lr1110_dcdc_tcxo, get_lr1110_hf, get_lr1110_lp, Delayer, TestFixture,
+};
 
 use crate::mod_params::{RadioMode, RxMode};
 use crate::mod_traits::RadioKind;
@@ -190,6 +192,34 @@ async fn test_set_tx_power_and_ramp_time_lp() {
 
     let mut radio = get_lr1110_lp();
     radio.set_tx_power_and_ramp_time(10, None, true).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
+async fn test_set_tx_power_and_ramp_time_hf() {
+    // High-frequency (2.4 GHz) PA at max output. The vendor BSP always supplies
+    // the HF PA from VREG (it tops out at +13 dBm, below where VBAT is needed).
+    //
+    // The pa_duty_cycle / pa_hp_sel / power values below are the driver's own
+    // static mapping, not the vendor EVK board calibration table
+    // (LR11XX_PA_HF_CFG_TABLE), which uses different values at the same power
+    // (e.g. duty 0x00 at 13 dBm). The board table is kept as-is for now.
+    let mut reference_radio = reference();
+    reference_radio.set_pa_cfg(&sys::lr11xx_radio_pa_cfg_t {
+        pa_sel: sys::lr11xx_radio_pa_selection_t_LR11XX_RADIO_PA_SEL_HF,
+        pa_reg_supply: sys::lr11xx_radio_pa_reg_supply_t_LR11XX_RADIO_PA_REG_SUPPLY_VREG,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x00,
+    });
+    reference_radio.set_tx_params(13, sys::lr11xx_radio_ramp_time_t_LR11XX_RADIO_RAMP_208_US);
+
+    let mut radio = get_lr1110_hf();
+    radio.set_tx_power_and_ramp_time(13, None, true).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+
+    // Above-range power clamps to 13 dBm
+    let mut radio = get_lr1110_hf();
+    radio.set_tx_power_and_ramp_time(20, None, true).await.unwrap();
     assert_eq!(radio.intf.spi, reference_radio.inner);
 }
 

--- a/lora-phy/src/lr1110/test/mod.rs
+++ b/lora-phy/src/lr1110/test/mod.rs
@@ -179,20 +179,70 @@ async fn test_set_tx_power_and_ramp_time_hp() {
 }
 
 #[tokio::test]
+async fn test_set_tx_power_and_ramp_time_hp_low_power() {
+    // At or below 8 dBm the HP PA runs from VREG for efficiency (vendor BSP
+    // LR11XX_PWR_VREG_VBAT_SWITCH = 8). A 5 dBm request maps, per the vendor HP
+    // table, to configured power 15, duty 0x04, hp_sel 0x01.
+    let mut reference_radio = reference();
+    reference_radio.set_pa_cfg(&sys::lr11xx_radio_pa_cfg_t {
+        pa_sel: sys::lr11xx_radio_pa_selection_t_LR11XX_RADIO_PA_SEL_HP,
+        pa_reg_supply: sys::lr11xx_radio_pa_reg_supply_t_LR11XX_RADIO_PA_REG_SUPPLY_VREG,
+        pa_duty_cycle: 0x04,
+        pa_hp_sel: 0x01,
+    });
+    reference_radio.set_tx_params(15, sys::lr11xx_radio_ramp_time_t_LR11XX_RADIO_RAMP_208_US);
+
+    let mut radio = get_lr1110();
+    radio.set_tx_power_and_ramp_time(5, None, true).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
 async fn test_set_tx_power_and_ramp_time_lp() {
-    // Low-power PA mid range
+    // Low-power PA mid range. The vendor LP table (LR11XX_PA_LP_LF_CFG_TABLE)
+    // remaps a 10 dBm request to a configured power of 13 with duty 0x01, VREG.
     let mut reference_radio = reference();
     reference_radio.set_pa_cfg(&sys::lr11xx_radio_pa_cfg_t {
         pa_sel: sys::lr11xx_radio_pa_selection_t_LR11XX_RADIO_PA_SEL_LP,
         pa_reg_supply: sys::lr11xx_radio_pa_reg_supply_t_LR11XX_RADIO_PA_REG_SUPPLY_VREG,
-        pa_duty_cycle: 0x04,
+        pa_duty_cycle: 0x01,
         pa_hp_sel: 0x00,
     });
-    reference_radio.set_tx_params(10, sys::lr11xx_radio_ramp_time_t_LR11XX_RADIO_RAMP_208_US);
+    reference_radio.set_tx_params(13, sys::lr11xx_radio_ramp_time_t_LR11XX_RADIO_RAMP_208_US);
 
     let mut radio = get_lr1110_lp();
     radio.set_tx_power_and_ramp_time(10, None, true).await.unwrap();
     assert_eq!(radio.intf.spi, reference_radio.inner);
+
+    // Max output (+15 dBm) per the LR1110 v2.1 datasheet: configured power 14,
+    // duty 0x07, VREG.
+    let mut reference_radio = reference();
+    reference_radio.set_pa_cfg(&sys::lr11xx_radio_pa_cfg_t {
+        pa_sel: sys::lr11xx_radio_pa_selection_t_LR11XX_RADIO_PA_SEL_LP,
+        pa_reg_supply: sys::lr11xx_radio_pa_reg_supply_t_LR11XX_RADIO_PA_REG_SUPPLY_VREG,
+        pa_duty_cycle: 0x07,
+        pa_hp_sel: 0x00,
+    });
+    reference_radio.set_tx_params(14, sys::lr11xx_radio_ramp_time_t_LR11XX_RADIO_RAMP_208_US);
+
+    let mut radio = get_lr1110_lp();
+    radio.set_tx_power_and_ramp_time(15, None, true).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+
+    // At +15 dBm the LP entry's duty (0x07) exceeds 0x04, which is not allowed
+    // below 400 MHz: with a sub-400 MHz modulation the driver rejects it.
+    let mut radio = get_lr1110_lp();
+    let mod_params = radio
+        .create_modulation_params(SpreadingFactor::_10, Bandwidth::_125KHz, CodingRate::_4_5, 169_000_000)
+        .unwrap();
+    let err = radio
+        .set_tx_power_and_ramp_time(15, Some(&mod_params), true)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        crate::mod_params::RadioError::InvalidOutputPowerForFrequency
+    ));
 }
 
 #[tokio::test]
@@ -200,15 +250,13 @@ async fn test_set_tx_power_and_ramp_time_hf() {
     // High-frequency (2.4 GHz) PA at max output. The vendor BSP always supplies
     // the HF PA from VREG (it tops out at +13 dBm, below where VBAT is needed).
     //
-    // The pa_duty_cycle / pa_hp_sel / power values below are the driver's own
-    // static mapping, not the vendor EVK board calibration table
-    // (LR11XX_PA_HF_CFG_TABLE), which uses different values at the same power
-    // (e.g. duty 0x00 at 13 dBm). The board table is kept as-is for now.
+    // Values come from the vendor HF table (LR11XX_PA_HF_CFG_TABLE): +13 dBm
+    // maps to configured power 13, duty 0x00, hp_sel 0x00.
     let mut reference_radio = reference();
     reference_radio.set_pa_cfg(&sys::lr11xx_radio_pa_cfg_t {
         pa_sel: sys::lr11xx_radio_pa_selection_t_LR11XX_RADIO_PA_SEL_HF,
         pa_reg_supply: sys::lr11xx_radio_pa_reg_supply_t_LR11XX_RADIO_PA_REG_SUPPLY_VREG,
-        pa_duty_cycle: 0x04,
+        pa_duty_cycle: 0x00,
         pa_hp_sel: 0x00,
     });
     reference_radio.set_tx_params(13, sys::lr11xx_radio_ramp_time_t_LR11XX_RADIO_RAMP_208_US);

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -1,5 +1,8 @@
 mod radio_kind_params;
 
+#[cfg(test)]
+mod test;
+
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::*;
 pub use radio_kind_params::TcxoCtrlVoltage;
@@ -172,6 +175,11 @@ where
 
         (steps_int << SX126X_PLL_STEP_SHIFT_AMOUNT)
             + (((steps_frac << SX126X_PLL_STEP_SHIFT_AMOUNT) + (SX126X_PLL_STEP_SCALED >> 1)) / SX126X_PLL_STEP_SCALED)
+    }
+
+    #[cfg(test)]
+    fn take_spi(self) -> SPI {
+        self.intf.spi
     }
 
     // SX162x WriteRegister wrapper for single u8 value writes

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -479,8 +479,13 @@ where
                     }
                     HIGH_POWER_MIN..=14 => {
                         self.set_pa_config(0x02, 0x02, DeviceSel::HighPowerPA).await?;
-                        // table indicates 14 dBm => txp = 22, therefore we should add 8 to this range
-                        // this however seems to be wrong when looking at the reference driver
+                        // The vendors disagree on this row. Datasheet Table
+                        // 13-21 (through Rev 2.2) says SetTxParams +22 with
+                        // this PA config; ST's STM32CubeWL driver — an SX126x
+                        // die inside the STM32WL — commands +14 with the same
+                        // config, while agreeing with the datasheet on every
+                        // other row. We follow ST. Settling which is right
+                        // for a discrete SX1262 needs a power measurement.
                         // https://github.com/STMicroelectronics/STM32CubeWL/blob/139e8d28bcec6af78dec8b52a9b9f9057868cc2e/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L675
                         tx_params_power = txp as u8;
                     }

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -182,6 +182,11 @@ where
         self.intf.spi
     }
 
+    #[cfg(test)]
+    fn spi_mut(&mut self) -> &mut SPI {
+        &mut self.intf.spi
+    }
+
     // SX162x WriteRegister wrapper for single u8 value writes
     async fn reg_w_8(&mut self, reg: Register, value: u8) -> Result<(), RadioError> {
         self.intf

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -479,15 +479,20 @@ where
                     }
                     HIGH_POWER_MIN..=14 => {
                         self.set_pa_config(0x02, 0x02, DeviceSel::HighPowerPA).await?;
-                        // The vendors disagree on this row. Datasheet Table
-                        // 13-21 (through Rev 2.2) says SetTxParams +22 with
-                        // this PA config; ST's STM32CubeWL driver — an SX126x
-                        // die inside the STM32WL — commands +14 with the same
-                        // config, while agreeing with the datasheet on every
-                        // other row. We follow ST. Settling which is right
-                        // for a discrete SX1262 needs a power measurement.
+                        // The only row where ST's table for the STM32WL (an
+                        // SX126x die integrated into ST's part) differs from
+                        // datasheet Table 13-21: same PA config, but ST
+                        // commands the target dBm directly where the
+                        // datasheet interpolates from its +22 setpoint
+                        // (table row: 14 dBm => SetTxParams +22, so add 8).
+                        // Each part takes the table it was characterized
+                        // with.
                         // https://github.com/STMicroelectronics/STM32CubeWL/blob/139e8d28bcec6af78dec8b52a9b9f9057868cc2e/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L675
-                        tx_params_power = txp as u8;
+                        tx_params_power = if self.config.chip.use_st_power_table() {
+                            txp as u8
+                        } else {
+                            (txp + 8) as u8
+                        };
                     }
                     _ => {
                         unreachable!("Invalid output power value for high power PA!")

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -407,99 +407,39 @@ where
         mdltn_params: Option<&ModulationParams>,
         is_tx_prep: bool,
     ) -> Result<(), RadioError> {
-        let tx_params_power;
         let ramp_time = match is_tx_prep {
             true => RampTime::Ramp40Us,   // for instance, prior to TX or CAD
             false => RampTime::Ramp200Us, // for instance, on initialization
         };
 
+        // PA-specific preconditions
         match self.config.chip.get_device_sel() {
             DeviceSel::LowPowerPA => {
-                const LOW_POWER_MIN: i32 = -17;
-                const LOW_POWER_MAX: i32 = 15;
-                // Clamp power between [-17, 15] dBm
-                let txp = output_power.clamp(LOW_POWER_MIN, LOW_POWER_MAX);
-
-                if txp == 15 {
+                // For SX1261 the +15 dBm row is only valid above 400 MHz
+                // (below, paDutyCycle must not exceed 0x04)
+                if output_power >= 15 {
                     if let Some(m_p) = mdltn_params {
                         if m_p.frequency_in_hz < 400_000_000 {
                             return Err(RadioError::InvalidOutputPowerForFrequency);
                         }
                     }
                 }
-
-                // For SX1261:
-                // if f < 400 MHz, paDutyCycle should not be higher than 0x04,
-                // if f > 400 Mhz, paDutyCycle should not be higher than 0x07.
-                // From Table 13-21: PA Operating Modes with Optimal Settings
-                match txp {
-                    LOW_POWER_MAX => {
-                        self.set_pa_config(0x06, 0x00, DeviceSel::LowPowerPA).await?;
-                        tx_params_power = 14;
-                    }
-                    11..=14 => {
-                        self.set_pa_config(0x04, 0x00, DeviceSel::LowPowerPA).await?;
-                        tx_params_power = txp as u8;
-                    }
-                    // 10 and less
-                    LOW_POWER_MIN..=10 => {
-                        self.set_pa_config(0x01, 0x00, DeviceSel::LowPowerPA).await?;
-                        // table indicates 10 dBm => txp = 13, therefore we add 3 to values below 10
-                        tx_params_power = txp as u8 + 3;
-                    }
-                    _ => unreachable!("Invalid output power value for low power PA!"),
-                }
             }
             DeviceSel::HighPowerPA => {
-                const HIGH_POWER_MIN: i32 = -9;
-                const HIGH_POWER_MAX: i32 = 22;
-                // Clamp power between [-9, 22] dBm
-                let txp = output_power.clamp(HIGH_POWER_MIN, HIGH_POWER_MAX);
-
                 // Provide better resistance of the SX1262 Tx to antenna mismatch
                 // Bits 4-1 must be set to `1111`
                 let tx_clamp_val = self.reg_r_8(Register::TxClampCfg).await?;
                 self.reg_w_8(Register::TxClampCfg, tx_clamp_val | 0b11110).await?;
-
-                // From Table 13-21: PA Operating Modes with Optimal Settings
-                match txp {
-                    21..=HIGH_POWER_MAX => {
-                        self.set_pa_config(0x04, 0x07, DeviceSel::HighPowerPA).await?;
-                        tx_params_power = 22;
-                    }
-                    18..=20 => {
-                        self.set_pa_config(0x03, 0x05, DeviceSel::HighPowerPA).await?;
-                        // table indicates 20 dBm => txp = 22, therefore we add 2 to this range
-                        tx_params_power = txp as u8 + 2;
-                    }
-                    15..=17 => {
-                        self.set_pa_config(0x02, 0x03, DeviceSel::HighPowerPA).await?;
-                        // table indicates 17 dBm => txp = 22, therefore we add 5 to this range
-                        tx_params_power = txp as u8 + 5;
-                    }
-                    HIGH_POWER_MIN..=14 => {
-                        self.set_pa_config(0x02, 0x02, DeviceSel::HighPowerPA).await?;
-                        // The only row where ST's table for the STM32WL (an
-                        // SX126x die integrated into ST's part) differs from
-                        // datasheet Table 13-21: same PA config, but ST
-                        // commands the target dBm directly where the
-                        // datasheet interpolates from its +22 setpoint
-                        // (table row: 14 dBm => SetTxParams +22, so add 8).
-                        // Each part takes the table it was characterized
-                        // with.
-                        // https://github.com/STMicroelectronics/STM32CubeWL/blob/139e8d28bcec6af78dec8b52a9b9f9057868cc2e/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L675
-                        tx_params_power = if self.config.chip.use_st_power_table() {
-                            txp as u8
-                        } else {
-                            (txp + 8) as u8
-                        };
-                    }
-                    _ => {
-                        unreachable!("Invalid output power value for high power PA!")
-                    }
-                }
             }
         }
+
+        // PA config and SetTxParams power come from the variant's const
+        // power table (datasheet Table 13-21 for discrete parts; boards
+        // with their own PA characterization supply their own table)
+        let (entry, tx_params_power) = self.config.chip.pa_table().lookup(output_power);
+        self.set_pa_config(entry.pa_duty_cycle, entry.hp_max, self.config.chip.get_device_sel())
+            .await?;
+
         let op_code_and_tx_params = [OpCode::SetTxParams.value(), tx_params_power, ramp_time.value()];
         self.intf.write(&op_code_and_tx_params, false).await
     }

--- a/lora-phy/src/sx126x/radio_kind_params.rs
+++ b/lora-phy/src/sx126x/radio_kind_params.rs
@@ -88,6 +88,9 @@ impl Register {
 }
 
 #[derive(Clone, Copy, PartialEq)]
+// `from_repr` lets the sx126x emulator dispatch a wire byte back to a variant
+#[cfg_attr(test, derive(strum::FromRepr))]
+#[repr(u8)]
 #[allow(dead_code)]
 pub enum OpCode {
     GetStatus = 0xC0,

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -1,0 +1,333 @@
+//! A behavioral model of an sx126x chip driven over SPI. The real `Sx126x`
+//! driver and `LoRa` state machine run unmodified on top; tests hold a
+//! `Chip` handle to inject received packets and inspect transmitted ones.
+use crate::mod_params::RadioError;
+use crate::mod_traits::InterfaceVariant;
+use crate::sx126x::{Config, Sx1261, Sx126x};
+use embedded_hal::spi::{ErrorKind, Operation};
+use embedded_hal_async::delay::DelayNs;
+use embedded_hal_async::spi::SpiDevice;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+// Opcodes as the chip sees them (subset the driver uses)
+const WRITE_REGISTER: u8 = 0x0D;
+const READ_REGISTER: u8 = 0x1D;
+const WRITE_BUFFER: u8 = 0x0E;
+const READ_BUFFER: u8 = 0x1E;
+const SET_SLEEP: u8 = 0x84;
+const SET_STANDBY: u8 = 0x80;
+const SET_TX: u8 = 0x83;
+const SET_RX: u8 = 0x82;
+const SET_RF_FREQUENCY: u8 = 0x86;
+const SET_PACKET_PARAMS: u8 = 0x8C;
+const SET_BUFFER_BASE_ADDRESS: u8 = 0x8F;
+const CFG_DIO_IRQ: u8 = 0x08;
+const GET_IRQ_STATUS: u8 = 0x12;
+const CLR_IRQ_STATUS: u8 = 0x02;
+const GET_RX_BUFFER_STATUS: u8 = 0x13;
+const GET_PACKET_STATUS: u8 = 0x14;
+const SET_CAD: u8 = 0xC5;
+
+const IRQ_TX_DONE: u16 = 0x0001;
+const IRQ_RX_DONE: u16 = 0x0002;
+const IRQ_CAD_DONE: u16 = 0x0080;
+const IRQ_CAD_DETECTED: u16 = 0x0100;
+
+// No Tx variant: the model completes transmissions instantly inside SET_TX,
+// so the chip is never observable mid-transmit
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Mode {
+    Standby,
+    Sleep,
+    Rx,
+}
+
+pub struct PendingRx {
+    pub payload: Vec<u8>,
+    pub rssi_dbm: i16,
+    pub snr_db: i16,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TxRecord {
+    pub frequency_raw: u32,
+    pub payload: Vec<u8>,
+}
+
+pub struct ChipModel {
+    pub mode: Mode,
+    pub registers: HashMap<u16, u8>,
+    pub buffer: [u8; 256],
+    tx_base_addr: u8,
+    payload_length: u8,
+    frequency_raw: u32,
+    irq_status: u16,
+    irq_mask: u16,
+    dio1_mask: u16,
+    rx_len: u8,
+    pub cad_activity: bool,
+    pub pending_rx: Option<PendingRx>,
+    pub tx_log: Vec<TxRecord>,
+}
+
+impl ChipModel {
+    fn new() -> Self {
+        Self {
+            mode: Mode::Standby,
+            registers: HashMap::new(),
+            buffer: [0; 256],
+            tx_base_addr: 0,
+            payload_length: 0,
+            frequency_raw: 0,
+            irq_status: 0,
+            irq_mask: 0,
+            dio1_mask: 0,
+            rx_len: 0,
+            cad_activity: false,
+            pending_rx: None,
+            tx_log: vec![],
+        }
+    }
+
+    fn raise_irq(&mut self, irq: u16) {
+        self.irq_status |= irq & self.irq_mask;
+    }
+
+    fn reg_read(&self, addr: u16) -> u8 {
+        *self.registers.get(&addr).unwrap_or(&0)
+    }
+
+    /// Execute one command; `params` excludes the opcode byte. Returns the
+    /// response bytes for opcodes the driver reads from (status byte first).
+    fn execute(&mut self, opcode: u8, params: &[u8]) -> Vec<u8> {
+        const STATUS_OK: u8 = 0x00;
+        match opcode {
+            WRITE_REGISTER => {
+                let addr = u16::from_be_bytes([params[0], params[1]]);
+                for (i, b) in params[2..].iter().enumerate() {
+                    self.registers.insert(addr + i as u16, *b);
+                }
+                vec![]
+            }
+            READ_REGISTER => {
+                // params: addr(2) + nop; length comes from the driver's read buffer
+                let addr = u16::from_be_bytes([params[0], params[1]]);
+                (0..=u8::MAX).map(|i| self.reg_read(addr + i as u16)).collect()
+            }
+            WRITE_BUFFER => {
+                let offset = params[0] as usize;
+                self.buffer[offset..offset + params[1..].len()].copy_from_slice(&params[1..]);
+                vec![]
+            }
+            READ_BUFFER => {
+                // No status prefix: the driver reads this via plain read(),
+                // clocking the status byte out during its trailing nop write
+                let offset = params[0] as usize;
+                self.buffer[offset..].to_vec()
+            }
+            SET_SLEEP => {
+                self.mode = Mode::Sleep;
+                vec![]
+            }
+            SET_STANDBY => {
+                self.mode = Mode::Standby;
+                vec![]
+            }
+            SET_RF_FREQUENCY => {
+                self.frequency_raw = u32::from_be_bytes([params[0], params[1], params[2], params[3]]);
+                vec![]
+            }
+            SET_BUFFER_BASE_ADDRESS => {
+                self.tx_base_addr = params[0];
+                vec![]
+            }
+            SET_PACKET_PARAMS => {
+                // LoRa: preamble(2), header type, payload length, crc, invert IQ
+                self.payload_length = params[3];
+                vec![]
+            }
+            CFG_DIO_IRQ => {
+                self.irq_mask = u16::from_be_bytes([params[0], params[1]]);
+                self.dio1_mask = u16::from_be_bytes([params[2], params[3]]);
+                vec![]
+            }
+            CLR_IRQ_STATUS => {
+                self.irq_status &= !u16::from_be_bytes([params[0], params[1]]);
+                vec![]
+            }
+            GET_IRQ_STATUS => {
+                let [hi, lo] = self.irq_status.to_be_bytes();
+                vec![STATUS_OK, hi, lo]
+            }
+            SET_TX => {
+                let base = self.tx_base_addr as usize;
+                self.tx_log.push(TxRecord {
+                    frequency_raw: self.frequency_raw,
+                    payload: self.buffer[base..base + self.payload_length as usize].to_vec(),
+                });
+                // Transmission completes instantly; chip falls back to standby
+                self.mode = Mode::Standby;
+                self.raise_irq(IRQ_TX_DONE);
+                vec![]
+            }
+            SET_RX => {
+                self.mode = Mode::Rx;
+                if let Some(rx) = self.pending_rx.take() {
+                    self.buffer[..rx.payload.len()].copy_from_slice(&rx.payload);
+                    self.rx_len = rx.payload.len() as u8;
+                    self.registers.insert(REG_RSSI_SHADOW, (-2 * rx.rssi_dbm) as u8);
+                    self.registers.insert(REG_SNR_SHADOW, (4 * rx.snr_db) as u8);
+                    self.raise_irq(IRQ_RX_DONE);
+                }
+                vec![]
+            }
+            GET_RX_BUFFER_STATUS => vec![STATUS_OK, self.rx_len, 0x00],
+            GET_PACKET_STATUS => vec![
+                STATUS_OK,
+                self.reg_read(REG_RSSI_SHADOW),
+                self.reg_read(REG_SNR_SHADOW),
+                self.reg_read(REG_RSSI_SHADOW),
+            ],
+            SET_CAD => {
+                if self.cad_activity {
+                    self.raise_irq(IRQ_CAD_DONE | IRQ_CAD_DETECTED);
+                } else {
+                    self.raise_irq(IRQ_CAD_DONE);
+                }
+                vec![]
+            }
+            // Configuration commands the model accepts without side effects
+            _ => vec![STATUS_OK; 16],
+        }
+    }
+}
+
+// Model-internal scratch space for rx metadata, outside the chip's real
+// register map (real addresses are all < 0x0A00)
+const REG_RSSI_SHADOW: u16 = 0xFF00;
+const REG_SNR_SHADOW: u16 = 0xFF01;
+
+/// Test handle to the chip shared by the fake SPI bus and IRQ lines.
+#[derive(Clone)]
+pub struct Chip(Arc<Mutex<ChipModel>>);
+
+impl Chip {
+    pub fn new() -> Self {
+        Chip(Arc::new(Mutex::new(ChipModel::new())))
+    }
+
+    pub fn inject_rx(&self, payload: &[u8], rssi_dbm: i16, snr_db: i16) {
+        self.0.lock().unwrap().pending_rx = Some(PendingRx {
+            payload: payload.to_vec(),
+            rssi_dbm,
+            snr_db,
+        });
+    }
+
+    pub fn with_model<R>(&self, f: impl FnOnce(&mut ChipModel) -> R) -> R {
+        f(&mut self.0.lock().unwrap())
+    }
+}
+
+#[derive(Debug)]
+pub enum SpiError {}
+impl embedded_hal::spi::Error for SpiError {
+    fn kind(&self) -> ErrorKind {
+        todo!()
+    }
+}
+
+/// SPI bus wired to the chip model: writes execute commands, reads drain the
+/// command's response bytes (status byte first, matching read_with_status).
+pub struct FakeSpi(pub Chip);
+
+impl embedded_hal::spi::ErrorType for FakeSpi {
+    type Error = SpiError;
+}
+
+impl SpiDevice<u8> for FakeSpi {
+    async fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        let mut cmd: Vec<u8> = Vec::new();
+        for op in operations.iter() {
+            if let Operation::Write(buf) = op {
+                cmd.extend_from_slice(buf);
+            }
+        }
+        let mut response = if cmd.is_empty() {
+            vec![]
+        } else {
+            self.0 .0.lock().unwrap().execute(cmd[0], &cmd[1..])
+        };
+        let mut cursor = response.drain(..);
+        for op in operations.iter_mut() {
+            if let Operation::Read(buf) = op {
+                for b in buf.iter_mut() {
+                    *b = cursor.next().unwrap_or(0);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn write(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        self.transaction(&mut [Operation::Write(buf)]).await
+    }
+
+    async fn read(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transfer(&mut self, _read: &mut [u8], _write: &[u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transfer_in_place(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+}
+
+/// IRQ/busy/reset lines wired to the same chip model.
+pub struct FakeIv(pub Chip);
+
+impl InterfaceVariant for FakeIv {
+    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
+        self.0.with_model(|m| *m = ChipModel::new());
+        Ok(())
+    }
+    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn await_irq(&mut self) -> Result<(), RadioError> {
+        for _ in 0..1000 {
+            if self.0.with_model(|m| m.irq_status & m.dio1_mask != 0) {
+                return Ok(());
+            }
+            tokio::task::yield_now().await;
+        }
+        // The chip model has no pending IRQ and nothing left to raise one
+        Err(RadioError::Irq)
+    }
+    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+}
+
+pub fn get_emulated_sx1261(chip: &Chip) -> Sx126x<FakeSpi, FakeIv, Sx1261> {
+    Sx126x::new(
+        FakeSpi(chip.clone()),
+        FakeIv(chip.clone()),
+        Config {
+            chip: Sx1261,
+            tcxo_ctrl: None,
+            use_dcdc: false,
+            rx_boost: true,
+        },
+    )
+}

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -11,6 +11,7 @@ use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::SpiDevice;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::vec::Vec;
 
 // Dispatch constants derived from the driver's enums (enum variants can't
 // be `match` patterns against a raw byte, consts can). The byte values

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -33,6 +33,7 @@ const IRQ_TX_DONE: u16 = 0x0001;
 const IRQ_RX_DONE: u16 = 0x0002;
 const IRQ_CAD_DONE: u16 = 0x0080;
 const IRQ_CAD_DETECTED: u16 = 0x0100;
+const IRQ_RX_TX_TIMEOUT: u16 = 0x0200;
 
 // No Tx variant: the model completes transmissions instantly inside SET_TX,
 // so the chip is never observable mid-transmit
@@ -179,6 +180,15 @@ impl ChipModel {
                     self.registers.insert(REG_RSSI_SHADOW, (-2 * rx.rssi_dbm) as u8);
                     self.registers.insert(REG_SNR_SHADOW, (4 * rx.snr_db) as u8);
                     self.raise_irq(IRQ_RX_DONE);
+                } else if params[..3] != [0xFF, 0xFF, 0xFF] {
+                    // Anything but continuous mode times out when no packet
+                    // is pending. The wait is collapsed to zero — the model
+                    // has no clock, and nothing can arrive once SetRx has
+                    // executed — so this exercises the driver's timeout path
+                    // (single-mode symbol timeout and timed RX alike), not
+                    // timeout durations.
+                    self.mode = Mode::Standby;
+                    self.raise_irq(IRQ_RX_TX_TIMEOUT);
                 }
                 vec![]
             }

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -5,7 +5,8 @@ use crate::mod_params::RadioError;
 use crate::mod_traits::InterfaceVariant;
 use crate::sx126x::radio_kind_params::{IrqMask, OpCode};
 use crate::sx126x::{Config, Sx1261, Sx126x};
-use embedded_hal::spi::{ErrorKind, Operation};
+use crate::test_fixtures::SpiError;
+use embedded_hal::spi::Operation;
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::SpiDevice;
 use std::collections::HashMap;
@@ -242,14 +243,6 @@ impl Chip {
 
     pub fn with_model<R>(&self, f: impl FnOnce(&mut ChipModel) -> R) -> R {
         f(&mut self.0.lock().unwrap())
-    }
-}
-
-#[derive(Debug)]
-pub enum SpiError {}
-impl embedded_hal::spi::Error for SpiError {
-    fn kind(&self) -> ErrorKind {
-        todo!()
     }
 }
 

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -13,28 +13,10 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::vec::Vec;
 
-// Dispatch constants derived from the driver's enums (enum variants can't
-// be `match` patterns against a raw byte, consts can). The byte values
-// themselves are pinned independently by the SWL2001 comparison suite, so
-// deriving from the driver here is not circular — the emulator's job is
-// behavior, not encoding.
-const WRITE_REGISTER: u8 = OpCode::WriteRegister as u8;
-const READ_REGISTER: u8 = OpCode::ReadRegister as u8;
-const WRITE_BUFFER: u8 = OpCode::WriteBuffer as u8;
-const READ_BUFFER: u8 = OpCode::ReadBuffer as u8;
-const SET_SLEEP: u8 = OpCode::SetSleep as u8;
-const SET_STANDBY: u8 = OpCode::SetStandby as u8;
-const SET_TX: u8 = OpCode::SetTx as u8;
-const SET_RX: u8 = OpCode::SetRx as u8;
-const SET_RF_FREQUENCY: u8 = OpCode::SetRFFrequency as u8;
-const SET_PACKET_PARAMS: u8 = OpCode::SetPacketParams as u8;
-const SET_BUFFER_BASE_ADDRESS: u8 = OpCode::SetBufferBaseAddress as u8;
-const CFG_DIO_IRQ: u8 = OpCode::CfgDIOIrq as u8;
-const GET_IRQ_STATUS: u8 = OpCode::GetIrqStatus as u8;
-const CLR_IRQ_STATUS: u8 = OpCode::ClrIrqStatus as u8;
-const GET_RX_BUFFER_STATUS: u8 = OpCode::GetRxBufferStatus as u8;
-const GET_PACKET_STATUS: u8 = OpCode::GetPacketStatus as u8;
-const SET_CAD: u8 = OpCode::SetCAD as u8;
+// The wire byte is parsed back into an `OpCode` via `from_repr` and matched by
+// variant. The byte values themselves are pinned independently by the SWL2001
+// comparison suite, so dispatching on the driver's enum here is not circular:
+// the emulator's job is behavior, not encoding.
 
 const IRQ_TX_DONE: u16 = IrqMask::TxDone as u16;
 const IRQ_RX_DONE: u16 = IrqMask::RxDone as u16;
@@ -110,65 +92,65 @@ impl ChipModel {
     /// response bytes for opcodes the driver reads from (status byte first).
     fn execute(&mut self, opcode: u8, params: &[u8]) -> Vec<u8> {
         const STATUS_OK: u8 = 0x00;
-        match opcode {
-            WRITE_REGISTER => {
+        match OpCode::from_repr(opcode) {
+            Some(OpCode::WriteRegister) => {
                 let addr = u16::from_be_bytes([params[0], params[1]]);
                 for (i, b) in params[2..].iter().enumerate() {
                     self.registers.insert(addr + i as u16, *b);
                 }
                 vec![]
             }
-            READ_REGISTER => {
+            Some(OpCode::ReadRegister) => {
                 // params: addr(2) + nop; length comes from the driver's read buffer
                 let addr = u16::from_be_bytes([params[0], params[1]]);
                 (0..=u8::MAX).map(|i| self.reg_read(addr + i as u16)).collect()
             }
-            WRITE_BUFFER => {
+            Some(OpCode::WriteBuffer) => {
                 let offset = params[0] as usize;
                 self.buffer[offset..offset + params[1..].len()].copy_from_slice(&params[1..]);
                 vec![]
             }
-            READ_BUFFER => {
+            Some(OpCode::ReadBuffer) => {
                 // No status prefix: the driver reads this via plain read(),
                 // clocking the status byte out during its trailing nop write
                 let offset = params[0] as usize;
                 self.buffer[offset..].to_vec()
             }
-            SET_SLEEP => {
+            Some(OpCode::SetSleep) => {
                 self.mode = Mode::Sleep;
                 vec![]
             }
-            SET_STANDBY => {
+            Some(OpCode::SetStandby) => {
                 self.mode = Mode::Standby;
                 vec![]
             }
-            SET_RF_FREQUENCY => {
+            Some(OpCode::SetRFFrequency) => {
                 self.frequency_raw = u32::from_be_bytes([params[0], params[1], params[2], params[3]]);
                 vec![]
             }
-            SET_BUFFER_BASE_ADDRESS => {
+            Some(OpCode::SetBufferBaseAddress) => {
                 self.tx_base_addr = params[0];
                 vec![]
             }
-            SET_PACKET_PARAMS => {
+            Some(OpCode::SetPacketParams) => {
                 // LoRa: preamble(2), header type, payload length, crc, invert IQ
                 self.payload_length = params[3];
                 vec![]
             }
-            CFG_DIO_IRQ => {
+            Some(OpCode::CfgDIOIrq) => {
                 self.irq_mask = u16::from_be_bytes([params[0], params[1]]);
                 self.dio1_mask = u16::from_be_bytes([params[2], params[3]]);
                 vec![]
             }
-            CLR_IRQ_STATUS => {
+            Some(OpCode::ClrIrqStatus) => {
                 self.irq_status &= !u16::from_be_bytes([params[0], params[1]]);
                 vec![]
             }
-            GET_IRQ_STATUS => {
+            Some(OpCode::GetIrqStatus) => {
                 let [hi, lo] = self.irq_status.to_be_bytes();
                 vec![STATUS_OK, hi, lo]
             }
-            SET_TX => {
+            Some(OpCode::SetTx) => {
                 let base = self.tx_base_addr as usize;
                 self.tx_log.push(TxRecord {
                     frequency_raw: self.frequency_raw,
@@ -179,7 +161,7 @@ impl ChipModel {
                 self.raise_irq(IRQ_TX_DONE);
                 vec![]
             }
-            SET_RX => {
+            Some(OpCode::SetRx) => {
                 self.mode = Mode::Rx;
                 if let Some(rx) = self.pending_rx.take() {
                     self.buffer[..rx.payload.len()].copy_from_slice(&rx.payload);
@@ -199,14 +181,14 @@ impl ChipModel {
                 }
                 vec![]
             }
-            GET_RX_BUFFER_STATUS => vec![STATUS_OK, self.rx_len, 0x00],
-            GET_PACKET_STATUS => vec![
+            Some(OpCode::GetRxBufferStatus) => vec![STATUS_OK, self.rx_len, 0x00],
+            Some(OpCode::GetPacketStatus) => vec![
                 STATUS_OK,
                 self.reg_read(REG_RSSI_SHADOW),
                 self.reg_read(REG_SNR_SHADOW),
                 self.reg_read(REG_RSSI_SHADOW),
             ],
-            SET_CAD => {
+            Some(OpCode::SetCAD) => {
                 if self.cad_activity {
                     self.raise_irq(IRQ_CAD_DONE | IRQ_CAD_DETECTED);
                 } else {
@@ -214,7 +196,8 @@ impl ChipModel {
                 }
                 vec![]
             }
-            // Configuration commands the model accepts without side effects
+            // Configuration commands the model accepts without side effects,
+            // plus any opcode byte the driver never sends (from_repr → None)
             _ => vec![STATUS_OK; 16],
         }
     }

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -3,6 +3,7 @@
 //! `Chip` handle to inject received packets and inspect transmitted ones.
 use crate::mod_params::RadioError;
 use crate::mod_traits::InterfaceVariant;
+use crate::sx126x::radio_kind_params::{IrqMask, OpCode};
 use crate::sx126x::{Config, Sx1261, Sx126x};
 use embedded_hal::spi::{ErrorKind, Operation};
 use embedded_hal_async::delay::DelayNs;
@@ -10,30 +11,34 @@ use embedded_hal_async::spi::SpiDevice;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-// Opcodes as the chip sees them (subset the driver uses)
-const WRITE_REGISTER: u8 = 0x0D;
-const READ_REGISTER: u8 = 0x1D;
-const WRITE_BUFFER: u8 = 0x0E;
-const READ_BUFFER: u8 = 0x1E;
-const SET_SLEEP: u8 = 0x84;
-const SET_STANDBY: u8 = 0x80;
-const SET_TX: u8 = 0x83;
-const SET_RX: u8 = 0x82;
-const SET_RF_FREQUENCY: u8 = 0x86;
-const SET_PACKET_PARAMS: u8 = 0x8C;
-const SET_BUFFER_BASE_ADDRESS: u8 = 0x8F;
-const CFG_DIO_IRQ: u8 = 0x08;
-const GET_IRQ_STATUS: u8 = 0x12;
-const CLR_IRQ_STATUS: u8 = 0x02;
-const GET_RX_BUFFER_STATUS: u8 = 0x13;
-const GET_PACKET_STATUS: u8 = 0x14;
-const SET_CAD: u8 = 0xC5;
+// Dispatch constants derived from the driver's enums (enum variants can't
+// be `match` patterns against a raw byte, consts can). The byte values
+// themselves are pinned independently by the SWL2001 comparison suite, so
+// deriving from the driver here is not circular — the emulator's job is
+// behavior, not encoding.
+const WRITE_REGISTER: u8 = OpCode::WriteRegister as u8;
+const READ_REGISTER: u8 = OpCode::ReadRegister as u8;
+const WRITE_BUFFER: u8 = OpCode::WriteBuffer as u8;
+const READ_BUFFER: u8 = OpCode::ReadBuffer as u8;
+const SET_SLEEP: u8 = OpCode::SetSleep as u8;
+const SET_STANDBY: u8 = OpCode::SetStandby as u8;
+const SET_TX: u8 = OpCode::SetTx as u8;
+const SET_RX: u8 = OpCode::SetRx as u8;
+const SET_RF_FREQUENCY: u8 = OpCode::SetRFFrequency as u8;
+const SET_PACKET_PARAMS: u8 = OpCode::SetPacketParams as u8;
+const SET_BUFFER_BASE_ADDRESS: u8 = OpCode::SetBufferBaseAddress as u8;
+const CFG_DIO_IRQ: u8 = OpCode::CfgDIOIrq as u8;
+const GET_IRQ_STATUS: u8 = OpCode::GetIrqStatus as u8;
+const CLR_IRQ_STATUS: u8 = OpCode::ClrIrqStatus as u8;
+const GET_RX_BUFFER_STATUS: u8 = OpCode::GetRxBufferStatus as u8;
+const GET_PACKET_STATUS: u8 = OpCode::GetPacketStatus as u8;
+const SET_CAD: u8 = OpCode::SetCAD as u8;
 
-const IRQ_TX_DONE: u16 = 0x0001;
-const IRQ_RX_DONE: u16 = 0x0002;
-const IRQ_CAD_DONE: u16 = 0x0080;
-const IRQ_CAD_DETECTED: u16 = 0x0100;
-const IRQ_RX_TX_TIMEOUT: u16 = 0x0200;
+const IRQ_TX_DONE: u16 = IrqMask::TxDone as u16;
+const IRQ_RX_DONE: u16 = IrqMask::RxDone as u16;
+const IRQ_CAD_DONE: u16 = IrqMask::CADDone as u16;
+const IRQ_CAD_DETECTED: u16 = IrqMask::CADActivityDetected as u16;
+const IRQ_RX_TX_TIMEOUT: u16 = IrqMask::RxTxTimeout as u16;
 
 // No Tx variant: the model completes transmissions instantly inside SET_TX,
 // so the chip is never observable mid-transmit

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -3,6 +3,7 @@ pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
 use embedded_hal::spi::Operation;
 use embedded_hal_async::spi::SpiDevice;
 use std::collections::{HashMap, VecDeque};
+use std::vec::Vec;
 
 /// Records every SPI operation so the byte stream of our driver can be
 /// compared against the byte stream of Semtech's reference driver. Implements

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -1,8 +1,6 @@
-use crate::mod_params::RadioError;
-use crate::mod_traits::InterfaceVariant;
 use crate::sx126x::{Config, Sx1261, Sx1262, Sx126x};
-use embedded_hal::spi::{ErrorKind, Operation};
-use embedded_hal_async::delay::DelayNs;
+pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
+use embedded_hal::spi::Operation;
 use embedded_hal_async::spi::SpiDevice;
 use std::collections::{HashMap, VecDeque};
 
@@ -103,15 +101,8 @@ pub enum Ops {
     Read(Vec<u8>, usize),
 }
 
-#[derive(Debug)]
-pub enum Error {}
-impl embedded_hal::spi::Error for Error {
-    fn kind(&self) -> ErrorKind {
-        todo!()
-    }
-}
 impl embedded_hal::spi::ErrorType for TestFixture {
-    type Error = Error;
+    type Error = SpiError;
 }
 
 impl embedded_hal::spi::SpiDevice for TestFixture {
@@ -169,32 +160,4 @@ pub fn get_sx1262() -> Sx126x<TestFixture, DummyVariant, Sx1262> {
             rx_boost: true,
         },
     )
-}
-
-pub struct Delayer;
-impl DelayNs for Delayer {
-    async fn delay_ns(&mut self, _ns: u32) {}
-}
-
-pub struct DummyVariant;
-
-impl InterfaceVariant for DummyVariant {
-    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn await_irq(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
 }

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -1,6 +1,6 @@
 use crate::mod_params::RadioError;
 use crate::mod_traits::InterfaceVariant;
-use crate::sx126x::{Config, Sx1261, Sx126x};
+use crate::sx126x::{Config, Sx1261, Sx1262, Sx126x};
 use embedded_hal::spi::{ErrorKind, Operation};
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::SpiDevice;
@@ -142,6 +142,19 @@ pub fn get_sx126x() -> Sx126x<TestFixture, DummyVariant, Sx1261> {
         DummyVariant,
         Config {
             chip: Sx1261,
+            tcxo_ctrl: None,
+            use_dcdc: false,
+            rx_boost: true,
+        },
+    )
+}
+
+pub fn get_sx1262() -> Sx126x<TestFixture, DummyVariant, Sx1262> {
+    Sx126x::new(
+        TestFixture::new(),
+        DummyVariant,
+        Config {
+            chip: Sx1262,
             tcxo_ctrl: None,
             use_dcdc: false,
             rx_boost: true,

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -4,36 +4,75 @@ use crate::sx126x::{Config, Sx1261, Sx126x};
 use embedded_hal::spi::{ErrorKind, Operation};
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::SpiDevice;
+use std::collections::HashMap;
 
-/// Records every SPI write so the byte stream of our driver can be compared
-/// against the byte stream of Semtech's reference driver. Implements both the
-/// blocking `SpiDevice` (for the reference driver, via smtc-modem-cores) and
-/// the async one (for lora-phy).
-#[derive(Clone, PartialEq, Eq, Debug)]
+/// Records every SPI operation so the byte stream of our driver can be
+/// compared against the byte stream of Semtech's reference driver. Implements
+/// both the blocking `SpiDevice` (for the reference driver, via
+/// smtc-modem-cores) and the async one (for lora-phy). Reads answer from
+/// `read_responses` (zeros when unprimed) so read-modify-write command
+/// sequences stay comparable across the two drivers.
+#[derive(Clone, Debug)]
 pub struct TestFixture {
     pub ops: Vec<Ops>,
+    read_responses: HashMap<Vec<u8>, Vec<u8>>,
 }
+
+impl PartialEq for TestFixture {
+    fn eq(&self, other: &Self) -> bool {
+        self.ops == other.ops
+    }
+}
+impl Eq for TestFixture {}
 
 impl TestFixture {
     pub fn new() -> Self {
-        Self { ops: vec![] }
+        Self {
+            ops: vec![],
+            read_responses: HashMap::new(),
+        }
+    }
+
+    /// Canned response for a read identified by its full command bytes
+    pub fn prime_read(&mut self, command: &[u8], response: &[u8]) {
+        self.read_responses.insert(command.to_vec(), response.to_vec());
+    }
+
+    pub fn writes(&self) -> Vec<&Ops> {
+        self.ops.iter().filter(|op| matches!(op, Ops::Write(_))).collect()
     }
 
     fn record(&mut self, operations: &mut [Operation<'_, u8>]) {
-        let mut vec = Vec::new();
-        for op in operations {
+        let mut cmd = Vec::new();
+        let mut read_len = 0;
+        for op in operations.iter() {
             match op {
-                Operation::Write(buf) => vec.extend_from_slice(buf),
+                Operation::Write(buf) => cmd.extend_from_slice(buf),
+                Operation::Read(buf) => read_len += buf.len(),
                 _ => todo!(),
             }
         }
-        self.ops.push(Ops::Write(vec));
+        if read_len == 0 {
+            self.ops.push(Ops::Write(cmd));
+            return;
+        }
+        let response = self.read_responses.get(&cmd).cloned().unwrap_or_default();
+        let mut cursor = response.iter().copied();
+        for op in operations.iter_mut() {
+            if let Operation::Read(buf) = op {
+                for b in buf.iter_mut() {
+                    *b = cursor.next().unwrap_or(0);
+                }
+            }
+        }
+        self.ops.push(Ops::Read(cmd, read_len));
     }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Ops {
     Write(Vec<u8>),
+    Read(Vec<u8>, usize),
 }
 
 #[derive(Debug)]

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -18,9 +18,28 @@ pub struct TestFixture {
     read_responses: HashMap<Vec<u8>, Vec<u8>>,
 }
 
+/// Wire-canonical form of one SPI transaction: (written bytes with trailing
+/// NOPs trimmed, total bytes clocked). The two drivers split transactions
+/// differently — C sends `[opcode, NOP]` then reads N, ours sends `[opcode]`
+/// then reads status + N — but on the wire both clock the same bytes: MOSI
+/// idles at 0x00 during reads, so a trailing NOP write and a read byte are
+/// indistinguishable to the chip.
+fn canonical(ops: &[Ops]) -> Vec<(&[u8], usize)> {
+    ops.iter()
+        .map(|op| {
+            let (cmd, total) = match op {
+                Ops::Write(cmd) => (cmd, cmd.len()),
+                Ops::Read(cmd, read_len) => (cmd, cmd.len() + read_len),
+            };
+            let trimmed = cmd.len() - cmd.iter().rev().take_while(|b| **b == 0).count();
+            (&cmd[..trimmed], total)
+        })
+        .collect()
+}
+
 impl PartialEq for TestFixture {
     fn eq(&self, other: &Self) -> bool {
-        self.ops == other.ops
+        canonical(&self.ops) == canonical(&other.ops)
     }
 }
 impl Eq for TestFixture {}

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -4,7 +4,7 @@ use crate::sx126x::{Config, Sx1261, Sx1262, Sx126x};
 use embedded_hal::spi::{ErrorKind, Operation};
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::SpiDevice;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 /// Records every SPI operation so the byte stream of our driver can be
 /// compared against the byte stream of Semtech's reference driver. Implements
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 #[derive(Clone, Debug)]
 pub struct TestFixture {
     pub ops: Vec<Ops>,
-    read_responses: HashMap<Vec<u8>, Vec<u8>>,
+    read_responses: HashMap<Vec<u8>, VecDeque<Vec<u8>>>,
 }
 
 /// Wire-canonical form of one SPI transaction: (written bytes with trailing
@@ -52,9 +52,14 @@ impl TestFixture {
         }
     }
 
-    /// Canned response for a read identified by its full command bytes
+    /// Canned response for a read identified by its full command bytes.
+    /// Priming the same command again queues a response for the next read
+    /// (read-modify-write sequences hit the same command repeatedly).
     pub fn prime_read(&mut self, command: &[u8], response: &[u8]) {
-        self.read_responses.insert(command.to_vec(), response.to_vec());
+        self.read_responses
+            .entry(command.to_vec())
+            .or_default()
+            .push_back(response.to_vec());
     }
 
     pub fn writes(&self) -> Vec<&Ops> {
@@ -75,7 +80,11 @@ impl TestFixture {
             self.ops.push(Ops::Write(cmd));
             return;
         }
-        let response = self.read_responses.get(&cmd).cloned().unwrap_or_default();
+        let response = self
+            .read_responses
+            .get_mut(&cmd)
+            .and_then(|queue| queue.pop_front())
+            .unwrap_or_default();
         let mut cursor = response.iter().copied();
         for op in operations.iter_mut() {
             if let Operation::Read(buf) = op {

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -1,0 +1,120 @@
+use crate::mod_params::RadioError;
+use crate::mod_traits::InterfaceVariant;
+use crate::sx126x::{Config, Sx1261, Sx126x};
+use embedded_hal::spi::{ErrorKind, Operation};
+use embedded_hal_async::delay::DelayNs;
+use embedded_hal_async::spi::SpiDevice;
+
+/// Records every SPI write so the byte stream of our driver can be compared
+/// against the byte stream of Semtech's reference driver. Implements both the
+/// blocking `SpiDevice` (for the reference driver, via smtc-modem-cores) and
+/// the async one (for lora-phy).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TestFixture {
+    pub ops: Vec<Ops>,
+}
+
+impl TestFixture {
+    pub fn new() -> Self {
+        Self { ops: vec![] }
+    }
+
+    fn record(&mut self, operations: &mut [Operation<'_, u8>]) {
+        let mut vec = Vec::new();
+        for op in operations {
+            match op {
+                Operation::Write(buf) => vec.extend_from_slice(buf),
+                _ => todo!(),
+            }
+        }
+        self.ops.push(Ops::Write(vec));
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Ops {
+    Write(Vec<u8>),
+}
+
+#[derive(Debug)]
+pub enum Error {}
+impl embedded_hal::spi::Error for Error {
+    fn kind(&self) -> ErrorKind {
+        todo!()
+    }
+}
+impl embedded_hal::spi::ErrorType for TestFixture {
+    type Error = Error;
+}
+
+impl embedded_hal::spi::SpiDevice for TestFixture {
+    fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        self.record(operations);
+        Ok(())
+    }
+}
+
+impl SpiDevice<u8> for TestFixture {
+    async fn write(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        self.ops.push(Ops::Write(buf.to_vec()));
+        Ok(())
+    }
+
+    async fn read(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        self.record(operations);
+        Ok(())
+    }
+
+    async fn transfer(&mut self, _read: &mut [u8], _write: &[u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transfer_in_place(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+}
+
+pub fn get_sx126x() -> Sx126x<TestFixture, DummyVariant, Sx1261> {
+    Sx126x::new(
+        TestFixture::new(),
+        DummyVariant,
+        Config {
+            chip: Sx1261,
+            tcxo_ctrl: None,
+            use_dcdc: false,
+            rx_boost: true,
+        },
+    )
+}
+
+pub struct Delayer;
+impl DelayNs for Delayer {
+    async fn delay_ns(&mut self, _ns: u32) {}
+}
+
+pub struct DummyVariant;
+
+impl InterfaceVariant for DummyVariant {
+    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn await_irq(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+}

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -6,11 +6,18 @@ mod fixtures;
 use emulator::{get_emulated_sx1261, Chip, Mode};
 use fixtures::{get_sx126x, Delayer, TestFixture};
 
-use crate::mod_params::RxMode;
+use crate::mod_params::{RadioMode, RxMode};
 use crate::mod_traits::RadioKind;
 use crate::LoRa;
 use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
-use smtc_modem_cores::sx126x::{Context, SleepCfg};
+use smtc_modem_cores::sx126x::{
+    sx126x_lora_bw_e, sx126x_lora_cr_e, sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t,
+    sx126x_pkt_params_lora_t, sx126x_standby_cfgs_e, Context, SleepCfg,
+};
+
+fn reference() -> Context<TestFixture> {
+    Context::new(TestFixture::new())
+}
 
 #[tokio::test]
 async fn test_sleep_cold_start() {
@@ -28,6 +35,159 @@ async fn test_sleep_warm_start() {
     let mut sx1261 = get_sx126x();
     sx1261.set_sleep(true, &mut Delayer).await.unwrap();
     assert_eq!(sx1261.take_spi(), smtc_sx126x.inner);
+}
+
+#[tokio::test]
+async fn test_standby() {
+    let mut reference = reference();
+    reference.set_standby(sx126x_standby_cfgs_e::SX126X_STANDBY_CFG_RC);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_standby().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_set_channel() {
+    for freq in [433_000_000u32, 868_100_000, TEST_FREQ_HZ] {
+        let mut reference = reference();
+        reference.set_rf_freq(freq);
+        let mut sx1261 = get_sx126x();
+        sx1261.set_channel(freq).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "freq {freq}");
+    }
+}
+
+#[tokio::test]
+async fn test_modulation_params() {
+    // Second case exercises the 500 kHz TxModulation workaround branch and
+    // the low-data-rate-optimize flag
+    let cases = [
+        (
+            SpreadingFactor::_7,
+            Bandwidth::_125KHz,
+            sx126x_lora_sf_e::SX126X_LORA_SF7,
+            sx126x_lora_bw_e::SX126X_LORA_BW_125,
+            0u8,
+        ),
+        (
+            SpreadingFactor::_12,
+            Bandwidth::_500KHz,
+            sx126x_lora_sf_e::SX126X_LORA_SF12,
+            sx126x_lora_bw_e::SX126X_LORA_BW_500,
+            0u8,
+        ),
+        (
+            SpreadingFactor::_11,
+            Bandwidth::_125KHz,
+            sx126x_lora_sf_e::SX126X_LORA_SF11,
+            sx126x_lora_bw_e::SX126X_LORA_BW_125,
+            1u8,
+        ),
+    ];
+    for (sf, bw, c_sf, c_bw, ldro) in cases {
+        let mut reference = reference();
+        reference.set_lora_mod_params(&sx126x_mod_params_lora_t {
+            sf: c_sf,
+            bw: c_bw,
+            cr: sx126x_lora_cr_e::SX126X_LORA_CR_4_5,
+            ldro,
+        });
+        let mut sx1261 = get_sx126x();
+        let mdltn_params = sx1261
+            .create_modulation_params(sf, bw, CodingRate::_4_5, TEST_FREQ_HZ)
+            .unwrap();
+        assert_eq!(mdltn_params.low_data_rate_optimize, ldro, "ldro for {sf:?}/{bw:?}");
+        sx1261.set_modulation_params(&mdltn_params).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "{sf:?}/{bw:?}");
+    }
+}
+
+#[tokio::test]
+async fn test_packet_params() {
+    for iq_inverted in [false, true] {
+        let mut reference = reference();
+        reference.set_lora_pkt_params(&sx126x_pkt_params_lora_t {
+            preamble_len_in_symb: 8,
+            header_type: sx126x_lora_pkt_len_modes_e::SX126X_LORA_PKT_EXPLICIT,
+            pld_len_in_bytes: 32,
+            crc_is_on: true,
+            invert_iq_is_on: iq_inverted,
+        });
+        let mut sx1261 = get_sx126x();
+        let mdltn_params = sx1261
+            .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, TEST_FREQ_HZ)
+            .unwrap();
+        let pkt_params = sx1261
+            .create_packet_params(8, false, 32, true, iq_inverted, &mdltn_params)
+            .unwrap();
+        sx1261.set_packet_params(&pkt_params).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "iq_inverted {iq_inverted}");
+    }
+}
+
+#[tokio::test]
+async fn test_sync_word() {
+    // Our driver skips the read-modify-write and writes the known reset
+    // values (0x14 0x24) with the sync nibbles applied; prime the reference
+    // with those reset values and both land on the same register write.
+    let mut fixture = TestFixture::new();
+    fixture.prime_read(&[0x1D, 0x07, 0x40, 0x00], &[0x14, 0x24]);
+    let mut reference = Context::new(fixture);
+    reference.set_lora_sync_word(0x34);
+    match reference.inner.writes()[..] {
+        [fixtures::Ops::Write(bytes)] => assert_eq!(bytes, &[0x0D, 0x07, 0x40, 0x34, 0x44]),
+        ref other => panic!("unexpected write stream {other:?}"),
+    }
+    // 0x34 -> [0x34, 0x44] is asserted against our driver in
+    // sx126x::tests::test_convert_sync_word
+}
+
+#[tokio::test]
+async fn test_buffer_base_address() {
+    let mut reference = reference();
+    reference.set_buffer_base_address(0, 0);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_tx_rx_buffer_base_address(0, 0).await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_write_buffer() {
+    let payload = b"hello reference driver";
+    let mut reference = reference();
+    reference.write_buffer(0, payload);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_payload(payload).await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_set_tx() {
+    let mut reference = reference();
+    reference.set_tx(0);
+    let mut sx1261 = get_sx126x();
+    sx1261.do_tx().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_dio_irq_params() {
+    // Transmit mode masks: TxDone | RxTxTimeout
+    let mask = 0x0201;
+    let mut reference = reference();
+    reference.set_dio_irq_params(mask, mask, 0, 0);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_irq_params(Some(RadioMode::Transmit)).await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_clear_irq_status() {
+    let mut reference = reference();
+    reference.clear_irq_status(0xFFFF);
+    let mut sx1261 = get_sx126x();
+    sx1261.clear_irq_status().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
 }
 
 const TEST_FREQ_HZ: u32 = 903_900_000;

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -559,3 +559,47 @@ async fn test_init_lora_composed() {
 
     assert_eq!(sx1261.take_spi().writes(), reference_radio.inner.writes());
 }
+
+#[tokio::test]
+async fn test_emulated_cad_end_to_end() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1261(&chip), true, Delayer).await.unwrap();
+
+    // Quiet channel
+    let mdltn_params = modulation(&mut lora);
+    lora.prepare_for_cad(&mdltn_params).await.unwrap();
+    assert!(!lora.cad(&mdltn_params).await.unwrap());
+
+    // Busy channel
+    chip.with_model(|m| m.cad_activity = true);
+    lora.prepare_for_cad(&mdltn_params).await.unwrap();
+    assert!(lora.cad(&mdltn_params).await.unwrap());
+}
+
+#[tokio::test]
+async fn test_emulated_rx_single_timeout() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1261(&chip), true, Delayer).await.unwrap();
+
+    // Nothing injected: single-mode reception must surface ReceiveTimeout
+    // (the model collapses the symbol-timeout wait to zero)
+    let mdltn_params = modulation(&mut lora);
+    let rx_pkt_params = lora
+        .create_rx_packet_params(8, false, 255, true, false, &mdltn_params)
+        .unwrap();
+    lora.prepare_for_rx(RxMode::Single(8), &mdltn_params, &rx_pkt_params)
+        .await
+        .unwrap();
+
+    let mut buf = [0u8; 255];
+    let result = lora.rx(&rx_pkt_params, &mut buf).await;
+    assert!(matches!(result, Err(crate::mod_params::RadioError::ReceiveTimeout)));
+
+    // The same radio still receives fine afterwards
+    lora.prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params)
+        .await
+        .unwrap();
+    chip.inject_rx(b"after-timeout", -90, 2);
+    let (len, _) = lora.rx(&rx_pkt_params, &mut buf).await.unwrap();
+    assert_eq!(&buf[..len as usize], b"after-timeout");
+}

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -4,7 +4,7 @@
 mod emulator;
 mod fixtures;
 use emulator::{get_emulated_sx1261, Chip, Mode};
-use fixtures::{get_sx126x, Delayer, TestFixture};
+use fixtures::{get_sx1262, get_sx126x, Delayer, TestFixture};
 
 use crate::mod_params::{RadioMode, RxMode};
 use crate::mod_traits::RadioKind;
@@ -12,8 +12,8 @@ use crate::LoRa;
 use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 use smtc_modem_cores::sx126x::{
     sx126x_cad_exit_modes_e, sx126x_cad_params_t, sx126x_cad_symbs_e, sx126x_lora_bw_e, sx126x_lora_cr_e,
-    sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t, sx126x_pkt_params_lora_t,
-    sx126x_standby_cfgs_e, Context, SleepCfg,
+    sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t, sx126x_pa_cfg_params_t,
+    sx126x_pkt_params_lora_t, sx126x_ramp_time_e, sx126x_standby_cfgs_e, Context, SleepCfg,
 };
 
 fn reference() -> Context<TestFixture> {
@@ -346,6 +346,97 @@ async fn test_tx_continuous_wave() {
     reference.set_tx_cw();
     let mut sx1261 = get_sx126x();
     sx1261.set_tx_continuous_wave_mode().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+/// Reference-side mirror of one row of datasheet Table 13-21 (PA Operating
+/// Modes with Optimal Settings): SetPaConfig values + the SetTxParams power
+/// the chip should be handed for a requested dBm. The table itself lives in
+/// our driver; SWL2001 leaves it to the BSP layer, so the C driver is fed
+/// these values and verifies the command encoding around them.
+fn reference_tx_power(
+    reference: &mut Context<TestFixture>,
+    pa_duty_cycle: u8,
+    hp_max: u8,
+    device_sel: u8,
+    tx_power: i8,
+    ramp: sx126x_ramp_time_e,
+) {
+    reference.set_pa_cfg(&sx126x_pa_cfg_params_t {
+        pa_duty_cycle,
+        hp_max,
+        device_sel,
+        pa_lut: 0x01,
+    });
+    reference.set_tx_params(tx_power, ramp);
+}
+
+#[tokio::test]
+async fn test_tx_power_sx1261() {
+    // (requested dBm, paDutyCycle, hpMax, SetTxParams power)
+    // -30 clamps to the low-power PA floor of -17
+    let cases = [
+        (15i32, 0x06u8, 0x00u8, 14i8),
+        (14, 0x04, 0x00, 14),
+        (10, 0x01, 0x00, 13),
+        (0, 0x01, 0x00, 3),
+        (-17, 0x01, 0x00, -14),
+        (-30, 0x01, 0x00, -14),
+    ];
+    for (dbm, duty, hp_max, tx_power) in cases {
+        let mut reference = reference();
+        reference_tx_power(
+            &mut reference,
+            duty,
+            hp_max,
+            1, // device_sel: SX1261
+            tx_power,
+            sx126x_ramp_time_e::SX126X_RAMP_40_US,
+        );
+        let mut sx1261 = get_sx126x();
+        sx1261.set_tx_power_and_ramp_time(dbm, None, true).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "{dbm} dBm");
+    }
+}
+
+#[tokio::test]
+async fn test_tx_power_sx1262() {
+    // The high-power path first applies the TX clamp workaround (datasheet
+    // §15.2), matching the reference's cfg_tx_clamp read-modify-write.
+    // 30 clamps to 22; 14 keeps txp per the STM32 reference driver (our
+    // driver's comment documents the datasheet table disagreement there).
+    let cases = [
+        (22i32, 0x04u8, 0x07u8, 22i8),
+        (30, 0x04, 0x07, 22),
+        (20, 0x03, 0x05, 22),
+        (17, 0x02, 0x03, 22),
+        (14, 0x02, 0x02, 14),
+        (-9, 0x02, 0x02, -9),
+    ];
+    for (dbm, duty, hp_max, tx_power) in cases {
+        let mut reference = reference();
+        reference.cfg_tx_clamp();
+        reference_tx_power(
+            &mut reference,
+            duty,
+            hp_max,
+            0, // device_sel: SX1262
+            tx_power,
+            sx126x_ramp_time_e::SX126X_RAMP_40_US,
+        );
+        let mut sx1262 = get_sx1262();
+        sx1262.set_tx_power_and_ramp_time(dbm, None, true).await.unwrap();
+        assert_eq!(sx1262.take_spi(), reference.inner, "{dbm} dBm");
+    }
+}
+
+#[tokio::test]
+async fn test_tx_power_init_ramp() {
+    // Outside TX prep (e.g. at init) the driver uses the slower 200 us ramp
+    let mut reference = reference();
+    reference_tx_power(&mut reference, 0x01, 0x00, 1, 3, sx126x_ramp_time_e::SX126X_RAMP_200_US);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_tx_power_and_ramp_time(0, None, false).await.unwrap();
     assert_eq!(sx1261.take_spi(), reference.inner);
 }
 

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -232,6 +232,123 @@ async fn test_do_cad() {
     assert_eq!(sx1261.take_spi(), reference.inner);
 }
 
+#[tokio::test]
+async fn test_get_rx_payload() {
+    // Chip reports 4 bytes at offset 0. Ours reads a status byte our
+    // reference discards via a NOP write; wire streams are canonically equal.
+    let mut sx1261 = get_sx126x();
+    sx1261.spi_mut().prime_read(&[0x13], &[0x00, 4, 0]);
+    let mdltn_params = sx1261
+        .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, TEST_FREQ_HZ)
+        .unwrap();
+    let pkt_params = sx1261
+        .create_packet_params(8, false, 255, true, false, &mdltn_params)
+        .unwrap();
+    let mut buf = [0u8; 255];
+    let len = sx1261.get_rx_payload(&pkt_params, &mut buf).await.unwrap();
+    assert_eq!(len, 4);
+
+    let mut reference = reference();
+    let (_, rx_status) = reference.get_rx_buffer_status();
+    let mut c_buf = [0u8; 4];
+    reference.read_buffer(rx_status.buffer_start_pointer, &mut c_buf);
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_get_packet_status() {
+    // Raw chip bytes: rssi 160, snr 20, signal rssi 162
+    let mut sx1261 = get_sx126x();
+    sx1261.spi_mut().prime_read(&[0x14], &[0x00, 160, 20, 162]);
+    let pkt_status = sx1261.get_rx_packet_status().await.unwrap();
+
+    let mut fixture = TestFixture::new();
+    fixture.prime_read(&[0x14, 0x00], &[160, 20, 162]);
+    let mut reference = Context::new(fixture);
+    let (_, c_status) = reference.get_lora_pkt_status();
+
+    // Byte streams and the decoded values both match the reference
+    assert_eq!(sx1261.take_spi(), reference.inner);
+    assert_eq!(pkt_status.rssi, c_status.rssi_pkt_in_dbm as i16);
+    assert_eq!(pkt_status.snr, c_status.snr_pkt_in_db as i16);
+}
+
+#[tokio::test]
+async fn test_get_rssi() {
+    let mut sx1261 = get_sx126x();
+    sx1261.spi_mut().prime_read(&[0x15], &[0x00, 161]);
+    let rssi = sx1261.get_rssi().await.unwrap();
+
+    let mut fixture = TestFixture::new();
+    fixture.prime_read(&[0x15, 0x00], &[161]);
+    let mut reference = Context::new(fixture);
+    let (_, c_rssi) = reference.get_rssi_inst();
+
+    assert_eq!(sx1261.take_spi(), reference.inner);
+    assert_eq!(rssi, c_rssi);
+}
+
+#[tokio::test]
+async fn test_get_irq_status() {
+    use crate::mod_traits::IrqState;
+    let mut sx1261 = get_sx126x();
+    sx1261.spi_mut().prime_read(&[0x12], &[0x00, 0x00, 0x01]); // TxDone
+    let state = sx1261
+        .process_irq_event(RadioMode::Transmit, None, false)
+        .await
+        .unwrap();
+    assert!(matches!(state, Some(IrqState::Done)));
+
+    let mut fixture = TestFixture::new();
+    fixture.prime_read(&[0x12, 0x00], &[0x00, 0x01]);
+    let mut reference = Context::new(fixture);
+    let (_, c_irq) = reference.get_irq_status();
+
+    assert_eq!(sx1261.take_spi(), reference.inner);
+    assert_eq!(c_irq, 0x0001);
+}
+
+#[tokio::test]
+async fn test_ensure_ready_after_sleep() {
+    // Waking from sleep: ours writes GetStatus + NOP, the reference reads one
+    // status byte after GetStatus — same bytes on the wire
+    let mut sx1261 = get_sx126x();
+    sx1261.ensure_ready(RadioMode::Sleep).await.unwrap();
+
+    let mut reference = reference();
+    reference.get_status();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_calibrate_image() {
+    // Our band table follows datasheet Table 9-2. The reference's Hz helper
+    // (cal_img_in_mhz) computes ceil(band_end/4) instead, which lands one
+    // step short of the table for most bands (e.g. 928 MHz -> 0xE8 vs 0xE9),
+    // so compare against cal_img with the table bytes.
+    let cases = [
+        (903_900_000u32, 0xE1u8, 0xE9u8),
+        (868_100_000, 0xD7, 0xDB),
+        (433_000_000, 0x6B, 0x6F),
+    ];
+    for (freq_hz, f1, f2) in cases {
+        let mut reference = reference();
+        reference.cal_img(f1, f2);
+        let mut sx1261 = get_sx126x();
+        sx1261.calibrate_image(freq_hz).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "freq {freq_hz}");
+    }
+}
+
+#[tokio::test]
+async fn test_tx_continuous_wave() {
+    let mut reference = reference();
+    reference.set_tx_cw();
+    let mut sx1261 = get_sx126x();
+    sx1261.set_tx_continuous_wave_mode().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
 const TEST_FREQ_HZ: u32 = 903_900_000;
 
 fn modulation(lora: &mut LoRa<impl RadioKind, Delayer>) -> crate::mod_params::ModulationParams {

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -1,0 +1,25 @@
+//! Compare this driver's SPI byte stream against Semtech's reference driver
+//! (SWL2001, via the smtc-modem-cores bindings).
+mod fixtures;
+use fixtures::{get_sx126x, Delayer, TestFixture};
+
+use crate::mod_traits::RadioKind;
+use smtc_modem_cores::sx126x::{Context, SleepCfg};
+
+#[tokio::test]
+async fn test_sleep_cold_start() {
+    let mut smtc_sx126x = Context::new(TestFixture::new());
+    smtc_sx126x.set_sleep(SleepCfg::ColdStart);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_sleep(false, &mut Delayer).await.unwrap();
+    assert_eq!(sx1261.take_spi(), smtc_sx126x.inner);
+}
+
+#[tokio::test]
+async fn test_sleep_warm_start() {
+    let mut smtc_sx126x = Context::new(TestFixture::new());
+    smtc_sx126x.set_sleep(SleepCfg::WarmStart);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_sleep(true, &mut Delayer).await.unwrap();
+    assert_eq!(sx1261.take_spi(), smtc_sx126x.inner);
+}

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -11,8 +11,9 @@ use crate::mod_traits::RadioKind;
 use crate::LoRa;
 use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 use smtc_modem_cores::sx126x::{
-    sx126x_lora_bw_e, sx126x_lora_cr_e, sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t,
-    sx126x_pkt_params_lora_t, sx126x_standby_cfgs_e, Context, SleepCfg,
+    sx126x_cad_exit_modes_e, sx126x_cad_params_t, sx126x_cad_symbs_e, sx126x_lora_bw_e, sx126x_lora_cr_e,
+    sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t, sx126x_pkt_params_lora_t,
+    sx126x_standby_cfgs_e, Context, SleepCfg,
 };
 
 fn reference() -> Context<TestFixture> {
@@ -187,6 +188,47 @@ async fn test_clear_irq_status() {
     reference.clear_irq_status(0xFFFF);
     let mut sx1261 = get_sx126x();
     sx1261.clear_irq_status().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_do_rx() {
+    // (mode, symbol timeout the driver programs, SetRx timeout in rtc steps)
+    let cases = [
+        ("continuous", RxMode::Continuous, 0u8, 0xFFFFFF_u32),
+        ("single8", RxMode::Single(8), 8, 0),
+    ];
+    for (label, mode, symbs, rtc_timeout) in cases {
+        let mut reference = reference();
+        reference.stop_timer_on_preamble(true);
+        reference.set_lora_symb_nb_timeout(symbs);
+        reference.cfg_rx_boosted(true);
+        reference.set_rx_with_timeout_in_rtc_step(rtc_timeout);
+
+        let mut sx1261 = get_sx126x();
+        sx1261.do_rx(mode).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "{label}");
+    }
+}
+
+#[tokio::test]
+async fn test_do_cad() {
+    let mut reference = reference();
+    reference.cfg_rx_boosted(true);
+    reference.set_cad_params(&sx126x_cad_params_t {
+        cad_symb_nb: sx126x_cad_symbs_e::SX126X_CAD_08_SYMB,
+        cad_detect_peak: 7 + 13, // SF7 + 13, per Semtech's CAD application note
+        cad_detect_min: 10,
+        cad_exit_mode: sx126x_cad_exit_modes_e::SX126X_CAD_ONLY,
+        cad_timeout: 0,
+    });
+    reference.set_cad();
+
+    let mut sx1261 = get_sx126x();
+    let mdltn_params = sx1261
+        .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, TEST_FREQ_HZ)
+        .unwrap();
+    sx1261.do_cad(&mdltn_params).await.unwrap();
     assert_eq!(sx1261.take_spi(), reference.inner);
 }
 

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -407,9 +407,12 @@ async fn test_tx_power_sx1262() {
     // throughout: the 14 dBm-and-below rows keep PA config 0x02/0x02 and
     // interpolate SetTxParams from the +22 setpoint (txp + 8); the ST table
     // for that row belongs to the Stm32wl variant only.
+    // 21 interpolates within the +22 row (the old range code over-commanded
+    // 22 for a 21 dBm request)
     let cases = [
         (22i32, 0x04u8, 0x07u8, 22i8),
         (30, 0x04, 0x07, 22),
+        (21, 0x04, 0x07, 21),
         (20, 0x03, 0x05, 22),
         (17, 0x02, 0x03, 22),
         (14, 0x02, 0x02, 22),

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -1,9 +1,15 @@
 //! Compare this driver's SPI byte stream against Semtech's reference driver
-//! (SWL2001, via the smtc-modem-cores bindings).
+//! (SWL2001, via the smtc-modem-cores bindings), and run the full LoRa
+//! state machine against an emulated chip.
+mod emulator;
 mod fixtures;
+use emulator::{get_emulated_sx1261, Chip, Mode};
 use fixtures::{get_sx126x, Delayer, TestFixture};
 
+use crate::mod_params::RxMode;
 use crate::mod_traits::RadioKind;
+use crate::LoRa;
+use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 use smtc_modem_cores::sx126x::{Context, SleepCfg};
 
 #[tokio::test]
@@ -22,4 +28,87 @@ async fn test_sleep_warm_start() {
     let mut sx1261 = get_sx126x();
     sx1261.set_sleep(true, &mut Delayer).await.unwrap();
     assert_eq!(sx1261.take_spi(), smtc_sx126x.inner);
+}
+
+const TEST_FREQ_HZ: u32 = 903_900_000;
+
+fn modulation(lora: &mut LoRa<impl RadioKind, Delayer>) -> crate::mod_params::ModulationParams {
+    lora.create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, TEST_FREQ_HZ)
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_emulated_tx_end_to_end() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1261(&chip), true, Delayer).await.unwrap();
+
+    let mdltn_params = modulation(&mut lora);
+    let mut tx_pkt_params = lora
+        .create_tx_packet_params(8, false, true, false, &mdltn_params)
+        .unwrap();
+
+    let payload = b"hello lora";
+    lora.prepare_for_tx(&mdltn_params, &mut tx_pkt_params, 10, payload)
+        .await
+        .unwrap();
+    lora.tx().await.unwrap();
+
+    chip.with_model(|m| {
+        assert_eq!(m.tx_log.len(), 1);
+        assert_eq!(m.tx_log[0].payload, payload);
+        assert_eq!(m.mode, Mode::Standby);
+
+        // Frequency round-trips through the chip's PLL-step encoding
+        let hz = (m.tx_log[0].frequency_raw as u64 * 32_000_000) >> 25;
+        assert!((hz as i64 - TEST_FREQ_HZ as i64).abs() <= 1, "freq {hz}");
+
+        // LoRa public network sync word 0x34 lands in register 0x0740 as 0x34 0x44
+        assert_eq!(m.registers[&0x0740], 0x34);
+        assert_eq!(m.registers[&0x0741], 0x44);
+    });
+}
+
+#[tokio::test]
+async fn test_emulated_rx_end_to_end() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1261(&chip), true, Delayer).await.unwrap();
+
+    let mdltn_params = modulation(&mut lora);
+    let rx_pkt_params = lora
+        .create_rx_packet_params(8, false, 255, true, false, &mdltn_params)
+        .unwrap();
+    lora.prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params)
+        .await
+        .unwrap();
+
+    chip.inject_rx(b"ping", -80, 5);
+
+    let mut buf = [0u8; 255];
+    let (len, status) = lora.rx(&rx_pkt_params, &mut buf).await.unwrap();
+    assert_eq!(&buf[..len as usize], b"ping");
+    assert_eq!(status.rssi, -80);
+    assert_eq!(status.snr, 5);
+}
+
+#[tokio::test]
+async fn test_emulated_sleep_and_wake() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1261(&chip), true, Delayer).await.unwrap();
+
+    lora.sleep(true).await.unwrap();
+    chip.with_model(|m| assert_eq!(m.mode, Mode::Sleep));
+
+    // Wake back up into a working tx
+    let mdltn_params = modulation(&mut lora);
+    let mut tx_pkt_params = lora
+        .create_tx_packet_params(8, false, true, false, &mdltn_params)
+        .unwrap();
+    lora.prepare_for_tx(&mdltn_params, &mut tx_pkt_params, 10, b"wake")
+        .await
+        .unwrap();
+    lora.tx().await.unwrap();
+    chip.with_model(|m| {
+        assert_eq!(m.tx_log.len(), 1);
+        assert_eq!(m.tx_log[0].payload, b"wake");
+    });
 }

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -13,7 +13,7 @@ use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 use smtc_modem_cores::sx126x::{
     sx126x_cad_exit_modes_e, sx126x_cad_params_t, sx126x_cad_symbs_e, sx126x_lora_bw_e, sx126x_lora_cr_e,
     sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t, sx126x_pa_cfg_params_t,
-    sx126x_pkt_params_lora_t, sx126x_ramp_time_e, sx126x_standby_cfgs_e, Context, SleepCfg,
+    sx126x_pkt_params_lora_t, sx126x_pkt_types_e, sx126x_ramp_time_e, sx126x_standby_cfgs_e, Context, SleepCfg,
 };
 
 fn reference() -> Context<TestFixture> {
@@ -521,4 +521,41 @@ async fn test_emulated_sleep_and_wake() {
         assert_eq!(m.tx_log.len(), 1);
         assert_eq!(m.tx_log[0].payload, b"wake");
     });
+}
+
+#[tokio::test]
+async fn test_init_lora_composed() {
+    // The whole init_lora sequence against the reference calls chained in
+    // the same order. Writes-only comparison, same as the single sync-word
+    // test: the C sync word setter is a read-modify-write where ours writes
+    // the known reset-derived values directly, so the read halves differ by
+    // design (primed with the reset values, the write halves converge).
+    const RETENTION_READ: [u8; 4] = [0x1D, 0x02, 0x9F, 0x00];
+    const RETENTION_AFTER_RX_GAIN: [u8; 9] = [1, 0x08, 0xAC, 0, 0, 0, 0, 0, 0];
+
+    let mut reference_radio = reference();
+    reference_radio.set_dio2_as_rf_sw_ctrl(true);
+    reference_radio.set_pkt_type(sx126x_pkt_types_e::SX126X_PKT_TYPE_LORA);
+    reference_radio
+        .inner
+        .prime_read(&[0x1D, 0x07, 0x40, 0x00], &[0x14, 0x24]);
+    reference_radio.set_lora_sync_word(0x34);
+    reference_radio.set_buffer_base_address(0, 0);
+    // Retention list, mirroring ours' one-register-at-a-time factoring; the
+    // queued second response lets the second add see the first (the batch
+    // form add_registers_to_retention_list(&[both]) would collapse this to
+    // one read + one write — a different transaction count by design)
+    reference_radio.inner.prime_read(&RETENTION_READ, &[0u8; 9]);
+    reference_radio.add_registers_to_retention_list(&[0x08AC]);
+    reference_radio
+        .inner
+        .prime_read(&RETENTION_READ, &RETENTION_AFTER_RX_GAIN);
+    reference_radio.add_registers_to_retention_list(&[0x0889]);
+
+    let mut sx1261 = get_sx126x();
+    sx1261.spi_mut().prime_read(&RETENTION_READ, &[0u8; 9]);
+    sx1261.spi_mut().prime_read(&RETENTION_READ, &RETENTION_AFTER_RX_GAIN);
+    sx1261.init_lora(0x34).await.unwrap();
+
+    assert_eq!(sx1261.take_spi().writes(), reference_radio.inner.writes());
 }

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -650,3 +650,66 @@ async fn test_tx_power_stm32wl() {
         assert_eq!(radio.take_spi(), reference.inner, "{dbm} dBm");
     }
 }
+
+/// Pin every `OpCode` discriminant to Semtech's SWL2001 command values
+/// (`sx126x_commands_e`, SWL2001 sx126x_driver/src/sx126x.c). The driver
+/// builds every SPI command from this enum and the emulator dispatches on
+/// it, so a wrong byte here silently talks to the wrong command on real
+/// hardware. The transaction-comparison tests above only pin the opcodes
+/// their flows exercise; this pins all of them in one place. The vendor
+/// values are transcribed independently of the driver enum, so a typo in
+/// either side won't match the other.
+#[test]
+fn opcodes_match_swl2001() {
+    use crate::sx126x::radio_kind_params::OpCode;
+    // (name, our driver's byte, SWL2001's byte)
+    let cases: &[(&str, u8, u8)] = &[
+        ("GetStatus", OpCode::GetStatus as u8, 0xC0),
+        ("WriteRegister", OpCode::WriteRegister as u8, 0x0D),
+        ("ReadRegister", OpCode::ReadRegister as u8, 0x1D),
+        ("WriteBuffer", OpCode::WriteBuffer as u8, 0x0E),
+        ("ReadBuffer", OpCode::ReadBuffer as u8, 0x1E),
+        ("SetSleep", OpCode::SetSleep as u8, 0x84),
+        ("SetStandby", OpCode::SetStandby as u8, 0x80),
+        ("SetFS", OpCode::SetFS as u8, 0xC1),
+        ("SetTx", OpCode::SetTx as u8, 0x83),
+        ("SetRx", OpCode::SetRx as u8, 0x82),
+        ("SetRxDutyCycle", OpCode::SetRxDutyCycle as u8, 0x94),
+        ("SetCAD", OpCode::SetCAD as u8, 0xC5),
+        ("SetTxContinuousWave", OpCode::SetTxContinuousWave as u8, 0xD1),
+        ("SetTxContinuousPremable", OpCode::SetTxContinuousPremable as u8, 0xD2),
+        ("SetPacketType", OpCode::SetPacketType as u8, 0x8A),
+        ("GetPacketType", OpCode::GetPacketType as u8, 0x11),
+        ("SetRFFrequency", OpCode::SetRFFrequency as u8, 0x86),
+        ("SetTxParams", OpCode::SetTxParams as u8, 0x8E),
+        ("SetPAConfig", OpCode::SetPAConfig as u8, 0x95),
+        ("SetCADParams", OpCode::SetCADParams as u8, 0x88),
+        ("SetBufferBaseAddress", OpCode::SetBufferBaseAddress as u8, 0x8F),
+        ("SetModulationParams", OpCode::SetModulationParams as u8, 0x8B),
+        ("SetPacketParams", OpCode::SetPacketParams as u8, 0x8C),
+        ("GetRxBufferStatus", OpCode::GetRxBufferStatus as u8, 0x13),
+        ("GetPacketStatus", OpCode::GetPacketStatus as u8, 0x14),
+        ("GetRSSIInst", OpCode::GetRSSIInst as u8, 0x15),
+        ("GetStats", OpCode::GetStats as u8, 0x10),
+        ("ResetStats", OpCode::ResetStats as u8, 0x00),
+        ("CfgDIOIrq", OpCode::CfgDIOIrq as u8, 0x08),
+        ("GetIrqStatus", OpCode::GetIrqStatus as u8, 0x12),
+        ("ClrIrqStatus", OpCode::ClrIrqStatus as u8, 0x02),
+        ("Calibrate", OpCode::Calibrate as u8, 0x89),
+        ("CalibrateImage", OpCode::CalibrateImage as u8, 0x98),
+        ("SetRegulatorMode", OpCode::SetRegulatorMode as u8, 0x96),
+        ("GetDeviceErrors", OpCode::GetDeviceErrors as u8, 0x17),
+        ("ClearDeviceErrors", OpCode::ClearDeviceErrors as u8, 0x07),
+        ("SetTCXOMode", OpCode::SetTCXOMode as u8, 0x97),
+        ("SetTxFallbackMode", OpCode::SetTxFallbackMode as u8, 0x93),
+        ("SetDIO2AsRfSwitchCtrl", OpCode::SetDIO2AsRfSwitchCtrl as u8, 0x9D),
+        ("SetStopRxTimerOnPreamble", OpCode::SetStopRxTimerOnPreamble as u8, 0x9F),
+        ("SetLoRaSymbTimeout", OpCode::SetLoRaSymbTimeout as u8, 0xA0),
+    ];
+    for (name, driver, vendor) in cases {
+        assert_eq!(
+            driver, vendor,
+            "OpCode::{name} = {driver:#04x}, SWL2001 = {vendor:#04x}"
+        );
+    }
+}

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -403,15 +403,17 @@ async fn test_tx_power_sx1261() {
 async fn test_tx_power_sx1262() {
     // The high-power path first applies the TX clamp workaround (datasheet
     // §15.2), matching the reference's cfg_tx_clamp read-modify-write.
-    // 30 clamps to 22; 14 keeps txp per the STM32 reference driver (our
-    // driver's comment documents the datasheet table disagreement there).
+    // 30 clamps to 22. The discrete SX1262 takes datasheet Table 13-21
+    // throughout: the 14 dBm-and-below rows keep PA config 0x02/0x02 and
+    // interpolate SetTxParams from the +22 setpoint (txp + 8); the ST table
+    // for that row belongs to the Stm32wl variant only.
     let cases = [
         (22i32, 0x04u8, 0x07u8, 22i8),
         (30, 0x04, 0x07, 22),
         (20, 0x03, 0x05, 22),
         (17, 0x02, 0x03, 22),
-        (14, 0x02, 0x02, 14),
-        (-9, 0x02, 0x02, -9),
+        (14, 0x02, 0x02, 22),
+        (-9, 0x02, 0x02, -1),
     ];
     for (dbm, duty, hp_max, tx_power) in cases {
         let mut reference = reference();
@@ -602,4 +604,46 @@ async fn test_emulated_rx_single_timeout() {
     chip.inject_rx(b"after-timeout", -90, 2);
     let (len, _) = lora.rx(&rx_pkt_params, &mut buf).await.unwrap();
     assert_eq!(&buf[..len as usize], b"after-timeout");
+}
+
+#[tokio::test]
+async fn test_tx_power_stm32wl() {
+    // The Stm32wl variant takes ST's table: identical to the datasheet on
+    // every row except 14 dBm and below, where ST commands the target dBm
+    // directly with the same 0x02/0x02 PA config (STM32CubeWL
+    // SUBGRF_SetTxParams). Each part uses the table it was characterized
+    // with — the STM32WL is an SX126x die integrated into ST's package.
+    use crate::sx126x::Stm32wl;
+    let cases = [
+        (22i32, 0x04u8, 0x07u8, 22i8),
+        (17, 0x02, 0x03, 22),
+        (14, 0x02, 0x02, 14),
+        (-9, 0x02, 0x02, -9),
+    ];
+    for (dbm, duty, hp_max, tx_power) in cases {
+        let mut reference = reference();
+        reference.cfg_tx_clamp();
+        reference_tx_power(
+            &mut reference,
+            duty,
+            hp_max,
+            0, // device_sel: high-power PA
+            tx_power,
+            sx126x_ramp_time_e::SX126X_RAMP_40_US,
+        );
+        let mut radio = crate::sx126x::Sx126x::new(
+            fixtures::TestFixture::new(),
+            fixtures::DummyVariant,
+            crate::sx126x::Config {
+                chip: Stm32wl {
+                    use_high_power_pa: true,
+                },
+                tcxo_ctrl: None,
+                use_dcdc: false,
+                rx_boost: true,
+            },
+        );
+        radio.set_tx_power_and_ramp_time(dbm, None, true).await.unwrap();
+        assert_eq!(radio.take_spi(), reference.inner, "{dbm} dBm");
+    }
 }

--- a/lora-phy/src/sx126x/variant.rs
+++ b/lora-phy/src/sx126x/variant.rs
@@ -1,5 +1,138 @@
 use super::DeviceSel;
 
+/// One row of a PA power table: the SetPaConfig values for a band of output
+/// powers, anchored at the row's highest power. Requests below the anchor
+/// interpolate by lowering SetTxParams one-for-one, per the datasheet's
+/// guidance for powers between the optimal settings.
+#[derive(Clone, Copy, Debug)]
+pub struct PaTableEntry {
+    /// Highest output power this row covers [dBm]
+    pub max_dbm: i8,
+    /// SetPaConfig paDutyCycle for this row
+    pub pa_duty_cycle: u8,
+    /// SetPaConfig hpMax for this row (0 on the low-power PA)
+    pub hp_max: u8,
+    /// SetTxParams power commanded at `max_dbm`; lower targets within the
+    /// row subtract the shortfall
+    pub tx_params_at_max: i8,
+}
+
+/// A PA power table: rows sorted by ascending `max_dbm`; requests clamp to
+/// `[min_dbm, last row's max_dbm]`. `&'static` tables live in flash — no RAM.
+#[derive(Debug)]
+pub struct PaTable {
+    /// Lowest supported output power [dBm]
+    pub min_dbm: i8,
+    /// Rows sorted by ascending `max_dbm`; must be non-empty
+    pub entries: &'static [PaTableEntry],
+}
+
+impl PaTable {
+    /// The row covering `dbm` (clamped) and the SetTxParams power for it
+    pub(crate) fn lookup(&self, dbm: i32) -> (&PaTableEntry, u8) {
+        let max = self.entries[self.entries.len() - 1].max_dbm;
+        let txp = dbm.clamp(self.min_dbm as i32, max as i32) as i8;
+        let entry = self
+            .entries
+            .iter()
+            .find(|e| e.max_dbm >= txp)
+            .unwrap_or(&self.entries[self.entries.len() - 1]);
+        (entry, (entry.tx_params_at_max - (entry.max_dbm - txp)) as u8)
+    }
+}
+
+/// SX1261 low-power PA rows from datasheet Table 13-21 (+15/+14/+10 dBm)
+pub const SX1261_PA_TABLE: PaTable = PaTable {
+    min_dbm: -17,
+    entries: &[
+        PaTableEntry {
+            max_dbm: 10,
+            pa_duty_cycle: 0x01,
+            hp_max: 0x00,
+            tx_params_at_max: 13,
+        },
+        PaTableEntry {
+            max_dbm: 14,
+            pa_duty_cycle: 0x04,
+            hp_max: 0x00,
+            tx_params_at_max: 14,
+        },
+        PaTableEntry {
+            max_dbm: 15,
+            pa_duty_cycle: 0x06,
+            hp_max: 0x00,
+            tx_params_at_max: 14,
+        },
+    ],
+};
+
+/// SX1262 high-power PA rows from datasheet Table 13-21 (+22/+20/+17/+14 dBm);
+/// every row commands SetTxParams +22 at its anchor
+pub const SX1262_PA_TABLE: PaTable = PaTable {
+    min_dbm: -9,
+    entries: &[
+        PaTableEntry {
+            max_dbm: 14,
+            pa_duty_cycle: 0x02,
+            hp_max: 0x02,
+            tx_params_at_max: 22,
+        },
+        PaTableEntry {
+            max_dbm: 17,
+            pa_duty_cycle: 0x02,
+            hp_max: 0x03,
+            tx_params_at_max: 22,
+        },
+        PaTableEntry {
+            max_dbm: 20,
+            pa_duty_cycle: 0x03,
+            hp_max: 0x05,
+            tx_params_at_max: 22,
+        },
+        PaTableEntry {
+            max_dbm: 22,
+            pa_duty_cycle: 0x04,
+            hp_max: 0x07,
+            tx_params_at_max: 22,
+        },
+    ],
+};
+
+/// ST's high-power table for the STM32WL (an SX126x die integrated into
+/// ST's package, characterized by ST in STM32CubeWL). Identical to
+/// [`SX1262_PA_TABLE`] except the 14 dBm-and-below row, where ST commands
+/// the target dBm directly instead of interpolating from +22.
+/// <https://github.com/STMicroelectronics/STM32CubeWL/blob/139e8d28bcec6af78dec8b52a9b9f9057868cc2e/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L675>
+pub const STM32WL_HP_PA_TABLE: PaTable = PaTable {
+    min_dbm: -9,
+    entries: &[
+        PaTableEntry {
+            max_dbm: 14,
+            pa_duty_cycle: 0x02,
+            hp_max: 0x02,
+            tx_params_at_max: 14,
+        },
+        PaTableEntry {
+            max_dbm: 17,
+            pa_duty_cycle: 0x02,
+            hp_max: 0x03,
+            tx_params_at_max: 22,
+        },
+        PaTableEntry {
+            max_dbm: 20,
+            pa_duty_cycle: 0x03,
+            hp_max: 0x05,
+            tx_params_at_max: 22,
+        },
+        PaTableEntry {
+            max_dbm: 22,
+            pa_duty_cycle: 0x04,
+            hp_max: 0x07,
+            tx_params_at_max: 22,
+        },
+    ],
+};
+
 /// Implement this trait on your custom variant or use provided impls
 pub trait Sx126xVariant {
     /// whether to use high or low power PA
@@ -10,14 +143,15 @@ pub trait Sx126xVariant {
         true
     }
 
-    /// Use ST's power table instead of the SX126x datasheet's. The STM32WL
-    /// is an SX126x die integrated into ST's package, characterized by ST
-    /// with its own table; discrete Semtech parts take the datasheet table
-    /// (Table 13-21). The two differ only in the high-power PA's 14 dBm-and-
-    /// below row: same PA config, but ST commands the target dBm directly
-    /// where the datasheet interpolates from a +22 setpoint.
-    fn use_st_power_table(&self) -> bool {
-        false
+    /// The PA power table for this variant. Defaults to the SX126x datasheet
+    /// tables (Table 13-21) for the selected PA. Boards with their own PA
+    /// characterization (e.g. the STM32WL) return a different `&'static`
+    /// table — compile-time data, no RAM cost.
+    fn pa_table(&self) -> &'static PaTable {
+        match self.get_device_sel() {
+            DeviceSel::LowPowerPA => &SX1261_PA_TABLE,
+            DeviceSel::HighPowerPA => &SX1262_PA_TABLE,
+        }
     }
 }
 
@@ -54,7 +188,11 @@ impl Sx126xVariant for Stm32wl {
     fn use_dio2_as_rfswitch(&self) -> bool {
         false
     }
-    fn use_st_power_table(&self) -> bool {
-        true
+    fn pa_table(&self) -> &'static PaTable {
+        if self.use_high_power_pa {
+            &STM32WL_HP_PA_TABLE
+        } else {
+            &SX1261_PA_TABLE
+        }
     }
 }

--- a/lora-phy/src/sx126x/variant.rs
+++ b/lora-phy/src/sx126x/variant.rs
@@ -9,6 +9,16 @@ pub trait Sx126xVariant {
     fn use_dio2_as_rfswitch(&self) -> bool {
         true
     }
+
+    /// Use ST's power table instead of the SX126x datasheet's. The STM32WL
+    /// is an SX126x die integrated into ST's package, characterized by ST
+    /// with its own table; discrete Semtech parts take the datasheet table
+    /// (Table 13-21). The two differ only in the high-power PA's 14 dBm-and-
+    /// below row: same PA config, but ST commands the target dBm directly
+    /// where the datasheet interpolates from a +22 setpoint.
+    fn use_st_power_table(&self) -> bool {
+        false
+    }
 }
 
 /// Sx1261 uses only LowPowerPA
@@ -43,5 +53,8 @@ impl Sx126xVariant for Stm32wl {
     }
     fn use_dio2_as_rfswitch(&self) -> bool {
         false
+    }
+    fn use_st_power_table(&self) -> bool {
+        true
     }
 }

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -25,20 +25,16 @@ const SX1276_RSSI_OFFSET_LF: i16 = -164;
 const SX1276_RSSI_OFFSET_HF: i16 = -157;
 const SX1276_RF_MID_BAND_THRESH: u32 = 525_000_000;
 
-// Frequency synthesizer step for frequency calculation (Hz)
-// FXOSC (32 MHz) * 1000000 (Hz/MHz) / 524288 (2^19)
-const SCALE: u32 = 8;
-const STEP_SCALED: u32 = 32_000_000 >> (19 - SCALE);
-
+// Frequency synthesizer step: FXOSC (32 MHz) / 524288 (2^19) = 61.03515625 Hz
 fn freq_to_pll_step(freq_in_hz: u32) -> u32 {
-    // We can use simplified integer formula which gives the same
-    // value for whole and half Mhz values ((i.e. 868.0, 868.5, 869, ...)
-    // `(freq_in_hz as f64 / 61.03515625) as u32`
-    (freq_in_hz / STEP_SCALED) << SCALE
+    // Full-precision integer form of freq / 61.03515625. The previous
+    // truncate-then-shift shortcut zeroed the low 8 pll-step bits, putting
+    // fractional-MHz channels (868.1, 903.9, ...) up to ~15 kHz off.
+    (((freq_in_hz as u64) << 19) / 32_000_000) as u32
 }
 
 fn pll_step_to_freq(pll_step: u32) -> u32 {
-    (pll_step >> SCALE) * STEP_SCALED
+    (((pll_step as u64) * 32_000_000) >> 19) as u32
 }
 
 // RSSI requires linearization when SNR >= 0
@@ -123,6 +119,16 @@ where
     // Set the over current protection (mA) on the radio
     async fn set_ocp(&mut self, ocp_trim: OcpTrim) -> Result<(), RadioError> {
         self.write_register(Register::RegOcp, ocp_trim.value()).await
+    }
+
+    #[cfg(test)]
+    fn take_spi(self) -> SPI {
+        self.intf.spi
+    }
+
+    #[cfg(test)]
+    fn spi_mut(&mut self) -> &mut SPI {
+        &mut self.intf.spi
     }
 }
 
@@ -279,8 +285,8 @@ where
             _ => (0x03, 0x0a),
         };
         let reg_val = self.read_register(Register::RegDetectionOptimize).await?;
-        // Keep reserved bits [6:3] for RegDetectOptimize
-        let val = (reg_val & 0b0111_1000) | opt;
+        // Keep AutomaticIFOn [7] (errata 2.3) and reserved bits [6:3]
+        let val = (reg_val & 0b1111_1000) | opt;
         self.write_register(Register::RegDetectionOptimize, val).await?;
         self.write_register(Register::RegDetectionThreshold, thr).await?;
         // Spreading Factor, Bandwidth, codingrate, ldro
@@ -413,10 +419,13 @@ where
 
             let rssi_offset = C::rssi_offset(self).await?;
 
+            // Section 5.5.5: the 16/15 linearization applies to the raw
+            // packet RSSI in both branches (the reference driver and
+            // LoRaMac-node agree; only the negative-SNR term differs)
             if snr >= 0 {
                 rssi_offset + linearize_rssi(packet_rssi)
             } else {
-                rssi_offset + (packet_rssi as i16) + snr
+                rssi_offset + linearize_rssi(packet_rssi) + snr
             }
         };
 

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -3,6 +3,8 @@ mod sx1272;
 pub use sx1272::Sx1272;
 mod sx1276;
 pub use sx1276::Sx1276;
+#[cfg(test)]
+mod test;
 
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::*;

--- a/lora-phy/src/sx127x/radio_kind_params.rs
+++ b/lora-phy/src/sx127x/radio_kind_params.rs
@@ -182,6 +182,8 @@ pub enum Register {
     RegFreqErrorMid = 0x29,
     RegFreqErrorLsb = 0x2a,
     RegRssiWideband = 0x2c,
+    RegIfFreq1 = 0x2f,
+    RegIfFreq2 = 0x30,
     RegDetectionOptimize = 0x31,
     RegInvertiq = 0x33,
     RegHighBwOptimize1 = 0x36,

--- a/lora-phy/src/sx127x/sx1276.rs
+++ b/lora-phy/src/sx127x/sx1276.rs
@@ -63,8 +63,11 @@ impl Sx127xVariant for Sx1276 {
             // Output via PA_BOOST: [2, 20] dBm
             let txp = p_out.clamp(2, 20);
 
-            // Pout=17-(15-OutputPower)
-            let output_power: i32 = txp - 2;
+            // PaDac off: Pout = 2 + OutputPower; PaDac on: Pout = 5 + OutputPower.
+            // The pre-fix code used txp - 2 in both branches, so 18..20 dBm
+            // requests overflowed the 4-bit OutputPower field (20 dBm wrote
+            // OutputPower 2 and bled a bit into MaxPower).
+            let output_power: i32 = if txp > 17 { txp - 5 } else { txp - 2 };
 
             if txp > 17 {
                 radio.write_register(pa_reg, PaDac::_20DbmOn.value()).await?;
@@ -80,17 +83,22 @@ impl Sx127xVariant for Sx1276 {
             // Clamp output: [-4, 14] dBm
             let txp = p_out.clamp(-4, 14);
 
-            // Pmax=10.8+0.6*MaxPower, where MaxPower is set below as 7 and therefore Pmax is 15
-            // Pout=Pmax-(15-OutputPower)
-            let output_power: i32 = txp;
+            // Pout = Pmax - (15 - OutputPower) with Pmax = 10.8 + 0.6 * MaxPower.
+            // Positive targets use MaxPower=7 (Pmax 15) so Pout = OutputPower;
+            // 0 dBm and below drop to MaxPower=0 (Pmax 10.8) so OutputPower =
+            // txp + 4 stays in the 4-bit field. The pre-fix code kept
+            // MaxPower=7 for negative targets, casting a negative OutputPower
+            // to u8 and corrupting the register (PA_BOOST bit included).
+            let (max_power, output_power) = if txp > 0 {
+                (PaConfig::MaxPower7NoPaBoost.value(), txp)
+            } else {
+                (0x00, txp + 4)
+            };
 
             radio.write_register(pa_reg, PaDac::_20DbmOff.value()).await?;
             radio.set_ocp(OcpTrim::_100Ma).await?;
             radio
-                .write_register(
-                    Register::RegPaConfig,
-                    PaConfig::MaxPower7NoPaBoost.value() | (output_power as u8),
-                )
+                .write_register(Register::RegPaConfig, max_power | (output_power as u8))
                 .await?;
         }
         Ok(())

--- a/lora-phy/src/sx127x/sx1276.rs
+++ b/lora-phy/src/sx127x/sx1276.rs
@@ -144,13 +144,16 @@ impl Sx127xVariant for Sx1276 {
 
             if mdltn_params.bandwidth == Bandwidth::_500KHz {
                 let val_1 = 0x02;
+                // Errata band edges are in Hz; these literals used to be in
+                // kHz, so no real frequency ever matched and the optimization
+                // values were never written
                 match mdltn_params.frequency_in_hz {
-                    862_000..=1_020_000 => {
+                    862_000_000..=1_020_000_000 => {
                         radio.write_register(Register::RegHighBwOptimize1, val_1).await?;
                         radio.write_register(Register::RegHighBwOptimize2, 0x64).await?;
                         return Ok(());
                     }
-                    410_000..=525_000 => {
+                    410_000_000..=525_000_000 => {
                         radio.write_register(Register::RegHighBwOptimize1, val_1).await?;
                         radio.write_register(Register::RegHighBwOptimize2, 0x7f).await?;
                         return Ok(());

--- a/lora-phy/src/sx127x/sx1276.rs
+++ b/lora-phy/src/sx127x/sx1276.rs
@@ -140,31 +140,44 @@ impl Sx127xVariant for Sx1276 {
         radio.write_register(Register::RegModemConfig3, config_3).await?;
 
         if radio.data.sensitivity_quirk {
-            // apply Errata 2.1: Sensitivity optimization with 500 kHz bandwidth
-
-            if mdltn_params.bandwidth == Bandwidth::_500KHz {
-                let val_1 = 0x02;
-                // Errata band edges are in Hz; these literals used to be in
-                // kHz, so no real frequency ever matched and the optimization
-                // values were never written
-                match mdltn_params.frequency_in_hz {
-                    862_000_000..=1_020_000_000 => {
-                        radio.write_register(Register::RegHighBwOptimize1, val_1).await?;
-                        radio.write_register(Register::RegHighBwOptimize2, 0x64).await?;
-                        return Ok(());
-                    }
-                    410_000_000..=525_000_000 => {
-                        radio.write_register(Register::RegHighBwOptimize1, val_1).await?;
-                        radio.write_register(Register::RegHighBwOptimize2, 0x7f).await?;
-                        return Ok(());
-                    }
-                    // fall through...
-                    _ => {}
-                }
+            // apply Errata 2.1: Sensitivity optimization with 500 kHz bandwidth.
+            // Errata band edges are in Hz; these literals used to be in kHz,
+            // so no real frequency ever matched and the optimization values
+            // were never written
+            let bw500_optimize = match (mdltn_params.bandwidth, mdltn_params.frequency_in_hz) {
+                (Bandwidth::_500KHz, 862_000_000..=1_020_000_000) => Some(0x64),
+                (Bandwidth::_500KHz, 410_000_000..=525_000_000) => Some(0x7f),
+                _ => None,
+            };
+            if let Some(val_2) = bw500_optimize {
+                radio.write_register(Register::RegHighBwOptimize1, 0x02).await?;
+                radio.write_register(Register::RegHighBwOptimize2, val_2).await?;
+            } else {
+                // for all other combinations of bandwidth / frequencies, reset to
+                // 0x03 (RegHighBwOptimize2 is automatically set by the chip)
+                radio.write_register(Register::RegHighBwOptimize1, 0x03).await?;
             }
+        }
 
-            // for all other combinations of bandwidth / frequencies, reset to 0x03 (RegHighBwOptimize2 is automatically set by the chip)
-            radio.write_register(Register::RegHighBwOptimize1, 0x03).await?;
+        // Errata 2.3: receiver spurious reception of a LoRa signal. At
+        // 500 kHz AutomaticIFOn stays set (reset default); other bandwidths
+        // need it cleared plus a manual IF of 0x40/0x00 in RegIfFreq1/2.
+        // The reference applies this on every SetRx; the registers only
+        // affect the receiver, so setting them with the modulation config
+        // is equivalent. Bandwidths below 62.5 kHz additionally require the
+        // RF frequency shifted up by one bandwidth, which set_channel owns —
+        // those keep chip defaults (as before this change).
+        let detect_optimize = radio.read_register(Register::RegDetectionOptimize).await?;
+        if mdltn_params.bandwidth == Bandwidth::_500KHz {
+            radio
+                .write_register(Register::RegDetectionOptimize, detect_optimize | 0x80)
+                .await?;
+        } else if mdltn_params.bandwidth.hz() >= 62_500 {
+            radio
+                .write_register(Register::RegDetectionOptimize, detect_optimize & 0x7f)
+                .await?;
+            radio.write_register(Register::RegIfFreq1, 0x40).await?;
+            radio.write_register(Register::RegIfFreq2, 0x00).await?;
         }
 
         Ok(())

--- a/lora-phy/src/sx127x/test/emulator.rs
+++ b/lora-phy/src/sx127x/test/emulator.rs
@@ -1,0 +1,337 @@
+//! A behavioral model of an sx127x chip with an *edge-triggered* DIO0 line.
+//!
+//! The register-file fixture compares final state, which is blind to IRQ
+//! lifecycle bugs: RegIrqFlags is write-1-to-clear with no auto-clear on
+//! mode changes (SX1276 DS §4.1.2.4), and the MCU's DIO0 interrupt is
+//! edge-triggered, so a stale flag holds the line high and a level-based
+//! model would wave the bug through. Here `await_irq` completes only on a
+//! 0→1 transition of the DIO0 level derived from RegIrqFlags, the IRQ mask
+//! and the DIO0 mapping — a stale flag means no edge, exactly like real
+//! hardware.
+//!
+//! The chip "runs" inside `await_irq`: in-flight operations complete (and
+//! raise their IRQs) only while the host is waiting on the line, so every
+//! completion produces an observable edge or an observable hang.
+use super::fixtures::RESET_VALUES;
+use crate::mod_params::RadioError;
+use crate::mod_traits::InterfaceVariant;
+use crate::sx127x::{Config, Sx1276, Sx127x};
+use crate::test_fixtures::SpiError;
+use embedded_hal::spi::Operation;
+use embedded_hal_async::delay::DelayNs;
+use embedded_hal_async::spi::SpiDevice;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::vec::Vec;
+
+const REG_FIFO: u8 = 0x00;
+const REG_OP_MODE: u8 = 0x01;
+const REG_FIFO_ADDR_PTR: u8 = 0x0D;
+const REG_FIFO_TX_BASE: u8 = 0x0E;
+const REG_FIFO_RX_BASE: u8 = 0x0F;
+const REG_FIFO_RX_CURRENT: u8 = 0x10;
+const REG_IRQ_FLAGS_MASK: u8 = 0x11;
+const REG_IRQ_FLAGS: u8 = 0x12;
+const REG_RX_NB_BYTES: u8 = 0x13;
+const REG_PKT_SNR: u8 = 0x19;
+const REG_PKT_RSSI: u8 = 0x1A;
+const REG_PAYLOAD_LENGTH: u8 = 0x22;
+const REG_DIO_MAPPING1: u8 = 0x40;
+
+const IRQ_RX_DONE: u8 = 0x40;
+const IRQ_TX_DONE: u8 = 0x08;
+const IRQ_CAD_DONE: u8 = 0x04;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Mode {
+    Sleep,
+    Standby,
+    Tx,
+    Rx,
+    Cad,
+    Other,
+}
+
+pub struct PendingRx {
+    pub payload: Vec<u8>,
+    pub rssi_raw: u8,
+    pub snr_db: i8,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TxRecord {
+    pub frequency_raw: u32,
+    pub payload: Vec<u8>,
+}
+
+pub struct ChipModel {
+    regs: HashMap<u8, u8>,
+    fifo: [u8; 256],
+    tx_in_flight: bool,
+    pending_rx: Option<PendingRx>,
+    pub tx_log: Vec<TxRecord>,
+}
+
+impl ChipModel {
+    fn new() -> Self {
+        Self {
+            regs: RESET_VALUES.iter().copied().collect(),
+            fifo: [0; 256],
+            tx_in_flight: false,
+            pending_rx: None,
+            tx_log: vec![],
+        }
+    }
+
+    fn reg(&self, address: u8) -> u8 {
+        *self.regs.get(&address).unwrap_or(&0)
+    }
+
+    pub fn mode(&self) -> Mode {
+        match self.reg(REG_OP_MODE) & 0x07 {
+            0 => Mode::Sleep,
+            1 => Mode::Standby,
+            3 => Mode::Tx,
+            5 | 6 => Mode::Rx,
+            7 => Mode::Cad,
+            _ => Mode::Other,
+        }
+    }
+
+    /// Latch an IRQ through the mask register (masked flags never appear)
+    fn raise_irq(&mut self, irq: u8) {
+        let flags = self.reg(REG_IRQ_FLAGS) | (irq & !self.reg(REG_IRQ_FLAGS_MASK));
+        self.regs.insert(REG_IRQ_FLAGS, flags);
+    }
+
+    /// The DIO0 pin level: the flag currently routed to DIO0 by
+    /// RegDioMapping1 bits 7:6 (00 RxDone, 01 TxDone, 10 CadDone)
+    fn dio0_level(&self) -> bool {
+        let flag = match self.reg(REG_DIO_MAPPING1) >> 6 {
+            0 => IRQ_RX_DONE,
+            1 => IRQ_TX_DONE,
+            2 => IRQ_CAD_DONE,
+            _ => return false,
+        };
+        self.reg(REG_IRQ_FLAGS) & flag != 0
+    }
+
+    fn deliver_rx(&mut self, rx: PendingRx) {
+        let base = self.reg(REG_FIFO_RX_BASE);
+        for (i, b) in rx.payload.iter().enumerate() {
+            self.fifo[base.wrapping_add(i as u8) as usize] = *b;
+        }
+        self.regs.insert(REG_RX_NB_BYTES, rx.payload.len() as u8);
+        self.regs.insert(REG_FIFO_RX_CURRENT, base);
+        self.regs.insert(REG_PKT_SNR, (rx.snr_db as i16 * 4) as u8);
+        self.regs.insert(REG_PKT_RSSI, rx.rssi_raw);
+        self.raise_irq(IRQ_RX_DONE);
+    }
+
+    /// Advance chip time: complete whatever operation is in flight. Runs
+    /// only while the host waits on the IRQ line, so completions are
+    /// observable as edges (or observably missing).
+    fn step(&mut self) {
+        if self.tx_in_flight {
+            self.tx_in_flight = false;
+            let base = self.reg(REG_FIFO_TX_BASE);
+            let len = self.reg(REG_PAYLOAD_LENGTH);
+            let payload = (0..len).map(|i| self.fifo[base.wrapping_add(i) as usize]).collect();
+            let frequency_raw =
+                ((self.reg(0x06) as u32) << 16) | ((self.reg(0x07) as u32) << 8) | self.reg(0x08) as u32;
+            self.tx_log.push(TxRecord { frequency_raw, payload });
+            // TX auto-returns to standby
+            let op_mode = (self.reg(REG_OP_MODE) & !0x07) | 0x01;
+            self.regs.insert(REG_OP_MODE, op_mode);
+            self.raise_irq(IRQ_TX_DONE);
+        } else if self.mode() == Mode::Rx {
+            if let Some(rx) = self.pending_rx.take() {
+                self.deliver_rx(rx);
+            }
+        }
+    }
+
+    fn write(&mut self, address: u8, value: u8) {
+        match address {
+            REG_FIFO => {
+                let ptr = self.reg(REG_FIFO_ADDR_PTR);
+                self.fifo[ptr as usize] = value;
+                self.regs.insert(REG_FIFO_ADDR_PTR, ptr.wrapping_add(1));
+            }
+            REG_IRQ_FLAGS => {
+                // write-1-to-clear
+                let flags = self.reg(REG_IRQ_FLAGS) & !value;
+                self.regs.insert(REG_IRQ_FLAGS, flags);
+            }
+            REG_OP_MODE => {
+                self.regs.insert(REG_OP_MODE, value);
+                if self.mode() == Mode::Tx {
+                    self.tx_in_flight = true;
+                }
+            }
+            _ => {
+                self.regs.insert(address, value);
+            }
+        }
+    }
+
+    fn read(&mut self, address: u8) -> u8 {
+        if address == REG_FIFO {
+            let ptr = self.reg(REG_FIFO_ADDR_PTR);
+            self.regs.insert(REG_FIFO_ADDR_PTR, ptr.wrapping_add(1));
+            self.fifo[ptr as usize]
+        } else {
+            self.reg(address)
+        }
+    }
+}
+
+/// Test handle to the chip shared by the fake SPI bus and IRQ lines.
+#[derive(Clone)]
+pub struct Chip(Arc<Mutex<ChipModel>>);
+
+impl Chip {
+    pub fn new() -> Self {
+        Chip(Arc::new(Mutex::new(ChipModel::new())))
+    }
+
+    /// A packet arrives over the air: delivered immediately if the chip is
+    /// receiving, otherwise held until it next enters RX (the chip acts on
+    /// its own clock — no SPI traffic is involved).
+    pub fn inject_rx(&self, payload: &[u8], rssi_raw: u8, snr_db: i8) {
+        let rx = PendingRx {
+            payload: payload.to_vec(),
+            rssi_raw,
+            snr_db,
+        };
+        self.with_model(|m| {
+            if m.mode() == Mode::Rx {
+                m.deliver_rx(rx);
+            } else {
+                m.pending_rx = Some(rx);
+            }
+        })
+    }
+
+    pub fn with_model<R>(&self, f: impl FnOnce(&mut ChipModel) -> R) -> R {
+        f(&mut self.0.lock().unwrap())
+    }
+}
+
+/// SPI bus wired to the chip model. sx127x transactions are an address byte
+/// (wnr in bit 7) followed by data bytes; bursts auto-increment except at
+/// the FIFO port, which the model handles in read/write.
+pub struct FakeSpi(pub Chip);
+
+impl embedded_hal::spi::ErrorType for FakeSpi {
+    type Error = SpiError;
+}
+
+impl SpiDevice<u8> for FakeSpi {
+    async fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        let mut cmd: Vec<u8> = Vec::new();
+        for op in operations.iter() {
+            if let Operation::Write(buf) = op {
+                cmd.extend_from_slice(buf);
+            }
+        }
+        assert!(!cmd.is_empty(), "sx127x transaction with no address byte");
+        let wnr = cmd[0] & 0x80 != 0;
+        let address = cmd[0] & 0x7F;
+        self.0.with_model(|m| {
+            if wnr {
+                for (i, b) in cmd[1..].iter().enumerate() {
+                    let addr = if address == REG_FIFO {
+                        address
+                    } else {
+                        address + i as u8
+                    };
+                    m.write(addr, *b);
+                }
+            } else {
+                let mut offset = 0u8;
+                for op in operations.iter_mut() {
+                    if let Operation::Read(buf) = op {
+                        for b in buf.iter_mut() {
+                            let addr = if address == REG_FIFO { address } else { address + offset };
+                            *b = m.read(addr);
+                            offset += 1;
+                        }
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+
+    async fn write(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        self.transaction(&mut [Operation::Write(buf)]).await
+    }
+
+    async fn read(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transfer(&mut self, _read: &mut [u8], _write: &[u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transfer_in_place(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+}
+
+/// IRQ/reset lines wired to the same chip model. `await_irq` is
+/// edge-triggered like a real MCU GPIO interrupt: it samples DIO0 when the
+/// wait is armed and completes only on a low→high transition. A flag
+/// already latched at arm time produces no edge — ever — which is the
+/// hardware failure mode stale-IRQ bugs cause.
+pub struct FakeIv(pub Chip);
+
+impl InterfaceVariant for FakeIv {
+    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
+        self.0.with_model(|m| *m = ChipModel::new());
+        Ok(())
+    }
+    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn await_irq(&mut self) -> Result<(), RadioError> {
+        let mut prev = self.0.with_model(|m| m.dio0_level());
+        for _ in 0..1000 {
+            let level = self.0.with_model(|m| {
+                m.step();
+                m.dio0_level()
+            });
+            if level && !prev {
+                return Ok(());
+            }
+            prev = level;
+            tokio::task::yield_now().await;
+        }
+        // No edge and nothing left that could produce one
+        Err(RadioError::Irq)
+    }
+    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+}
+
+pub fn get_emulated_sx1276(chip: &Chip) -> Sx127x<FakeSpi, FakeIv, Sx1276> {
+    Sx127x::new(
+        FakeSpi(chip.clone()),
+        FakeIv(chip.clone()),
+        Config {
+            chip: Sx1276,
+            tcxo_used: false,
+            tx_boost: false,
+            rx_boost: false,
+        },
+    )
+}

--- a/lora-phy/src/sx127x/test/fixtures.rs
+++ b/lora-phy/src/sx127x/test/fixtures.rs
@@ -1,0 +1,266 @@
+use crate::mod_params::RadioError;
+use crate::mod_traits::InterfaceVariant;
+use crate::sx127x::{Config, Sx1276, Sx127x};
+use embedded_hal::spi::{ErrorKind, Operation};
+use embedded_hal_async::delay::DelayNs;
+use embedded_hal_async::spi::SpiDevice;
+use std::collections::{BTreeMap, VecDeque};
+
+/// Register-file SPI fixture for the sx127x.
+///
+/// The sx127x is register-based and the two drivers legitimately factor
+/// their register traffic differently: the reference burst-writes runs of
+/// registers (`Frf` in one transaction, auto-increment) and reads registers
+/// back for read-modify-write where ours keeps shadow copies (and vice
+/// versa). Comparing raw transactions would fail on equivalent behavior, so
+/// this fixture *executes* the traffic against a small register file instead:
+/// writes update it (auto-incrementing across a burst), reads answer from it.
+///
+/// Equality compares chip-visible outcomes: the final register file, the
+/// byte stream written to the FIFO (address 0x00, no auto-increment), and
+/// the write-1-to-clear bits pushed at RegIrqFlags (kept out of the register
+/// file since writing 0xFF there clears flags rather than storing 0xFF).
+#[derive(Clone, Debug)]
+pub struct TestFixture {
+    regs: BTreeMap<u8, u8>,
+    pub fifo_written: Vec<u8>,
+    pub irq_flags_written: Vec<u8>,
+    fifo_read: VecDeque<u8>,
+}
+
+const REG_FIFO: u8 = 0x00;
+const REG_OP_MODE: u8 = 0x01;
+const REG_IRQ_FLAGS: u8 = 0x12;
+
+/// SX1276 power-on defaults (datasheet table 41) for every register either
+/// driver touches in the compared flows; both sides start from the same file.
+const RESET_VALUES: &[(u8, u8)] = &[
+    (0x01, 0x80), // RegOpMode: LoRa, sleep (both drivers enter LoRa mode from reset)
+    (0x06, 0x6C), // RegFrfMsb..Lsb: 434 MHz
+    (0x07, 0x80),
+    (0x08, 0x00),
+    (0x09, 0x4F), // RegPaConfig
+    (0x0A, 0x09), // RegPaRamp
+    (0x0B, 0x2B), // RegOcp
+    (0x0C, 0x20), // RegLna
+    (0x0D, 0x00), // RegFifoAddrPtr
+    (0x0E, 0x80), // RegFifoTxBaseAddr
+    (0x0F, 0x00), // RegFifoRxBaseAddr
+    (0x11, 0x00), // RegIrqFlagsMask
+    (0x1D, 0x72), // RegModemConfig1
+    (0x1E, 0x70), // RegModemConfig2
+    (0x1F, 0x64), // RegSymbTimeoutLsb
+    (0x20, 0x00), // RegPreambleMsb
+    (0x21, 0x08), // RegPreambleLsb
+    (0x22, 0x01), // RegPayloadLength
+    (0x26, 0x00), // RegModemConfig3
+    (0x31, 0xC3), // RegDetectionOptimize
+    (0x33, 0x27), // RegInvertiq
+    (0x37, 0x0A), // RegDetectionThreshold
+    (0x39, 0x12), // RegSyncWord
+    (0x3B, 0x1D), // RegInvertiq2
+    (0x40, 0x00), // RegDioMapping1
+    (0x41, 0x00), // RegDioMapping2
+    (0x42, 0x12), // RegVersion
+    (0x4D, 0x84), // RegPaDac (sx1276)
+];
+
+impl PartialEq for TestFixture {
+    fn eq(&self, other: &Self) -> bool {
+        // irq_flags_written is deliberately NOT compared: the reference
+        // driver clears IRQ flags at the chip only inside its DIO interrupt
+        // handlers (its public clear_irq_status is shadow-state only), so
+        // the W1C traffic has no C counterpart in these flows. Tests assert
+        // ours' clears explicitly where they matter.
+        self.regs == other.regs && self.fifo_written == other.fifo_written
+    }
+}
+impl Eq for TestFixture {}
+
+impl Default for TestFixture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestFixture {
+    pub fn new() -> Self {
+        Self {
+            regs: RESET_VALUES.iter().copied().collect(),
+            fifo_written: vec![],
+            irq_flags_written: vec![],
+            fifo_read: VecDeque::new(),
+        }
+    }
+
+    /// Override a register value (e.g. status registers before a read test)
+    pub fn set_reg(&mut self, address: u8, value: u8) {
+        self.regs.insert(address, value);
+    }
+
+    pub fn reg(&self, address: u8) -> u8 {
+        *self.regs.get(&address).unwrap_or(&0)
+    }
+
+    /// Queue bytes the FIFO will yield on reads
+    pub fn prime_fifo_read(&mut self, data: &[u8]) {
+        self.fifo_read.extend(data);
+    }
+
+    fn record(&mut self, operations: &mut [Operation<'_, u8>]) {
+        let mut cmd = Vec::new();
+        for op in operations.iter() {
+            if let Operation::Write(buf) = op {
+                cmd.extend_from_slice(buf)
+            }
+        }
+        let has_read = operations.iter().any(|op| matches!(op, Operation::Read(_)));
+        assert!(!cmd.is_empty(), "sx127x transaction with no address byte");
+        let wnr = cmd[0] & 0x80 != 0;
+        let address = cmd[0] & 0x7F;
+
+        if has_read {
+            assert!(!wnr, "read transaction with wnr bit set: {cmd:02x?}");
+            assert_eq!(cmd.len(), 1, "bytes written during a read: {cmd:02x?}");
+            let mut offset = 0u8;
+            for op in operations.iter_mut() {
+                if let Operation::Read(buf) = op {
+                    for b in buf.iter_mut() {
+                        *b = if address == REG_FIFO {
+                            self.fifo_read.pop_front().unwrap_or(0)
+                        } else {
+                            self.reg(address + offset)
+                        };
+                        offset += 1;
+                    }
+                }
+            }
+        } else {
+            assert!(wnr, "write transaction without wnr bit: {cmd:02x?}");
+            for (i, b) in cmd[1..].iter().enumerate() {
+                let mut b = *b;
+                if address == REG_FIFO {
+                    self.fifo_written.push(b);
+                    continue;
+                }
+                if address == REG_IRQ_FLAGS {
+                    self.irq_flags_written.push(b);
+                    continue;
+                }
+                if address + (i as u8) == REG_OP_MODE {
+                    // LongRangeMode is only writable while the device is in
+                    // sleep AND the same write keeps it there; otherwise the
+                    // chip ignores bit 7. SWL2001 writes mode-only values
+                    // (bit 7 clear) relying on this; our driver rewrites the
+                    // full byte. Both land on the same device state.
+                    let current = self.reg(REG_OP_MODE);
+                    let in_sleep = current & 0x07 == 0;
+                    let write_stays_in_sleep = b & 0x07 == 0;
+                    if !(in_sleep && write_stays_in_sleep) {
+                        b = (current & 0x80) | (b & 0x7F);
+                    }
+                }
+                self.regs.insert(address + i as u8, b);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {}
+impl embedded_hal::spi::Error for Error {
+    fn kind(&self) -> ErrorKind {
+        todo!()
+    }
+}
+impl embedded_hal::spi::ErrorType for TestFixture {
+    type Error = Error;
+}
+
+impl embedded_hal::spi::SpiDevice for TestFixture {
+    fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        self.record(operations);
+        Ok(())
+    }
+}
+
+impl SpiDevice<u8> for TestFixture {
+    async fn write(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        let mut ops = [Operation::Write(buf)];
+        self.record(&mut ops);
+        Ok(())
+    }
+
+    async fn read(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        self.record(operations);
+        Ok(())
+    }
+
+    async fn transfer(&mut self, _read: &mut [u8], _write: &[u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transfer_in_place(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+}
+
+/// SX1276, no TCXO, RFO output, no RX boost
+pub fn get_sx1276() -> Sx127x<TestFixture, DummyVariant, Sx1276> {
+    Sx127x::new(
+        TestFixture::new(),
+        DummyVariant,
+        Config {
+            chip: Sx1276,
+            tcxo_used: false,
+            tx_boost: false,
+            rx_boost: false,
+        },
+    )
+}
+
+/// SX1276 with PA_BOOST output
+pub fn get_sx1276_boost() -> Sx127x<TestFixture, DummyVariant, Sx1276> {
+    Sx127x::new(
+        TestFixture::new(),
+        DummyVariant,
+        Config {
+            chip: Sx1276,
+            tcxo_used: false,
+            tx_boost: true,
+            rx_boost: false,
+        },
+    )
+}
+
+pub struct Delayer;
+impl DelayNs for Delayer {
+    async fn delay_ns(&mut self, _ns: u32) {}
+}
+
+pub struct DummyVariant;
+
+impl InterfaceVariant for DummyVariant {
+    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn await_irq(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+}

--- a/lora-phy/src/sx127x/test/fixtures.rs
+++ b/lora-phy/src/sx127x/test/fixtures.rs
@@ -3,6 +3,7 @@ pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
 use embedded_hal::spi::Operation;
 use embedded_hal_async::spi::SpiDevice;
 use std::collections::{BTreeMap, VecDeque};
+use std::vec::Vec;
 
 /// Register-file SPI fixture for the sx127x.
 ///

--- a/lora-phy/src/sx127x/test/fixtures.rs
+++ b/lora-phy/src/sx127x/test/fixtures.rs
@@ -1,8 +1,6 @@
-use crate::mod_params::RadioError;
-use crate::mod_traits::InterfaceVariant;
 use crate::sx127x::{Config, Sx1276, Sx127x};
-use embedded_hal::spi::{ErrorKind, Operation};
-use embedded_hal_async::delay::DelayNs;
+pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
+use embedded_hal::spi::Operation;
 use embedded_hal_async::spi::SpiDevice;
 use std::collections::{BTreeMap, VecDeque};
 
@@ -171,15 +169,8 @@ impl TestFixture {
     }
 }
 
-#[derive(Debug)]
-pub enum Error {}
-impl embedded_hal::spi::Error for Error {
-    fn kind(&self) -> ErrorKind {
-        todo!()
-    }
-}
 impl embedded_hal::spi::ErrorType for TestFixture {
-    type Error = Error;
+    type Error = SpiError;
 }
 
 impl embedded_hal::spi::SpiDevice for TestFixture {
@@ -240,32 +231,4 @@ pub fn get_sx1276_boost() -> Sx127x<TestFixture, DummyVariant, Sx1276> {
             rx_boost: false,
         },
     )
-}
-
-pub struct Delayer;
-impl DelayNs for Delayer {
-    async fn delay_ns(&mut self, _ns: u32) {}
-}
-
-pub struct DummyVariant;
-
-impl InterfaceVariant for DummyVariant {
-    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn await_irq(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
-    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
-        Ok(())
-    }
 }

--- a/lora-phy/src/sx127x/test/fixtures.rs
+++ b/lora-phy/src/sx127x/test/fixtures.rs
@@ -25,6 +25,11 @@ pub struct TestFixture {
     pub fifo_written: Vec<u8>,
     pub irq_flags_written: Vec<u8>,
     fifo_read: VecDeque<u8>,
+    /// Every register write in wire order as (address, value), excluded from
+    /// equality — for tests asserting write *ordering* (e.g. where an IRQ
+    /// clear lands relative to mode/DIO writes), which the register file
+    /// can't see.
+    pub write_log: Vec<(u8, u8)>,
 }
 
 // Deliberately hardcoded (datasheet addresses), NOT derived from the
@@ -74,8 +79,8 @@ impl PartialEq for TestFixture {
         // irq_flags_written is deliberately NOT compared: the reference
         // driver clears IRQ flags at the chip only inside its DIO interrupt
         // handlers (its public clear_irq_status is shadow-state only), so
-        // the W1C traffic has no C counterpart in these flows. Tests assert
-        // ours' clears explicitly where they matter.
+        // our flag-clearing writes have no C counterpart in these flows.
+        // Tests assert ours' clears explicitly where they matter.
         self.regs == other.regs && self.fifo_written == other.fifo_written
     }
 }
@@ -94,6 +99,7 @@ impl TestFixture {
             fifo_written: vec![],
             irq_flags_written: vec![],
             fifo_read: VecDeque::new(),
+            write_log: vec![],
         }
     }
 
@@ -143,6 +149,13 @@ impl TestFixture {
             assert!(wnr, "write transaction without wnr bit: {cmd:02x?}");
             for (i, b) in cmd[1..].iter().enumerate() {
                 let mut b = *b;
+                // FIFO writes don't auto-increment the address
+                let logged_addr = if address == REG_FIFO {
+                    address
+                } else {
+                    address + i as u8
+                };
+                self.write_log.push((logged_addr, b));
                 if address == REG_FIFO {
                     self.fifo_written.push(b);
                     continue;

--- a/lora-phy/src/sx127x/test/fixtures.rs
+++ b/lora-phy/src/sx127x/test/fixtures.rs
@@ -28,6 +28,11 @@ pub struct TestFixture {
     fifo_read: VecDeque<u8>,
 }
 
+// Deliberately hardcoded (datasheet addresses), NOT derived from the
+// driver's Register enum: the special-case handling below keys off these,
+// and FIFO/IRQ traffic is excluded from the register-file equality. If a
+// driver enum value went wrong and these followed it, the special-casing
+// would absorb the misdirected write instead of the comparison catching it.
 const REG_FIFO: u8 = 0x00;
 const REG_OP_MODE: u8 = 0x01;
 const REG_IRQ_FLAGS: u8 = 0x12;

--- a/lora-phy/src/sx127x/test/fixtures.rs
+++ b/lora-phy/src/sx127x/test/fixtures.rs
@@ -43,7 +43,8 @@ const REG_IRQ_FLAGS: u8 = 0x12;
 
 /// SX1276 power-on defaults (datasheet table 41) for every register either
 /// driver touches in the compared flows; both sides start from the same file.
-const RESET_VALUES: &[(u8, u8)] = &[
+/// Also seeds the behavioral emulator's register file.
+pub(super) const RESET_VALUES: &[(u8, u8)] = &[
     (0x01, 0x80), // RegOpMode: LoRa, sleep (both drivers enter LoRa mode from reset)
     (0x06, 0x6C), // RegFrfMsb..Lsb: 434 MHz
     (0x07, 0x80),

--- a/lora-phy/src/sx127x/test/mod.rs
+++ b/lora-phy/src/sx127x/test/mod.rs
@@ -10,12 +10,15 @@
 //! The reference is SX1276-only here (our test variant); C composite calls
 //! like `sx127x_set_rx` fold in errata our driver applies elsewhere or not
 //! at all — noted per test.
+mod emulator;
 mod fixtures;
+use emulator::{get_emulated_sx1276, Chip, Mode};
 use fixtures::{get_sx1276, get_sx1276_boost, Delayer, TestFixture};
 
-use crate::mod_params::RadioMode;
+use crate::mod_params::{RadioMode, RxMode};
 use crate::mod_traits::RadioKind;
 use crate::sx127x::radio_kind_params::Register;
+use crate::LoRa;
 use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 use smtc_modem_cores::sx127x::{sx127x_radio_id_e, Context};
 use smtc_modem_cores::sys;
@@ -476,5 +479,98 @@ async fn test_spurious_rx_errata_round_trip() {
         radio.spi_mut().reg(0x31) & 0x80,
         0x80,
         "AutomaticIFOn must re-arm at 500 kHz"
+    );
+}
+
+fn emulated_modulation(lora: &mut LoRa<impl RadioKind, Delayer>) -> crate::mod_params::ModulationParams {
+    lora.create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, 868_100_000)
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_emulated_tx_end_to_end() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1276(&chip), true, Delayer).await.unwrap();
+
+    let mdltn_params = emulated_modulation(&mut lora);
+    let mut tx_pkt_params = lora
+        .create_tx_packet_params(8, false, true, false, &mdltn_params)
+        .unwrap();
+
+    let payload = b"hello sx1276";
+    lora.prepare_for_tx(&mdltn_params, &mut tx_pkt_params, 10, payload)
+        .await
+        .unwrap();
+    lora.tx().await.unwrap();
+
+    chip.with_model(|m| {
+        assert_eq!(m.tx_log.len(), 1);
+        assert_eq!(m.tx_log[0].payload, payload);
+        assert_eq!(m.mode(), Mode::Standby);
+
+        // Frequency round-trips through the chip's PLL-step encoding
+        let hz = (m.tx_log[0].frequency_raw as u64 * 32_000_000) >> 19;
+        assert!((hz as i64 - 868_100_000i64).abs() <= 61, "freq {hz}");
+    });
+}
+
+#[tokio::test]
+async fn test_emulated_rx_end_to_end() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1276(&chip), true, Delayer).await.unwrap();
+
+    let mdltn_params = emulated_modulation(&mut lora);
+    let rx_pkt_params = lora
+        .create_rx_packet_params(8, false, 255, true, false, &mdltn_params)
+        .unwrap();
+    lora.prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params)
+        .await
+        .unwrap();
+
+    // Queued until the chip enters RX, then delivered while the host waits
+    // on the DIO0 edge
+    chip.inject_rx(b"ping", 100, 5);
+
+    let mut buf = [0u8; 255];
+    let (len, status) = lora.rx(&rx_pkt_params, &mut buf).await.unwrap();
+    assert_eq!(&buf[..len as usize], b"ping");
+    // HF port offset -157, raw 100 linearized by 16/15: -157 + 107
+    assert_eq!(status.rssi, -50);
+    assert_eq!(status.snr, 5);
+}
+
+#[tokio::test]
+#[ignore = "documents a known bug: do_rx does not clear stale IRQ flags, so a \
+            restarted receive reports the abandoned session's RxDone as a fresh \
+            packet. Un-ignore when the stale-flag clear lands."]
+async fn test_restarted_rx_ignores_stale_flags() {
+    // RegIrqFlags stays latched until the host clears it by writing a 1 —
+    // mode changes don't reset it — so a receive that was started but never
+    // processed (e.g. its complete_rx future was cancelled by a select
+    // timeout) leaves RxDone latched. A restarted receive must not report
+    // that stale flag as a fresh packet.
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1276(&chip), true, Delayer).await.unwrap();
+
+    let mdltn_params = emulated_modulation(&mut lora);
+    let rx_pkt_params = lora
+        .create_rx_packet_params(8, false, 255, true, false, &mdltn_params)
+        .unwrap();
+    lora.prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params)
+        .await
+        .unwrap();
+    lora.start_rx().await.unwrap();
+
+    // A packet arrives, latching RxDone — but the caller abandons the
+    // receive without ever processing it
+    chip.inject_rx(b"stale", 100, 5);
+
+    // ...and later restarts reception. Nothing arrives this session.
+    lora.start_rx().await.unwrap();
+    let mut buf = [0u8; 255];
+    let result = lora.complete_rx(&rx_pkt_params, &mut buf).await.map(|(len, _)| len);
+    assert!(
+        result.is_err(),
+        "reported a phantom packet from a stale RxDone flag: {result:?}"
     );
 }

--- a/lora-phy/src/sx127x/test/mod.rs
+++ b/lora-phy/src/sx127x/test/mod.rs
@@ -400,3 +400,37 @@ async fn test_rssi_value_parity() {
 
     assert_eq!(rssi, c_rssi);
 }
+
+#[tokio::test]
+async fn test_bw500_sensitivity_errata() {
+    // Errata 2.1: with 500 kHz bandwidth in the HF band, RegHighBwOptimize1/2
+    // take 0x02/0x64. The reference applies this inside its set_rx composite
+    // (sx1276_fix_lora_500_khz_bw_sensitivity); ours applies it at
+    // set_modulation_params time when the chip version quirk matches, so the
+    // reference side mirrors the same register values raw. The frequency
+    // gate in ours compared kHz literals against Hz until this test — the
+    // errata values were never written on real channels.
+    let mut reference_radio = reference();
+    reference_radio.set_lora_sync_word(0x34);
+    reference_radio.write_register(0x0E, &[0x00]);
+    reference_radio.write_register(0x0F, &[0x00]);
+    reference_radio.set_lora_mod_params(&sys::sx127x_lora_mod_params_t {
+        sf: sys::sx127x_lora_sf_e_SX127X_LORA_SF9,
+        bw: sys::sx127x_lora_bw_e_SX127X_LORA_BW_500,
+        cr: sys::sx127x_lora_cr_e_SX127X_LORA_CR_4_5,
+        ldro: 0,
+    });
+    reference_radio.write_register(0x36, &[0x02]);
+    reference_radio.write_register(0x3A, &[0x64]);
+
+    let mut radio = get_sx1276();
+    // init_lora reads the chip version (seeded 0x12) which arms the quirk
+    radio.init_lora(0x34).await.unwrap();
+    let params = radio
+        .create_modulation_params(SpreadingFactor::_9, Bandwidth::_500KHz, CodingRate::_4_5, 868_100_000)
+        .unwrap();
+    radio.set_modulation_params(&params).await.unwrap();
+    assert_eq!(radio.take_spi(), *reference_radio.spi());
+    assert_eq!(reference_radio.spi().reg(0x36), 0x02);
+    assert_eq!(reference_radio.spi().reg(0x3A), 0x64);
+}

--- a/lora-phy/src/sx127x/test/mod.rs
+++ b/lora-phy/src/sx127x/test/mod.rs
@@ -81,6 +81,14 @@ async fn compare_mod_params(sf: SpreadingFactor, c_sf: u32, bw: Bandwidth, c_bw:
         ldro,
     });
 
+    // errata 2.3 registers: SWL2001 writes these on every SetRx, ours with
+    // the modulation config; mirror the same end state (none of these
+    // bandwidths are 500 kHz, so AutomaticIFOn clears + manual IF 0x40)
+    let detect_optimize = reference_radio.spi().reg(0x31);
+    reference_radio.write_register(0x31, &[detect_optimize & 0x7F]);
+    reference_radio.write_register(0x2F, &[0x40]);
+    reference_radio.write_register(0x30, &[0x00]);
+
     let mut radio = get_sx1276();
     let params = radio.create_modulation_params(sf, bw, cr, 868_100_000).unwrap();
     radio.set_modulation_params(&params).await.unwrap();
@@ -246,6 +254,11 @@ async fn test_tx_flow() {
         cr: sys::sx127x_lora_cr_e_SX127X_LORA_CR_4_5,
         ldro: 0,
     });
+    // errata 2.3 mirror (125 kHz): AutomaticIFOn off + manual IF
+    let detect_optimize = reference_radio.spi().reg(0x31);
+    reference_radio.write_register(0x31, &[detect_optimize & 0x7F]);
+    reference_radio.write_register(0x2F, &[0x40]);
+    reference_radio.write_register(0x30, &[0x00]);
     reference_radio.set_lora_pkt_params(&sys::sx127x_lora_pkt_params_t {
         preamble_len_in_symb: 8,
         header_type: sys::sx127x_lora_pkt_len_modes_e_SX127X_LORA_PKT_EXPLICIT,
@@ -433,4 +446,35 @@ async fn test_bw500_sensitivity_errata() {
     assert_eq!(radio.take_spi(), *reference_radio.spi());
     assert_eq!(reference_radio.spi().reg(0x36), 0x02);
     assert_eq!(reference_radio.spi().reg(0x3A), 0x64);
+}
+
+#[tokio::test]
+async fn test_spurious_rx_errata_round_trip() {
+    // Errata 2.3 mirrors SWL2001's sx1276_fix_lora_rx_spurious_signal:
+    // 125 kHz clears AutomaticIFOn and programs a manual IF of 0x40/0x00;
+    // going back to 500 kHz must re-set AutomaticIFOn. The reference applies
+    // this inside set_rx; ours with the modulation config — same end state.
+    let mut radio = get_sx1276();
+    let params_125 = radio
+        .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, 868_100_000)
+        .unwrap();
+    let params_500 = radio
+        .create_modulation_params(SpreadingFactor::_7, Bandwidth::_500KHz, CodingRate::_4_5, 868_100_000)
+        .unwrap();
+
+    radio.set_modulation_params(&params_125).await.unwrap();
+    assert_eq!(
+        radio.spi_mut().reg(0x31) & 0x80,
+        0,
+        "AutomaticIFOn must clear at 125 kHz"
+    );
+    assert_eq!(radio.spi_mut().reg(0x2F), 0x40);
+    assert_eq!(radio.spi_mut().reg(0x30), 0x00);
+
+    radio.set_modulation_params(&params_500).await.unwrap();
+    assert_eq!(
+        radio.spi_mut().reg(0x31) & 0x80,
+        0x80,
+        "AutomaticIFOn must re-arm at 500 kHz"
+    );
 }

--- a/lora-phy/src/sx127x/test/mod.rs
+++ b/lora-phy/src/sx127x/test/mod.rs
@@ -574,3 +574,70 @@ async fn test_restarted_rx_ignores_stale_flags() {
         "reported a phantom packet from a stale RxDone flag: {result:?}"
     );
 }
+
+/// Pin every `Register` address to Semtech's SWL2001 register maps
+/// (`sx127x_registers_common_e` in sx127x_regs_common_defs.h,
+/// `sx127x_registers_lora_e` in sx127x_regs_lora_defs.h). The driver
+/// addresses every register through this enum and the emulator's register
+/// file is keyed by these bytes, so a wrong address silently reads or writes
+/// the wrong register on real hardware. Vendor values are transcribed
+/// independently of the driver enum, so a typo in either won't match.
+///
+/// The driver names the frequency-error registers `RegFreqError*`; the
+/// vendor calls the same 0x28..0x2A registers `FEI_*` (frequency error
+/// indicator) — same address, different label.
+///
+/// Not pinned (no entry in the vendor register-address enums, so nothing to
+/// compare against): RegModemConfig3 (0x26) and the errata/chip-specific
+/// RegIfFreq1/2, RegHighBwOptimize1/2, RegPaDac*, and RegTcxo*. Their bytes
+/// are still exercised by the register-file comparison tests above.
+#[test]
+fn registers_match_swl2001() {
+    // (name, our driver's address, SWL2001's address)
+    let cases: &[(&str, u8, u8)] = &[
+        ("RegFifo", Register::RegFifo as u8, 0x00),
+        ("RegOpMode", Register::RegOpMode as u8, 0x01),
+        ("RegFrfMsb", Register::RegFrfMsb as u8, 0x06),
+        ("RegFrfMid", Register::RegFrfMid as u8, 0x07),
+        ("RegFrfLsb", Register::RegFrfLsb as u8, 0x08),
+        ("RegPaConfig", Register::RegPaConfig as u8, 0x09),
+        ("RegPaRamp", Register::RegPaRamp as u8, 0x0A),
+        ("RegOcp", Register::RegOcp as u8, 0x0B),
+        ("RegLna", Register::RegLna as u8, 0x0C),
+        ("RegFifoAddrPtr", Register::RegFifoAddrPtr as u8, 0x0D),
+        ("RegFifoTxBaseAddr", Register::RegFifoTxBaseAddr as u8, 0x0E),
+        ("RegFifoRxBaseAddr", Register::RegFifoRxBaseAddr as u8, 0x0F),
+        ("RegFifoRxCurrentAddr", Register::RegFifoRxCurrentAddr as u8, 0x10),
+        ("RegIrqFlagsMask", Register::RegIrqFlagsMask as u8, 0x11),
+        ("RegIrqFlags", Register::RegIrqFlags as u8, 0x12),
+        ("RegRxNbBytes", Register::RegRxNbBytes as u8, 0x13),
+        ("RegModemStat", Register::RegModemStat as u8, 0x18),
+        ("RegPktSnrValue", Register::RegPktSnrValue as u8, 0x19),
+        ("RegPktRssiValue", Register::RegPktRssiValue as u8, 0x1A),
+        ("RegRssiValue", Register::RegRssiValue as u8, 0x1B),
+        ("RegModemConfig1", Register::RegModemConfig1 as u8, 0x1D),
+        ("RegModemConfig2", Register::RegModemConfig2 as u8, 0x1E),
+        ("RegSymbTimeoutLsb", Register::RegSymbTimeoutLsb as u8, 0x1F),
+        ("RegPreambleMsb", Register::RegPreambleMsb as u8, 0x20),
+        ("RegPreambleLsb", Register::RegPreambleLsb as u8, 0x21),
+        ("RegPayloadLength", Register::RegPayloadLength as u8, 0x22),
+        ("RegMaxPayloadLength", Register::RegMaxPayloadLength as u8, 0x23),
+        ("RegFreqErrorMsb", Register::RegFreqErrorMsb as u8, 0x28),
+        ("RegFreqErrorMid", Register::RegFreqErrorMid as u8, 0x29),
+        ("RegFreqErrorLsb", Register::RegFreqErrorLsb as u8, 0x2A),
+        ("RegRssiWideband", Register::RegRssiWideband as u8, 0x2C),
+        ("RegDetectionOptimize", Register::RegDetectionOptimize as u8, 0x31),
+        ("RegInvertiq", Register::RegInvertiq as u8, 0x33),
+        ("RegDetectionThreshold", Register::RegDetectionThreshold as u8, 0x37),
+        ("RegSyncWord", Register::RegSyncWord as u8, 0x39),
+        ("RegInvertiq2", Register::RegInvertiq2 as u8, 0x3B),
+        ("RegDioMapping1", Register::RegDioMapping1 as u8, 0x40),
+        ("RegVersion", Register::RegVersion as u8, 0x42),
+    ];
+    for (name, driver, vendor) in cases {
+        assert_eq!(
+            driver, vendor,
+            "Register::{name} = {driver:#04x}, SWL2001 = {vendor:#04x}"
+        );
+    }
+}

--- a/lora-phy/src/sx127x/test/mod.rs
+++ b/lora-phy/src/sx127x/test/mod.rs
@@ -1,0 +1,402 @@
+//! Compare this driver's register traffic against Semtech's reference sx127x
+//! driver (SWL2001, via the smtc-modem-cores bindings).
+//!
+//! The sx127x is register-based and the two drivers factor their traffic
+//! differently (burst RMW vs single-register writes, shadow copies vs SPI
+//! read-back), so both run against a register-file fixture and equality is
+//! on chip-visible outcome: final register file + FIFO stream + IRQ-clear
+//! writes. See `fixtures.rs`.
+//!
+//! The reference is SX1276-only here (our test variant); C composite calls
+//! like `sx127x_set_rx` fold in errata our driver applies elsewhere or not
+//! at all — noted per test.
+mod fixtures;
+use fixtures::{get_sx1276, get_sx1276_boost, Delayer, TestFixture};
+
+use crate::mod_params::RadioMode;
+use crate::mod_traits::RadioKind;
+use crate::sx127x::radio_kind_params::Register;
+use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
+use smtc_modem_cores::sx127x::{sx127x_radio_id_e, Context};
+use smtc_modem_cores::sys;
+
+/// SX1276 reference with the LoRa packet engine selected. Selecting LoRa is
+/// part of both drivers' init flows (ours enters LoRa sleep from reset), and
+/// the register file is seeded to that state, so the switch is a no-op on
+/// the wire and both sides start identically.
+fn reference() -> Context<TestFixture> {
+    let mut c = Context::new(TestFixture::new(), sx127x_radio_id_e::SX127X_RADIO_ID_SX1276);
+    c.set_pkt_type(sys::sx127x_pkt_types_e_SX127X_PKT_TYPE_LORA);
+    c
+}
+
+#[tokio::test]
+async fn test_set_standby() {
+    let mut reference_radio = reference();
+    reference_radio.set_standby();
+
+    let mut radio = get_sx1276();
+    radio.set_standby().await.unwrap();
+    assert_eq!(radio.take_spi(), *reference_radio.spi());
+    assert_eq!(reference_radio.spi().reg(0x01), 0x81);
+}
+
+#[tokio::test]
+async fn test_set_sleep() {
+    // Standby first so the sleep transition is visible in the register file
+    let mut reference_radio = reference();
+    reference_radio.set_standby();
+    reference_radio.set_sleep();
+
+    let mut radio = get_sx1276();
+    radio.set_standby().await.unwrap();
+    radio.set_sleep(false, &mut Delayer).await.unwrap();
+    assert_eq!(radio.take_spi(), *reference_radio.spi());
+    assert_eq!(reference_radio.spi().reg(0x01), 0x80);
+}
+
+#[tokio::test]
+async fn test_set_channel() {
+    for freq in [433_000_000u32, 868_100_000, 915_000_000] {
+        let mut reference_radio = reference();
+        reference_radio.set_rf_freq(freq);
+
+        let mut radio = get_sx1276();
+        radio.set_channel(freq).await.unwrap();
+        assert_eq!(radio.take_spi(), *reference_radio.spi(), "freq {freq}");
+    }
+}
+
+async fn compare_mod_params(sf: SpreadingFactor, c_sf: u32, bw: Bandwidth, c_bw: u32, cr: CodingRate, c_cr: u32) {
+    let mut reference_radio = reference();
+    let ldro = match (sf, bw) {
+        // symbol duration > 16 ms
+        (SpreadingFactor::_12, Bandwidth::_125KHz) | (SpreadingFactor::_11, Bandwidth::_125KHz) => 1,
+        _ => 0,
+    };
+    reference_radio.set_lora_mod_params(&sys::sx127x_lora_mod_params_t {
+        sf: c_sf,
+        bw: c_bw,
+        cr: c_cr,
+        ldro,
+    });
+
+    let mut radio = get_sx1276();
+    let params = radio.create_modulation_params(sf, bw, cr, 868_100_000).unwrap();
+    radio.set_modulation_params(&params).await.unwrap();
+    assert_eq!(radio.take_spi(), *reference_radio.spi(), "sf {sf:?} bw {bw:?}");
+}
+
+#[tokio::test]
+async fn test_set_modulation_params() {
+    compare_mod_params(
+        SpreadingFactor::_7,
+        sys::sx127x_lora_sf_e_SX127X_LORA_SF7,
+        Bandwidth::_125KHz,
+        sys::sx127x_lora_bw_e_SX127X_LORA_BW_125,
+        CodingRate::_4_5,
+        sys::sx127x_lora_cr_e_SX127X_LORA_CR_4_5,
+    )
+    .await;
+    // LDRO forced on
+    compare_mod_params(
+        SpreadingFactor::_12,
+        sys::sx127x_lora_sf_e_SX127X_LORA_SF12,
+        Bandwidth::_125KHz,
+        sys::sx127x_lora_bw_e_SX127X_LORA_BW_125,
+        CodingRate::_4_8,
+        sys::sx127x_lora_cr_e_SX127X_LORA_CR_4_8,
+    )
+    .await;
+    // SF6 selects the SF6 detection optimize + threshold values
+    compare_mod_params(
+        SpreadingFactor::_6,
+        sys::sx127x_lora_sf_e_SX127X_LORA_SF6,
+        Bandwidth::_250KHz,
+        sys::sx127x_lora_bw_e_SX127X_LORA_BW_250,
+        CodingRate::_4_5,
+        sys::sx127x_lora_cr_e_SX127X_LORA_CR_4_5,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_set_packet_params() {
+    // IQ registers are excluded here on the C side: the reference driver
+    // only pushes IQ configuration to the chip inside set_tx/set_rx, while
+    // ours writes it in set_packet_params. The TX/RX flow tests below cover
+    // the IQ register values end to end.
+    let mut reference_radio = reference();
+    reference_radio.set_lora_pkt_params(&sys::sx127x_lora_pkt_params_t {
+        preamble_len_in_symb: 8,
+        header_type: sys::sx127x_lora_pkt_len_modes_e_SX127X_LORA_PKT_EXPLICIT,
+        pld_len_in_bytes: 32,
+        crc_is_on: true,
+        invert_iq_is_on: false,
+    });
+    // ours writes the (unchanged) IQ registers too; mirror the reset values
+    reference_radio.write_register(0x33, &[0x27]);
+    reference_radio.write_register(0x3B, &[0x1D]);
+
+    // The reference's set_lora_pkt_params is a composite: it forces standby
+    // and zeroes both FIFO base addresses (ours does those separately), and
+    // pins RegPayloadLength + RegMaxPayloadLength to the packet length even
+    // in explicit mode (ours writes RegPayloadLength at set_payload time and
+    // leaves MaxPayloadLength at reset, guarding RX size in software).
+    let mut radio = get_sx1276();
+    let mod_params = radio
+        .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, 868_100_000)
+        .unwrap();
+    let params = radio
+        .create_packet_params(8, false, 32, true, false, &mod_params)
+        .unwrap();
+    radio.set_standby().await.unwrap();
+    radio.set_tx_rx_buffer_base_address(0, 0).await.unwrap();
+    radio.set_packet_params(&params).await.unwrap();
+    radio.write_register(Register::RegPayloadLength, 32).await.unwrap();
+    radio.write_register(Register::RegMaxPayloadLength, 32).await.unwrap();
+    assert_eq!(radio.take_spi(), *reference_radio.spi());
+}
+
+#[tokio::test]
+async fn test_set_lora_sync_word() {
+    let mut reference_radio = reference();
+    reference_radio.set_lora_sync_word(0x34);
+
+    let mut radio = get_sx1276();
+    // init_lora also writes the buffer base addresses and reads the version
+    radio.init_lora(0x34).await.unwrap();
+    reference_radio.write_register(0x0E, &[0x00]);
+    reference_radio.write_register(0x0F, &[0x00]);
+    assert_eq!(radio.take_spi(), *reference_radio.spi());
+}
+
+#[tokio::test]
+async fn test_symbol_timeout() {
+    let mut reference_radio = reference();
+    reference_radio.set_lora_sync_timeout(100);
+
+    let mut radio = get_sx1276();
+    radio.set_lora_symbol_num_timeout(100).await.unwrap();
+    assert_eq!(radio.take_spi(), *reference_radio.spi());
+
+    // > 255 exercises the two MSBs in RegModemConfig2
+    let mut reference_radio = reference();
+    reference_radio.set_lora_sync_timeout(1000);
+
+    let mut radio = get_sx1276();
+    radio.set_lora_symbol_num_timeout(1000).await.unwrap();
+    assert_eq!(radio.take_spi(), *reference_radio.spi());
+}
+
+async fn compare_tx_power(boost: bool, p_out: i32, is_20_dbm: bool, ocp_trim: u8) {
+    let mut reference_radio = reference();
+    reference_radio.set_pa_cfg(&sys::sx127x_pa_cfg_params_t {
+        pa_select: if boost {
+            sys::sx127x_pa_select_e_SX127X_PA_SELECT_BOOST
+        } else {
+            sys::sx127x_pa_select_e_SX127X_PA_SELECT_RFO
+        },
+        is_20_dbm_output_on: is_20_dbm,
+    });
+    reference_radio.set_tx_params(p_out as i8, sys::sx127x_ramp_time_e_SX127X_RAMP_40_US);
+    // OCP policy lives outside the reference driver's TX-params flow; ours
+    // sets it alongside TX power. The reference's own set_ocp_value can't be
+    // used to mirror it: SWL2001 masks the trim with the inverted-form
+    // OCP_TRIM_MASK (~31), zeroing whatever trim is passed — every call
+    // writes 0x20 (OcpOn, 45 mA). Raw register write instead.
+    reference_radio.write_register(0x0B, &[0x20 | ocp_trim]);
+    if boost {
+        // MaxPower [6:4] is unused when PA_BOOST is selected: ours writes 0,
+        // the reference preserves the reset value via RMW. Align the dead
+        // bits so the live ones compare.
+        let pa_config = reference_radio.spi().reg(0x09);
+        reference_radio.write_register(0x09, &[pa_config & 0b1000_1111]);
+    }
+
+    let mut radio = if boost { get_sx1276_boost() } else { get_sx1276() };
+    radio.set_tx_power_and_ramp_time(p_out, None, true).await.unwrap();
+    assert_eq!(radio.take_spi(), *reference_radio.spi(), "boost {boost} p_out {p_out}");
+}
+
+#[tokio::test]
+async fn test_set_tx_power_boost() {
+    // PA_BOOST, high power path (PaDac on, 240 mA OCP)
+    compare_tx_power(true, 20, true, 0x1B).await;
+    // PA_BOOST standard
+    compare_tx_power(true, 14, false, 0x0B).await;
+}
+
+#[tokio::test]
+async fn test_set_tx_power_rfo() {
+    compare_tx_power(false, 14, false, 0x0B).await;
+    compare_tx_power(false, 0, false, 0x0B).await;
+}
+
+#[tokio::test]
+async fn test_tx_flow() {
+    // Full TX setup and start: config, payload, IRQ routing, mode switch
+    let payload = [0xCA, 0xFE, 0xBA, 0xBE, 0x42];
+
+    let mut reference_radio = reference();
+    reference_radio.set_rf_freq(868_100_000);
+    reference_radio.set_lora_mod_params(&sys::sx127x_lora_mod_params_t {
+        sf: sys::sx127x_lora_sf_e_SX127X_LORA_SF7,
+        bw: sys::sx127x_lora_bw_e_SX127X_LORA_BW_125,
+        cr: sys::sx127x_lora_cr_e_SX127X_LORA_CR_4_5,
+        ldro: 0,
+    });
+    reference_radio.set_lora_pkt_params(&sys::sx127x_lora_pkt_params_t {
+        preamble_len_in_symb: 8,
+        header_type: sys::sx127x_lora_pkt_len_modes_e_SX127X_LORA_PKT_EXPLICIT,
+        pld_len_in_bytes: payload.len() as u8,
+        crc_is_on: true,
+        invert_iq_is_on: false,
+    });
+    reference_radio.write_buffer(0, &payload);
+    reference_radio.set_irq_mask(sys::sx127x_irq_masks_e_SX127X_IRQ_TX_DONE as u16);
+    reference_radio.clear_irq_status(sys::sx127x_irq_masks_e_SX127X_IRQ_ALL as u16);
+    reference_radio.set_tx();
+
+    let mut radio = get_sx1276();
+    let mod_params = radio
+        .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, 868_100_000)
+        .unwrap();
+    let pkt_params = radio
+        .create_packet_params(8, false, payload.len() as u8, true, false, &mod_params)
+        .unwrap();
+    radio.set_channel(868_100_000).await.unwrap();
+    radio.set_modulation_params(&mod_params).await.unwrap();
+    radio.set_packet_params(&pkt_params).await.unwrap();
+    radio.set_tx_rx_buffer_base_address(0, 0).await.unwrap();
+    radio.set_payload(&payload).await.unwrap();
+    radio.set_irq_params(Some(RadioMode::Transmit)).await.unwrap();
+    radio.do_tx().await.unwrap();
+
+    // ours leaves RegMaxPayloadLength at reset (RX size is guarded in
+    // software); the reference pins it at pkt-params time
+    radio
+        .write_register(Register::RegMaxPayloadLength, payload.len() as u8)
+        .await
+        .unwrap();
+
+    let spi = radio.take_spi();
+    // ours clears all IRQ flags at the chip (set_irq_params); the reference
+    // only does so from its DIO interrupt handlers, outside this flow
+    assert_eq!(spi.irq_flags_written, vec![0xFF]);
+    assert_eq!(spi, *reference_radio.spi());
+    // TX mode, LoRa
+    assert_eq!(reference_radio.spi().reg(0x01), 0x83);
+    assert_eq!(reference_radio.spi().fifo_written, payload);
+}
+
+#[tokio::test]
+async fn test_cad_flow() {
+    let mut reference_radio = reference();
+    reference_radio.set_irq_mask(
+        (sys::sx127x_irq_masks_e_SX127X_IRQ_CAD_DONE | sys::sx127x_irq_masks_e_SX127X_IRQ_CAD_DETECTED) as u16,
+    );
+    reference_radio.clear_irq_status(sys::sx127x_irq_masks_e_SX127X_IRQ_ALL as u16);
+    reference_radio.set_cad();
+
+    let mut radio = get_sx1276();
+    let mod_params = radio
+        .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, 868_100_000)
+        .unwrap();
+    radio
+        .set_irq_params(Some(RadioMode::ChannelActivityDetection))
+        .await
+        .unwrap();
+    radio.do_cad(&mod_params).await.unwrap();
+
+    // ours re-asserts the (reset-default) LNA gain; the reference leaves it
+    reference_radio.write_register(0x0C, &[0x20]);
+
+    assert_eq!(radio.take_spi(), *reference_radio.spi());
+    assert_eq!(reference_radio.spi().reg(0x01), 0x87);
+}
+
+#[tokio::test]
+async fn test_get_rx_payload() {
+    let data = [0x01, 0x02, 0x03, 0x04, 0x05];
+
+    // The reference RX read path has no comparable wire footprint: its FIFO
+    // drain happens inside the DIO interrupt handlers into a RAM shadow
+    // buffer, and both get_rx_buffer_status and read_buffer serve from
+    // shadow state. Mirror ours' expected traffic with raw reference
+    // accesses instead: read length + current addr, point the FIFO pointer
+    // at the packet, drain, park the pointer at 0.
+    let mut reference_radio = reference();
+    reference_radio.spi_mut().set_reg(0x13, data.len() as u8); // RegRxNbBytes
+    reference_radio.spi_mut().set_reg(0x10, 0x40); // RegFifoRxCurrentAddr
+    reference_radio.spi_mut().prime_fifo_read(&data);
+    let mut reg = [0u8; 1];
+    reference_radio.read_register(0x13, &mut reg);
+    assert_eq!(reg[0], data.len() as u8);
+    reference_radio.read_register(0x10, &mut reg);
+    assert_eq!(reg[0], 0x40);
+    reference_radio.write_register(0x0D, &[0x40]);
+    let mut c_payload = [0u8; 5];
+    reference_radio.read_register(0x00, &mut c_payload);
+    reference_radio.write_register(0x0D, &[0x00]);
+
+    let mut radio = get_sx1276();
+    radio.spi_mut().set_reg(0x13, data.len() as u8);
+    radio.spi_mut().set_reg(0x10, 0x40);
+    radio.spi_mut().prime_fifo_read(&data);
+    let mod_params = radio
+        .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, 868_100_000)
+        .unwrap();
+    let pkt_params = radio
+        .create_packet_params(8, false, 16, true, false, &mod_params)
+        .unwrap();
+    let mut rx_buffer = [0u8; 16];
+    let len = radio.get_rx_payload(&pkt_params, &mut rx_buffer).await.unwrap();
+
+    assert_eq!(radio.take_spi(), *reference_radio.spi());
+    assert_eq!(len as usize, data.len());
+    assert_eq!(&rx_buffer[..data.len()], &data);
+    assert_eq!(&c_payload, &data);
+}
+
+#[tokio::test]
+async fn test_packet_status_value_parity() {
+    // SNR -6 dB (raw = -24 as u8 = 0xE8), RSSI raw 60 @ 868.1 MHz (HF port)
+    let mut reference_radio = reference();
+    reference_radio.set_rf_freq(868_100_000);
+    reference_radio.spi_mut().set_reg(0x19, 0xE8); // RegPktSnrValue
+    reference_radio.spi_mut().set_reg(0x1A, 60); // RegPktRssiValue
+    let (_, c_status) = reference_radio.get_lora_pkt_status();
+
+    let mut radio = get_sx1276();
+    radio.set_channel(868_100_000).await.unwrap();
+    radio.spi_mut().set_reg(0x19, 0xE8);
+    radio.spi_mut().set_reg(0x1A, 60);
+    let status = radio.get_rx_packet_status().await.unwrap();
+
+    assert_eq!(status.snr, c_status.snr_pkt_in_db as i16);
+    // both linearize the raw RSSI, with different integer approximations of
+    // the same 16/15 correction: ours rounds (raw * 16 + 7) / 15, the
+    // reference computes raw + (raw >> 4) — at most 1 dB apart
+    assert!(
+        (status.rssi - c_status.rssi_pkt_in_dbm as i16).abs() <= 1,
+        "rssi {} vs reference {}",
+        status.rssi,
+        c_status.rssi_pkt_in_dbm
+    );
+}
+
+#[tokio::test]
+async fn test_rssi_value_parity() {
+    let mut reference_radio = reference();
+    reference_radio.set_rf_freq(868_100_000);
+    reference_radio.spi_mut().set_reg(0x1B, 90); // RegRssiValue
+    let (_, c_rssi) = reference_radio.get_rssi_inst();
+
+    let mut radio = get_sx1276();
+    radio.set_channel(868_100_000).await.unwrap();
+    radio.spi_mut().set_reg(0x1B, 90);
+    let rssi = radio.get_rssi().await.unwrap();
+
+    assert_eq!(rssi, c_rssi);
+}

--- a/lora-phy/src/test_fixtures.rs
+++ b/lora-phy/src/test_fixtures.rs
@@ -1,0 +1,47 @@
+//! Chip-independent scaffolding shared by the per-chip comparison-test
+//! fixtures. Only zero-semantics boilerplate belongs here — each fixture's
+//! transaction recording and equality rules are chip-specific by design.
+use crate::mod_params::RadioError;
+use crate::mod_traits::InterfaceVariant;
+use embedded_hal::spi::ErrorKind;
+use embedded_hal_async::delay::DelayNs;
+
+/// SPI error type for fixtures that never fail
+#[derive(Debug)]
+pub enum SpiError {}
+impl embedded_hal::spi::Error for SpiError {
+    fn kind(&self) -> ErrorKind {
+        match *self {}
+    }
+}
+
+/// Delay provider that returns immediately
+pub struct Delayer;
+impl DelayNs for Delayer {
+    async fn delay_ns(&mut self, _ns: u32) {}
+}
+
+/// InterfaceVariant with no-op control lines (busy always ready, IRQ
+/// always pending, RF switch ignored)
+pub struct DummyVariant;
+
+impl InterfaceVariant for DummyVariant {
+    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn await_irq(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Tests lora-phy's radio drivers against Semtech's reference C implementation ([SWL2001](https://github.com/Lora-net/SWL2001) v4.9.0) by comparing the SPI traffic both produce for the same operations. Every lora-phy driver with a SWL2001 counterpart is covered: **sx126x**, **lr1110**, and **sx127x**. Supersedes #233 (same branch history, restructured description).

The bindings live in their own repository per earlier review feedback: [lora-rs/smtc-modem-cores](https://github.com/lora-rs/smtc-modem-cores), now **published on crates.io** (v0.1.0) and pulled in as a test-only dev-dependency — no git pin, no submodule; the sys crate packages only the compiled SWL2001 sources (255 KiB compressed). This PR is purely lora-phy test integration plus the driver bugs the comparison caught — no runtime dependencies change.

## Why

Driver encoding bugs are invisible to unit tests written from the same (mis)reading of the datasheet that produced the code. Comparing against Semtech's own driver catches them mechanically — and it did: **15 real bugs**, several of them silent on-air corruption.

## Bugs found and fixed

### lr1110 (8, commit "fix lr1110 command encodings against the SWL2001 reference")

Most of these were SX126x conventions ported into a chip that doesn't share them:

1. **Sleep config used the SX126x bit layout** — warm start is bit 0 on lr11xx, not bit 2. Every sleep was a cold sleep, silently dropping retention (and every LoRaWAN session state kept in it).
2. **Symbol timeout used the SX126x mantissa/exponent encoding** — the lr11xx takes a raw count for values ≤255, so 8 symbols became 32 (~4× the intended RX window).
3. **WriteBuffer8 sent a stray offset byte** — the command has none; the 0x00 would have gone over the air as the first payload byte.
4. **ReadBuffer8 sent 0 in its length field** — reads returned nothing.
5. **GFSK modulation params applied SX126x chip-format conversions** — the lr11xx takes raw bps/Hz; GFSK rates were garbage.
6. **GFSK packet status read the payload length from an RSSI byte** (layout is rssi_sync, rssi_avg, rx_len, status).
7. **AutoTxRx was missing the intermediary-mode and timeout fields** — short command on the wire.
8. **The high-ACP workaround was opt-in only** — the reference applies it on every SetTx/SetRx/SetCad; affected firmware (LR1110 0x0303–0x0307, LR1120 0x0101) wasn't covered on normal paths. Now applied in do_tx/do_rx/do_cad.

### sx127x (7, commits "fix sx127x frequency, TX power and RSSI decode…", "fix the sx1276 500 kHz sensitivity errata frequency gate", "apply errata 2.3…")

1. **PLL step math truncated the low 8 bits** — fractional-MHz channels (868.1, 903.9 MHz) sat up to ~15 kHz off carrier. The existing unit test only checked whole/half-MHz values, exactly where the shortcut happened to work.
2. **PA_BOOST above 17 dBm used the PaDac-off power formula** — 18–20 dBm requests overflowed the 4-bit OutputPower field; a 20 dBm request programmed roughly 7 dBm.
3. **RFO at or below 0 dBm cast a negative OutputPower to u8** — corrupted RegPaConfig including the PA_BOOST select bit.
4. **RegDetectionOptimize RMW dropped bit 7 (AutomaticIFOn)** on every set_modulation_params.
5. **Packet RSSI skipped the 16/15 linearization in the negative-SNR branch** (reference and LoRaMac-node apply it in both).
6. **The errata 2.1 (500 kHz sensitivity) frequency gate compared kHz literals against Hz** — dead code on every real channel; the optimization values were never written.
7. **Errata 2.3 (spurious LoRa reception) was never applied** — the reference programs the manual-IF workaround on every SetRx; ours now applies it with the modulation config, including re-arming AutomaticIFOn when returning to 500 kHz.

### sx126x (1 bug — encodings otherwise verified byte-identical)

The suite largely validated the existing driver, including the §15.1 TxModulation, §15.2 TX clamp, and §15.4 inverted-IQ workarounds, and the full RX/CAD path.

**One caveat worth knowing about the TX power comparison.** SWL2001 splits responsibility differently than lora-phy does: its driver only encodes SetPaConfig/SetTxParams, while the actual power table (which pa_duty_cycle/hp_max/power triple to use per dBm — datasheet Table 13-21) lives in its BSP layer, which this PR doesn't compile. So the reference is fed our driver's hardcoded triples, and the comparison verifies the command encoding while pinning our table as test data — it does not independently validate the table values against Semtech's choices. Two table-level differences are documented in test comments rather than "fixed":

- The 14 dBm-and-below high-power row turned into a driver fix during review of this PR. It's the one place ST's STM32WL table differs from datasheet Table 13-21 (checked against Rev 2.2, Dec 2024): same 0x02/0x02 PA config, but ST commands the target dBm directly where the datasheet interpolates SetTxParams from its +22 setpoint. Both tables are correct for their own hardware — the STM32WL is an SX126x die integrated into ST's package, characterized by ST — but the driver applied ST's value to every high-power variant, so **discrete SX1262 parts got the wrong row** (bug 15 of this PR, making the sx126x count 1 rather than 0). Fixed with `Sx126xVariant::pa_table() -> &'static PaTable` — the PA table is const data the variant supplies (flash, no RAM): `Sx1262`/`Sx1261` default to the datasheet tables, `Stm32wl` returns ST's, and boards with their own PA characterization can plug in their own table. Both shipped tables are pinned by comparison tests. A small fix fell out of the table refactor too: a 21 dBm request now interpolates to SetTxParams 21 within the +22 row instead of over-commanding 22.
- Image calibration: SWL2001's generic `cal_img_in_mhz` (ceil of band-edge/4) lands one step short of datasheet Table 9-2 for the 902–928 MHz band (0xE8 vs 0xE9). Our driver follows the table; the tests compare against the reference's fixed-byte `cal_img` entry point with the table values, and the lr11xx equivalent has the same off-by-one.

Also documented upstream: `sx127x_set_ocp_value` (sx127x side) always programs 45 mA — it masks the trim argument with the inverted-form `OCP_TRIM_MASK`, zeroing whatever is passed.

## How the comparison works

Each chip needed its own fixture shape, matching how its drivers talk:

- **sx126x** (command-based): both drivers record transactions into one op log; equality is wire-canonical (trailing-NOP-trimmed writes + total bytes clocked) because the two drivers split read transactions differently while clocking identical wire bytes.
- **lr1110** (command-based, two-transaction reads): both drivers split reads identically, so transactions compare exactly. Canned responses key off the preceding command write; command-less direct reads consume a FIFO.
- **sx127x** (register-based): the drivers legitimately factor traffic differently (burst RMW + shadow registers vs single-register RMW over SPI), so both execute against a small register file and equality is the chip-visible outcome — final register state plus the FIFO byte stream. The fixture models the OpMode LongRangeMode latch the reference silently relies on.

Read-path tests also assert decoded-value parity (RSSI/SNR/lengths), not just bytes.

## Emulator

`lora-phy/src/sx126x/test/emulator.rs` is a behavioral sx126x model that the **real** `Sx126x` driver and `LoRa` state machine run against unmodified — tests hold a `Chip` handle to inject received packets and inspect transmitted ones. End-to-end tests cover TX, RX, sleep/wake, CAD (quiet and busy channels), and single-mode RX timeout with recovery. Relates to #442: this tests actual driver code where a trait-level mock tests none, at the cost of being chip-specific; the two approaches complement each other.

## Bindings design (smtc-modem-cores)

The crate owns the `#[no_mangle]` HAL symbols the C drivers link against and dispatches through a monomorphized vtable stored at the head of a `repr(C)` context, so `Context::new(spi)` is the whole user API and multiple SPI types coexist in one binary. Each chip family's HAL needed its own shape: sx126x (write+read), lr11xx (write, two-transaction read, direct read, plus no-op GPIO-level symbols), sx127x (register write/read hung off `sx127x_t.hal_context`, host timers stubbed).

Beyond testing lora-phy, the bindings could anchor development of an sx128x driver (SWL2001 ships one; lora-phy has none).





