### PR TITLE
busy guard for lr1110, fix race condition

### DIFF
--- a/lora-phy/src/lr1110_interface.rs
+++ b/lora-phy/src/lr1110_interface.rs
@@ -31,6 +31,9 @@ where
 
     // Write a buffer to the radio.
     pub async fn write(&mut self, write_buffer: &[u8], is_sleep_command: bool) -> Result<(), RadioError> {
+        // Guard: wait for BUSY to be LOW before asserting NSS
+        self.iv.wait_on_busy().await?;
+
         self.spi.write(write_buffer).await.map_err(|_| SPI)?;
         trace!("write: {=[u8]:02x}", write_buffer);
 
@@ -68,10 +71,16 @@ where
     pub async fn read(&mut self, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<(), RadioError> {
         // Step 1: Write command in separate transaction
         if !write_buffer.is_empty() {
+            // Guard: wait for BUSY to be LOW before asserting NSS. If the
+            // previous transaction's BUSY de-assertion glitches or the GPIOTE
+            // edge-detection in wait_for_low returns early, writing a new
+            // command while BUSY is still asserted will corrupt the response.
+            self.iv.wait_on_busy().await?;
+
             self.spi.write(write_buffer).await.map_err(|_| SPI)?;
         }
 
-        // Step 2: Wait for BUSY to go low
+        // Step 2: Wait for BUSY to go low (post-command processing)
         self.iv.wait_on_busy().await?;
 
         // Step 3: Read response in separate transaction


### PR DESCRIPTION
this change was proposed by my random LLM while seeing this issue https://github.com/lora-rs/lora-rs/issues/449#issuecomment-5122266027

please check that the change is harmless

I'm testing with a NRF52832


we are still dependent on #445 for lorawan to work correctly on the LR1110

I tested that device.join( ) returns JoinResponse::JoinSuccess, no traffic after that