### PR TITLE
device: reconstruct 32-bit downlink frame counter and reject replays

### DIFF
--- a/lorawan-device/src/async_device/test/multicast.rs
+++ b/lorawan-device/src/async_device/test/multicast.rs
@@ -30,7 +30,9 @@ fn handle_multicast_setup_req(
     phy.set_f_port(200); // Remote multicast setup port
     phy.set_dev_addr(&[0; 4]);
     phy.set_uplink(false);
-    phy.set_fcnt(0);
+    // The class C setup already delivered a downlink at counter 0, so this one
+    // advances the downlink counter.
+    phy.set_fcnt(1);
 
     let finished =
         phy.build(setup_req, [], &get_key().into(), &get_key().into(), &DefaultFactory).unwrap();
@@ -135,7 +137,7 @@ fn handle_mc_group_delete_req<const GROUP_ID: u8>(
     phy.set_f_port(200); // Remote multicast setup port
     phy.set_dev_addr(&[0; 4]);
     phy.set_uplink(false);
-    phy.set_fcnt(1);
+    phy.set_fcnt(2);
 
     let finished =
         phy.build(setup_req, [], &get_key().into(), &get_key().into(), &DefaultFactory).unwrap();
@@ -202,7 +204,7 @@ async fn test_multicast_group_delete() {
     // Send the McGroupDeleteReq with correct groupID
     radio.handle_rxtx(handle_mc_group_delete_req::<0x01>).await;
     radio.handle_rxtx(verify_mc_group_delete_ans).await;
-    radio.handle_rxtx(handle_regular_downlink_msg::<2>).await;
+    radio.handle_rxtx(handle_regular_downlink_msg::<3>).await;
     let _ = task.await.unwrap();
 }
 
@@ -250,6 +252,6 @@ async fn test_multicast_invalid_group_delete() {
     // Send the McGroupDeleteReq with correct groupID
     radio.handle_rxtx(handle_mc_group_delete_req::<0x03>).await;
     radio.handle_rxtx(verify_mc_group_delete_ans_undefined).await;
-    radio.handle_rxtx(handle_regular_downlink_msg::<2>).await;
+    radio.handle_rxtx(handle_regular_downlink_msg::<3>).await;
     let _ = task.await.unwrap();
 }

--- a/lorawan-device/src/async_device/test/util.rs
+++ b/lorawan-device/src/async_device/test/util.rs
@@ -9,21 +9,7 @@ pub(crate) use crate::test_util::{handle_data_uplink_with_link_adr_req, Uplink};
 use crate::{AppSKey, NwkSKey};
 
 fn default_session() -> Session {
-    Session {
-        nwkskey: NwkSKey::from(get_key()),
-        appskey: AppSKey::from(get_key()),
-        devaddr: get_dev_addr(),
-        fcnt_up: 0,
-        fcnt_down: 0,
-        confirmed: false,
-        uplink: Default::default(),
-        #[cfg(feature = "certification")]
-        override_adr: false,
-        #[cfg(feature = "certification")]
-        override_confirmed: None,
-        #[cfg(feature = "certification")]
-        rx_app_cnt: 0,
-    }
+    Session::new(NwkSKey::from(get_key()), AppSKey::from(get_key()), get_dev_addr())
 }
 
 pub fn session_with_region(region: region::Configuration) -> (RadioChannel, TimerChannel, Device) {

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -3,6 +3,7 @@ use super::{
     uplink, FcntUp, Response, SendData,
 };
 use crate::radio::RadioBuffer;
+use crate::region::constants::MAX_FCNT_GAP;
 use crate::{region, AppSKey, Downlink, NwkSKey};
 use heapless::Vec;
 use lorawan::maccommandcreator::{
@@ -31,7 +32,10 @@ pub struct Session {
     pub appskey: AppSKey,
     pub devaddr: DevAddr<[u8; 4]>,
     pub fcnt_up: u32,
-    pub fcnt_down: u32,
+    /// Frame counter of the last accepted downlink, or `None` before the first
+    /// downlink of the session. Only the low 16 bits of the counter are on the
+    /// wire; the high 16 bits kept here are used to rebuild the full value.
+    fcnt_down: Option<u32>,
     // TODO: ADR handling
     #[cfg(feature = "certification")]
     /// Whether to force ADR bit for subsequent frames
@@ -83,7 +87,7 @@ impl Session {
             appskey,
             devaddr,
             confirmed: false,
-            fcnt_down: 0,
+            fcnt_down: None,
             fcnt_up: 0,
             uplink: uplink::Uplink::default(),
 
@@ -109,6 +113,12 @@ impl Session {
 
     pub fn nwkskey(&self) -> &NwkSKey {
         &self.nwkskey
+    }
+
+    /// Frame counter of the last accepted downlink, or `None` before the first
+    /// downlink of the session.
+    pub fn fcnt_down(&self) -> Option<u32> {
+        self.fcnt_down
     }
 
     pub fn get_session_keys(&self) -> Option<SessionKeys> {
@@ -163,18 +173,18 @@ impl Session {
                     return multicast.handle_rx(dl, encrypted_data).into();
                 }
             }
-            let fcnt = encrypted_data.fhdr().fcnt() as u32;
             let confirmed = encrypted_data.is_confirmed();
-            if encrypted_data.validate_mic(self.nwkskey().inner(), fcnt, &DefaultFactory)
-                && (fcnt > self.fcnt_down || fcnt == 0)
-            {
-                self.fcnt_down = fcnt;
+            let Some(fcnt) = next_fcnt_down(self.fcnt_down, encrypted_data.fhdr().fcnt()) else {
+                return Response::NoUpdate;
+            };
+            if encrypted_data.validate_mic(self.nwkskey().inner(), fcnt, &DefaultFactory) {
+                self.fcnt_down = Some(fcnt);
                 // We can safely unwrap here because we already validated the MIC
                 let decrypted = encrypted_data
                     .decrypt(
                         Some(self.nwkskey().inner()),
                         Some(self.appskey().inner()),
-                        self.fcnt_down,
+                        fcnt,
                         &DefaultFactory,
                     )
                     .unwrap();
@@ -213,9 +223,7 @@ impl Session {
                         #[cfg(feature = "certification")]
                         if certification.fport(fport) {
                             use crate::mac::certification::Response::*;
-                            match certification
-                                .handle_message(data, self.fcnt_down.try_into().unwrap())
-                            {
+                            match certification.handle_message(data, fcnt as u16) {
                                 AdrBitChange(adr) => {
                                     self.override_adr = adr;
                                 }
@@ -490,5 +498,98 @@ impl Session {
                 _ => (),
             }
         }
+    }
+}
+
+/// Rebuild the full 32-bit downlink frame counter from the 16-bit value carried
+/// on the wire and decide whether the frame is fresh.
+///
+/// Only the low 16 bits of the counter are transmitted (LoRaWAN 1.0.2
+/// §4.3.1.5); the receiver keeps the high 16 bits in `last` and advances them
+/// when the low half wraps. Returns the reconstructed counter to store, or
+/// `None` when the frame must be dropped because its counter does not advance
+/// past `last` or jumps further ahead than `MAX_FCNT_GAP` allows.
+///
+/// `last` is `None` until the first downlink of a session has been accepted, so
+/// that first frame is taken at face value instead of being compared against an
+/// initial counter.
+fn next_fcnt_down(last: Option<u32>, wire: u16) -> Option<u32> {
+    let Some(last) = last else {
+        return Some(u32::from(wire));
+    };
+    let high = last & 0xFFFF_0000;
+    let reconstructed = if wire >= last as u16 {
+        high | u32::from(wire)
+    } else {
+        // The low half wrapped, so the frame belongs to the next 16-bit epoch.
+        high.wrapping_add(0x1_0000) | u32::from(wire)
+    };
+    // Drop replays and counters that jump too far ahead. A stale frame from an
+    // earlier counter reconstructs to a value far beyond `last`, so the gap
+    // bound rejects it here before the MIC is even checked.
+    match reconstructed.checked_sub(last) {
+        Some(gap) if gap > 0 && gap <= MAX_FCNT_GAP as u32 => Some(reconstructed),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::next_fcnt_down;
+
+    #[test]
+    fn first_downlink_taken_at_face_value() {
+        // Before any downlink is seen, the wire value is accepted as-is even
+        // when it is zero (the counter both ends start from).
+        assert_eq!(next_fcnt_down(None, 0), Some(0));
+        assert_eq!(next_fcnt_down(None, 7), Some(7));
+    }
+
+    #[test]
+    fn increasing_counter_in_same_epoch() {
+        assert_eq!(next_fcnt_down(Some(5), 6), Some(6));
+        assert_eq!(next_fcnt_down(Some(100), 200), Some(200));
+    }
+
+    #[test]
+    fn jump_beyond_max_fcnt_gap_is_dropped() {
+        use super::MAX_FCNT_GAP;
+        let last = 5;
+        // A jump of exactly MAX_FCNT_GAP is still accepted.
+        let at_limit = last + MAX_FCNT_GAP as u16;
+        assert_eq!(next_fcnt_down(Some(last as u32), at_limit), Some(at_limit as u32));
+        // One past the limit is rejected.
+        assert_eq!(next_fcnt_down(Some(last as u32), at_limit + 1), None);
+    }
+
+    #[test]
+    fn replayed_or_stale_counter_is_dropped() {
+        // Exact replay of the last counter.
+        assert_eq!(next_fcnt_down(Some(6), 6), None);
+        // An older counter from the same epoch.
+        assert_eq!(next_fcnt_down(Some(6), 5), None);
+        // A wire value of zero no longer resets the counter or bypasses the
+        // freshness check once a downlink has been seen.
+        assert_eq!(next_fcnt_down(Some(6), 0), None);
+    }
+
+    #[test]
+    fn counter_is_reconstructed_past_16_bits() {
+        // Wire wraps 0xFFFF -> 0x0000: the reconstructed value crosses into the
+        // next epoch rather than folding back to zero.
+        assert_eq!(next_fcnt_down(Some(0xFFFF), 0), Some(0x1_0000));
+        // Further progress inside the high epoch.
+        assert_eq!(next_fcnt_down(Some(0x1_0000), 1), Some(0x1_0001));
+        // A frame far into the session reconstructs correctly instead of
+        // capping at 0xFFFF.
+        assert_eq!(next_fcnt_down(Some(0x0003_FFFE), 0xFFFF), Some(0x0003_FFFF));
+        assert_eq!(next_fcnt_down(Some(0x0003_FFFF), 0), Some(0x0004_0000));
+    }
+
+    #[test]
+    fn near_top_of_range_does_not_wrap_backwards() {
+        // Reconstruction that would overflow the 32-bit counter is rejected
+        // rather than wrapping to a smaller value.
+        assert_eq!(next_fcnt_down(Some(0xFFFF_FFFE), 0), None);
     }
 }


### PR DESCRIPTION
The downlink frame counter was only read as the 16 bits carried on the wire and zero-extended, so it capped at 0xFFFF. Once the network counter passed that, the device validated the MIC against the wrong 32-bit value and silently dropped every legitimate downlink, and the replay window was only 16 bits wide.

This rebuilds the full counter from the high 16 bits retained in the session (LoRaWAN 1.0.2 section 4.3.1.5) and bounds the forward jump with `MAX_FCNT_GAP`, which was defined but previously unused. A stale or replayed frame is now rejected on the counter alone, before the MIC check.

It also removes the acceptance path for a wire counter of 0, which previously let any such frame through regardless of history and reset the stored counter to 0, reopening the replay window for captured frames. `Session::fcnt_down` is now a private `Option<u32>` (with a `fcnt_down()` accessor), where `None` means no downlink has been accepted yet, so the first frame of a session is taken at face value and a counter of 0 is only accepted once.

Notes for review:

- Breaking change: `fcnt_down` was a public field and is now private with a changed type. In-tree, only a test helper touched it directly.
- The certification path narrowed the counter to `u16` with `.try_into().unwrap()`, which would panic once the counter grows past 16 bits; it now truncates to the low 16 bits it expects.
- The multicast tests delivered two downlinks at counter 0 and only passed because of the old bypass; they now use increasing counters.
- The reconstruction logic lives in a pure helper, `next_fcnt_down`, with unit tests covering the first-frame case, replays, the 16-bit wrap, the gap bound, and the top of the 32-bit range.