### PR TITLE
docs: require release builds for STM32WL examples

### DIFF
--- a/examples/stm32wl/README.md
+++ b/examples/stm32wl/README.md
@@ -1,5 +1,24 @@
 # stm32wl examples
 
 ## Overview
+
 These examples demonstrate how to use lora-phy (and sometimes lorawan-device) on the STM32WL platform.
 The NUCLEO-WL55JC1 board is a readily available development board for the STM32WL55JC SoC and it features an on-board debugger.
+
+## Building and running
+
+Build these examples with the release profile. Unoptimized development builds are
+substantially larger and slower on this constrained target, and their different
+timing can prevent the radio examples from operating correctly.
+
+For example, to run the peer-to-peer transmitter from this directory:
+
+```sh
+cargo run --release --bin lora_p2p_send
+```
+
+Replace `lora_p2p_send` with any of the other binaries in `src/bin` as needed.
+The release profile retains debug information, so `probe-rs` can still report
+symbolized backtraces and source locations.
+
+Running these examples without `--release` is not supported.


### PR DESCRIPTION
The STM32WL examples can fail in unoptimized development builds because those builds are substantially larger and have different timing characteristics on the constrained target. This was previously only explained in the issue tracker.

Document that the examples must be run with the release profile, provide a copy-paste `cargo run --release` command, and clarify that the profile retains debug information for symbolized `probe-rs` output.

Closes #205.

Validation:
- `cargo metadata --manifest-path examples/stm32wl/Cargo.toml --no-deps --format-version 1`
- `git diff --check`