### PR TITLE
fix examples EUI environment variable byte order

### DIFF
--- a/examples/nrf52840/build.rs
+++ b/examples/nrf52840/build.rs
@@ -25,7 +25,12 @@ fn hex_to_bytes(s: &str) -> Option<Vec<u8>> {
 }
 
 /// Read and parse LoRaWAN keys as HEX strings from an environment variable
-fn parse_lorawan_id(val: Option<&str>, var: &str, len: usize) -> Option<String> {
+fn parse_lorawan_id(
+    val: Option<&str>,
+    var: &str,
+    len: usize,
+    lsb_first: bool,
+) -> Option<String> {
     if let Some(s) = val {
         let l = s.len();
         // Allow empty keys
@@ -40,7 +45,12 @@ fn parse_lorawan_id(val: Option<&str>, var: &str, len: usize) -> Option<String> 
                 2 * len
             );
         }
-        if let Some(v) = hex_to_bytes(s) {
+        if let Some(mut v) = hex_to_bytes(s) {
+            // Environment variables use the conventional MSB-first display form.
+            // EUIs must be stored in the generated array in LoRaWAN wire order.
+            if lsb_first {
+                v.reverse();
+            }
             return Some(format!("Some({:?})", v));
         } else {
             panic!(
@@ -71,9 +81,9 @@ fn main() {
             const DEVEUI: Option<[u8; 8]> = {};\n\
             const APPEUI: Option<[u8; 8]> = {};\n\
             const APPKEY: Option<[u8; 16]> = {};\n",
-                parse_lorawan_id(option_env!("LORA_DEVEUI"), "LORA_DEVEUI", 8).unwrap_or("None".to_string()),
-                parse_lorawan_id(option_env!("LORA_APPEUI"), "LORA_APPEUI", 8).unwrap_or("None".to_string()),
-                parse_lorawan_id(option_env!("LORA_APPKEY"), "LORA_APPKEY", 16).unwrap_or("None".to_string()),
+                parse_lorawan_id(option_env!("LORA_DEVEUI"), "LORA_DEVEUI", 8, true).unwrap_or("None".to_string()),
+                parse_lorawan_id(option_env!("LORA_APPEUI"), "LORA_APPEUI", 8, true).unwrap_or("None".to_string()),
+                parse_lorawan_id(option_env!("LORA_APPKEY"), "LORA_APPKEY", 16, false).unwrap_or("None".to_string()),
             )
         )
         .unwrap();

--- a/examples/stm32wl/build.rs
+++ b/examples/stm32wl/build.rs
@@ -25,7 +25,12 @@ fn hex_to_bytes(s: &str) -> Option<Vec<u8>> {
 }
 
 /// Read and parse LoRaWAN keys as HEX strings from an environment variable
-fn parse_lorawan_id(val: Option<&str>, var: &str, len: usize) -> Option<String> {
+fn parse_lorawan_id(
+    val: Option<&str>,
+    var: &str,
+    len: usize,
+    lsb_first: bool,
+) -> Option<String> {
     if let Some(s) = val {
         let l = s.len();
         // Allow empty keys
@@ -40,7 +45,12 @@ fn parse_lorawan_id(val: Option<&str>, var: &str, len: usize) -> Option<String> 
                 2 * len
             );
         }
-        if let Some(v) = hex_to_bytes(s) {
+        if let Some(mut v) = hex_to_bytes(s) {
+            // Environment variables use the conventional MSB-first display form.
+            // EUIs must be stored in the generated array in LoRaWAN wire order.
+            if lsb_first {
+                v.reverse();
+            }
             return Some(format!("Some({:?})", v));
         } else {
             panic!(
@@ -71,9 +81,9 @@ fn main() {
             const DEVEUI: Option<[u8; 8]> = {};\n\
             const APPEUI: Option<[u8; 8]> = {};\n\
             const APPKEY: Option<[u8; 16]> = {};\n",
-                parse_lorawan_id(option_env!("LORA_DEVEUI"), "LORA_DEVEUI", 8).unwrap_or("None".to_string()),
-                parse_lorawan_id(option_env!("LORA_APPEUI"), "LORA_APPEUI", 8).unwrap_or("None".to_string()),
-                parse_lorawan_id(option_env!("LORA_APPKEY"), "LORA_APPKEY", 16).unwrap_or("None".to_string()),
+                parse_lorawan_id(option_env!("LORA_DEVEUI"), "LORA_DEVEUI", 8, true).unwrap_or("None".to_string()),
+                parse_lorawan_id(option_env!("LORA_APPEUI"), "LORA_APPEUI", 8, true).unwrap_or("None".to_string()),
+                parse_lorawan_id(option_env!("LORA_APPKEY"), "LORA_APPKEY", 16, false).unwrap_or("None".to_string()),
             )
         )
         .unwrap();

--- a/examples/stm32wle5cx/build.rs
+++ b/examples/stm32wle5cx/build.rs
@@ -25,7 +25,12 @@ fn hex_to_bytes(s: &str) -> Option<Vec<u8>> {
 }
 
 /// Read and parse LoRaWAN keys as HEX strings from an environment variable
-fn parse_lorawan_id(val: Option<&str>, var: &str, len: usize) -> Option<String> {
+fn parse_lorawan_id(
+    val: Option<&str>,
+    var: &str,
+    len: usize,
+    lsb_first: bool,
+) -> Option<String> {
     if let Some(s) = val {
         let l = s.len();
         // Allow empty keys
@@ -40,7 +45,12 @@ fn parse_lorawan_id(val: Option<&str>, var: &str, len: usize) -> Option<String> 
                 2 * len
             );
         }
-        if let Some(v) = hex_to_bytes(s) {
+        if let Some(mut v) = hex_to_bytes(s) {
+            // Environment variables use the conventional MSB-first display form.
+            // EUIs must be stored in the generated array in LoRaWAN wire order.
+            if lsb_first {
+                v.reverse();
+            }
             return Some(format!("Some({:?})", v));
         } else {
             panic!(
@@ -71,9 +81,9 @@ fn main() {
             const DEVEUI: Option<[u8; 8]> = {};\n\
             const APPEUI: Option<[u8; 8]> = {};\n\
             const APPKEY: Option<[u8; 16]> = {};\n",
-                parse_lorawan_id(option_env!("LORA_DEVEUI"), "LORA_DEVEUI", 8).unwrap_or("None".to_string()),
-                parse_lorawan_id(option_env!("LORA_APPEUI"), "LORA_APPEUI", 8).unwrap_or("None".to_string()),
-                parse_lorawan_id(option_env!("LORA_APPKEY"), "LORA_APPKEY", 16).unwrap_or("None".to_string()),
+                parse_lorawan_id(option_env!("LORA_DEVEUI"), "LORA_DEVEUI", 8, true).unwrap_or("None".to_string()),
+                parse_lorawan_id(option_env!("LORA_APPEUI"), "LORA_APPEUI", 8, true).unwrap_or("None".to_string()),
+                parse_lorawan_id(option_env!("LORA_APPKEY"), "LORA_APPKEY", 16, false).unwrap_or("None".to_string()),
             )
         )
         .unwrap();

--- a/lorawan-encoding/src/keys.rs
+++ b/lorawan-encoding/src/keys.rs
@@ -200,13 +200,13 @@ macro_rules! lorawan_eui {
         $(#[$outer])*
         #[doc = concat!(
             "# Usage\n\n",
-            "## Creating from a hex-encoded LSB string:\n",
+            "## Creating from a human-readable, MSB-first hex string:\n",
             "```\n",
             "use lorawan::keys::", stringify!($type), ";\n",
             "use core::str::FromStr;\n",
             "let eui = ", stringify!($type), "::from_str(\"0011223344556677\").unwrap();\n",
             "```\n\n",
-            "## Creating from a byte array in LSB format:\n",
+            "## Creating from a byte array in LoRaWAN wire order (LSB first):\n",
             "```\n",
             "use lorawan::keys::", stringify!($type), ";\n",
             "let eui = ", stringify!($type), "::from([\n",


### PR DESCRIPTION
`DevEui::from_str` and `AppEui::from_str` already accept the conventional human-readable MSB-first representation and reverse it into the LSB-first order used on the LoRaWAN wire. The byte-array constructors intentionally do not reverse because they accept bytes already in wire order.

The nRF52840, STM32WL, and STM32WLE5Cx build scripts bypassed that string conversion: they decoded `LORA_DEVEUI` and `LORA_APPEUI` left-to-right and passed the resulting arrays directly to `From<[u8; 8]>`. Consequently, a conventional environment value such as `70B3D57ED8004152` was transmitted in the wrong order.

This change:

- reverses EUI environment-variable bytes into LoRaWAN wire order in all three affected build scripts;
- leaves `LORA_APPKEY` in MSB-first order; and
- clarifies that EUI `FromStr` accepts the human-readable MSB-first form, while `From<[u8; 8]>` accepts LSB-first wire-order bytes.

Closes #364.

Validation:

- `cargo fmt --all --check`
- `cargo test -p lorawan --features with-to-string`
- `cargo check --manifest-path examples/stm32wl/Cargo.toml --target thumbv7em-none-eabi --bins`
- `cargo check --manifest-path examples/stm32wle5cx/Cargo.toml --target thumbv7em-none-eabi --bins`
- `cargo check --manifest-path examples/nrf52840/Cargo.toml --target thumbv7em-none-eabi --bins`
- `git diff --check`