### PR TITLE
fix creators to initialize reused buffers

### DIFF
--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -81,6 +81,7 @@ impl<D: AsMut<[u8]>> JoinAcceptCreator<D> {
         if d.len() < JOIN_ACCEPT_LEN {
             return Err(Error::BufferTooShort);
         }
+        d[..JOIN_ACCEPT_LEN - MIC_LEN].fill(0);
         d[0] = 0x20;
         Ok(Self { data, with_c_f_list: false, encrypted: false })
     }
@@ -172,6 +173,7 @@ impl<D: AsMut<[u8]>> JoinAcceptCreator<D> {
         if d.len() < JOIN_ACCEPT_WITH_CFLIST_LEN {
             return Err(Error::BufferTooShort);
         }
+        d[13..JOIN_ACCEPT_WITH_CFLIST_LEN - MIC_LEN].fill(0);
         ch_list.iter().enumerate().for_each(|(i, fr)| {
             let v = fr.value() / 100;
             d[13 + i * 3] = (v & 0xff) as u8;
@@ -250,6 +252,7 @@ impl<D: AsMut<[u8]>> JoinRequestCreator<D> {
         if d.len() < JOIN_REQUEST_LEN {
             return Err(Error::BufferTooShort);
         }
+        d[..JOIN_REQUEST_LEN - MIC_LEN].fill(0);
         d[0] = 0x00;
         Ok(Self { data })
     }
@@ -348,6 +351,7 @@ impl<D: AsMut<[u8]>> DataPayloadCreator<D> {
         if d.len() < PHY_PAYLOAD_MIN_LEN {
             return Err(Error::BufferTooShort);
         }
+        d[..PHY_PAYLOAD_MIN_LEN - MIC_LEN].fill(0);
         d[0] = 0x40;
         Ok(DataPayloadCreator { data, data_f_port: None, fcnt: 0 })
     }
@@ -504,12 +508,13 @@ impl<D: AsMut<[u8]>> DataPayloadCreator<D> {
         if !has_fport && payload_len > 0 {
             return Err(Error::FRMPayloadWithFportZero);
         }
-        // Set FOptsLen if present
+        // Set FOptsLen, including clearing a value from a previous build.
+        d[5] &= 0xf0;
         if !has_fport_zero && mac_cmds_len > 0 {
             if d.len() < last_filled + mac_cmds_len + MIC_LEN {
                 return Err(Error::BufferTooShort);
             }
-            d[5] |= mac_cmds_len as u8 & 0x0f;
+            d[5] |= mac_cmds_len as u8;
             // copy mac commmands into d
             d[last_filled..last_filled + mac_cmds_len].copy_from_slice(mac_cmds.as_ref());
             last_filled += mac_cmds_len;

--- a/lorawan-encoding/tests/lorawan.rs
+++ b/lorawan-encoding/tests/lorawan.rs
@@ -502,6 +502,40 @@ fn test_data_payload_uplink_creator() {
 }
 
 #[test]
+fn test_data_payload_creator_does_not_depend_on_buffer_contents() {
+    let mut clean_buf = [0u8; 12];
+    let mut dirty_buf = [0xa5; 12];
+    let nwk_skey = [2; 16].into();
+    let app_skey = [1; 16].into();
+
+    let clean = DataPayloadCreator::new(&mut clean_buf)
+        .unwrap()
+        .build(b"", [], &nwk_skey, &app_skey, &DefaultFactory)
+        .unwrap()
+        .to_owned();
+    let dirty = DataPayloadCreator::new(&mut dirty_buf)
+        .unwrap()
+        .build(b"", [], &nwk_skey, &app_skey, &DefaultFactory)
+        .unwrap()
+        .to_owned();
+
+    assert_eq!(dirty, clean);
+}
+
+#[test]
+fn test_data_payload_creator_clears_previous_fopts_len() {
+    let mut buf = [0u8; 32];
+    let nwk_skey = [2; 16].into();
+    let app_skey = [1; 16].into();
+    let mut phy = DataPayloadCreator::new(&mut buf).unwrap();
+
+    phy.build(b"", [0x02, 0x03], &nwk_skey, &app_skey, &DefaultFactory).unwrap();
+    let rebuilt = phy.build(b"", [], &nwk_skey, &app_skey, &DefaultFactory).unwrap();
+
+    assert_eq!(rebuilt[5] & 0x0f, 0);
+}
+
+#[test]
 fn test_long_data_payload_uplink_creator() {
     let mut buf = [0u8; 256];
     let mut phy = DataPayloadCreator::new(&mut buf).unwrap();
@@ -674,6 +708,52 @@ fn test_join_accept_creator() {
 
     assert_eq!(phy.build(&key, &DefaultFactory), Ok(&phy_join_accept_payload()[..]));
 }
+
+#[test]
+fn test_join_accept_creator_does_not_depend_on_buffer_contents() {
+    let mut clean_buf = [0u8; 17];
+    let mut dirty_buf = [0xa5; 17];
+    let key = AES128(app_key());
+
+    let clean = JoinAcceptCreator::new(&mut clean_buf)
+        .unwrap()
+        .build(&key, &DefaultFactory)
+        .unwrap()
+        .to_owned();
+    let dirty = JoinAcceptCreator::new(&mut dirty_buf)
+        .unwrap()
+        .build(&key, &DefaultFactory)
+        .unwrap()
+        .to_owned();
+
+    assert_eq!(dirty, clean);
+}
+
+#[test]
+fn test_join_accept_creator_clears_unused_cflist_entries() {
+    let mut clean_buf = [0u8; 33];
+    let mut dirty_buf = [0xa5; 33];
+    let key = AES128(app_key());
+    let freqs = [Frequency::new_from_raw(&[0x18, 0x4f, 0x84])];
+
+    let clean = JoinAcceptCreator::new(&mut clean_buf)
+        .unwrap()
+        .set_c_f_list(&freqs)
+        .unwrap()
+        .build(&key, &DefaultFactory)
+        .unwrap()
+        .to_owned();
+    let dirty = JoinAcceptCreator::new(&mut dirty_buf)
+        .unwrap()
+        .set_c_f_list(&freqs)
+        .unwrap()
+        .build(&key, &DefaultFactory)
+        .unwrap()
+        .to_owned();
+
+    assert_eq!(dirty, clean);
+}
+
 #[test]
 fn test_join_accept_creator_long_buffer() {
     let mut buf = [0u8; 255];
@@ -732,6 +812,19 @@ fn test_join_request_creator() {
 
     assert_eq!(phy.build(&key, &DefaultFactory), &phy_join_request_payload());
 }
+
+#[test]
+fn test_join_request_creator_does_not_depend_on_buffer_contents() {
+    let clean_buf = [0u8; 23];
+    let dirty_buf = [0xa5; 23];
+    let key = [1; 16].into();
+
+    let clean = JoinRequestCreator::new(clean_buf).unwrap().build(&key, &DefaultFactory).to_owned();
+    let dirty = JoinRequestCreator::new(dirty_buf).unwrap().build(&key, &DefaultFactory).to_owned();
+
+    assert_eq!(dirty, clean);
+}
+
 #[test]
 fn test_join_request_creator_long_buffer() {
     let buf = [0u8; 255];


### PR DESCRIPTION
Payload creators accepted caller-owned buffers but initialized only the MHDR byte. Any field not explicitly set by the caller therefore retained prior buffer contents. In `DataPayloadCreator`, this affected FCtrl byte 5 directly: building an otherwise empty frame from a dirty buffer produced a different packet and MIC. Reusing a creator could also retain the previous build's FOptsLen because the new length was ORed into the old value.

Initialize the fixed protocol fields owned by each creator while leaving bytes outside the produced frame untouched. Set FOptsLen from scratch on every build. The audit requested in #136 found and fixes the same reliance in `JoinRequestCreator`, `JoinAcceptCreator`, and unused JoinAccept CFList entries.

Five regression tests compare clean and deliberately dirty buffers and cover creator reuse with a shrinking FOpts list.

Closes #136.

Validation:

- `cargo fmt --all --check`
- `cargo test -p lorawan --features with-to-string` (199 tests passed)
- `cargo clippy -p lorawan --lib --tests --features with-to-string`
- `git diff --check`

Note: `cargo clippy -p lorawan --all-targets` reaches an existing benchmark incompatibility with the current AES/cipher API (`benches/lorawan.rs` imports the removed `cipher::generic_array`); the affected library and test targets pass Clippy, with only the two existing `GenericArray::from_mut_slice` deprecation warnings.