### PR TITLE
phy: shared scaffolding for SWL2001 reference tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      # Needed to build the smtc-modem-cores bindings used by lora-phy tests
+      - name: Setup apt packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends cmake llvm-dev clang libclang-dev
+
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -87,6 +91,10 @@ jobs:
         uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
+
+      # Needed to build the smtc-modem-cores bindings used by lora-phy tests
+      - name: Setup apt packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends cmake llvm-dev clang libclang-dev
 
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -33,3 +33,7 @@ lorawan-radio = ["dep:lorawan-device"]
 [dev-dependencies]
 # Include lorawan-device unconditionally so all regions are enabled for tests
 lorawan-device = { path = "../lorawan-device" }
+# Bindings to Semtech's reference driver (SWL2001), used to test our
+# implementation against the vendor's SPI byte stream
+smtc-modem-cores = "0.2.1"
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/src/lib.rs
+++ b/lora-phy/src/lib.rs
@@ -31,6 +31,11 @@ pub mod mod_traits;
 pub mod sx126x;
 /// Specific implementation to support Semtech Sx127x chips
 pub mod sx127x;
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+#[cfg(test)]
+pub(crate) mod test_fixtures;
 
 pub use crate::mod_params::RxMode;
 

--- a/lora-phy/src/test_fixtures.rs
+++ b/lora-phy/src/test_fixtures.rs
@@ -1,0 +1,50 @@
+//! Chip-independent scaffolding shared by the per-chip comparison-test
+//! fixtures. Only zero-semantics boilerplate belongs here — each fixture's
+//! transaction recording and equality rules are chip-specific by design.
+// Nothing references this module until the per-chip suites land; any of
+// those PRs can drop this allow.
+#![allow(dead_code)]
+use crate::mod_params::RadioError;
+use crate::mod_traits::InterfaceVariant;
+use embedded_hal::spi::ErrorKind;
+use embedded_hal_async::delay::DelayNs;
+
+/// SPI error type for fixtures that never fail
+#[derive(Debug)]
+pub enum SpiError {}
+impl embedded_hal::spi::Error for SpiError {
+    fn kind(&self) -> ErrorKind {
+        match *self {}
+    }
+}
+
+/// Delay provider that returns immediately
+pub struct Delayer;
+impl DelayNs for Delayer {
+    async fn delay_ns(&mut self, _ns: u32) {}
+}
+
+/// InterfaceVariant with no-op control lines (busy always ready, IRQ
+/// always pending, RF switch ignored)
+pub struct DummyVariant;
+
+impl InterfaceVariant for DummyVariant {
+    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn await_irq(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
First of four PRs splitting up #445 as discussed with @plaes.

Chip-independent groundwork for testing our drivers against Semtech's reference implementation (SWL2001) at the SPI byte level:

- dev-depend on smtc-modem-cores (bindings to SWL2001) from crates.io. Pinned to 0.2.1: 0.2.0 is yanked because its sx127x wrapper missed re-arming hal_context in read_register, which the comparison suite caught as a segfault.
- a small cfg(test) module with the fixture boilerplate shared by all three chips (no-op delay, no-op InterfaceVariant, never-failing SPI error type). Each chip suite brings its own transaction recording and equality rules; those are chip-specific by design.
- the crate stays unconditionally #![no_std]; test modules get std via a cfg(test) extern crate (the bindings are no_std since 0.2).
- CI installs cmake/llvm/clang, needed to build the bindings.

The per-chip suites follow as PRs based on this one:
- sx126x: comparison tests, behavioral emulator and the PA power table rework
- sx127x: register-level comparison tests, sx1276 errata fixes and an emulator with edge-triggered DIO0
- lr1110: comparison tests, command encoding fixes and vendor PA power tables

The shared module carries a temporary allow(dead_code) since nothing references it until a chip suite lands; whichever module PR merges first drops it.