### PR TITLE
phy: test the sx126x driver against SWL2001

### DIFF
--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -36,4 +36,6 @@ lorawan-device = { path = "../lorawan-device" }
 # Bindings to Semtech's reference driver (SWL2001), used to test our
 # implementation against the vendor's SPI byte stream
 smtc-modem-cores = "0.2.1"
+# Derive `OpCode::from_repr` for the sx126x behavioral emulator (test-only)
+strum = { version = "0.28", default-features = false, features = ["derive"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -1,5 +1,8 @@
 mod radio_kind_params;
 
+#[cfg(test)]
+mod test;
+
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::*;
 pub use radio_kind_params::TcxoCtrlVoltage;
@@ -172,6 +175,11 @@ where
 
         (steps_int << SX126X_PLL_STEP_SHIFT_AMOUNT)
             + (((steps_frac << SX126X_PLL_STEP_SHIFT_AMOUNT) + (SX126X_PLL_STEP_SCALED >> 1)) / SX126X_PLL_STEP_SCALED)
+    }
+
+    #[cfg(test)]
+    fn take_spi(self) -> SPI {
+        self.intf.spi
     }
 
     // SX162x WriteRegister wrapper for single u8 value writes

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -479,8 +479,13 @@ where
                     }
                     HIGH_POWER_MIN..=14 => {
                         self.set_pa_config(0x02, 0x02, DeviceSel::HighPowerPA).await?;
-                        // table indicates 14 dBm => txp = 22, therefore we should add 8 to this range
-                        // this however seems to be wrong when looking at the reference driver
+                        // The vendors disagree on this row. Datasheet Table
+                        // 13-21 (through Rev 2.2) says SetTxParams +22 with
+                        // this PA config; ST's STM32CubeWL driver — an SX126x
+                        // die inside the STM32WL — commands +14 with the same
+                        // config, while agreeing with the datasheet on every
+                        // other row. We follow ST. Settling which is right
+                        // for a discrete SX1262 needs a power measurement.
                         // https://github.com/STMicroelectronics/STM32CubeWL/blob/139e8d28bcec6af78dec8b52a9b9f9057868cc2e/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L675
                         tx_params_power = txp as u8;
                     }

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -182,6 +182,11 @@ where
         self.intf.spi
     }
 
+    #[cfg(test)]
+    fn spi_mut(&mut self) -> &mut SPI {
+        &mut self.intf.spi
+    }
+
     // SX162x WriteRegister wrapper for single u8 value writes
     async fn reg_w_8(&mut self, reg: Register, value: u8) -> Result<(), RadioError> {
         self.intf

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -479,15 +479,20 @@ where
                     }
                     HIGH_POWER_MIN..=14 => {
                         self.set_pa_config(0x02, 0x02, DeviceSel::HighPowerPA).await?;
-                        // The vendors disagree on this row. Datasheet Table
-                        // 13-21 (through Rev 2.2) says SetTxParams +22 with
-                        // this PA config; ST's STM32CubeWL driver — an SX126x
-                        // die inside the STM32WL — commands +14 with the same
-                        // config, while agreeing with the datasheet on every
-                        // other row. We follow ST. Settling which is right
-                        // for a discrete SX1262 needs a power measurement.
+                        // The only row where ST's table for the STM32WL (an
+                        // SX126x die integrated into ST's part) differs from
+                        // datasheet Table 13-21: same PA config, but ST
+                        // commands the target dBm directly where the
+                        // datasheet interpolates from its +22 setpoint
+                        // (table row: 14 dBm => SetTxParams +22, so add 8).
+                        // Each part takes the table it was characterized
+                        // with.
                         // https://github.com/STMicroelectronics/STM32CubeWL/blob/139e8d28bcec6af78dec8b52a9b9f9057868cc2e/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L675
-                        tx_params_power = txp as u8;
+                        tx_params_power = if self.config.chip.use_st_power_table() {
+                            txp as u8
+                        } else {
+                            (txp + 8) as u8
+                        };
                     }
                     _ => {
                         unreachable!("Invalid output power value for high power PA!")

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -407,99 +407,39 @@ where
         mdltn_params: Option<&ModulationParams>,
         is_tx_prep: bool,
     ) -> Result<(), RadioError> {
-        let tx_params_power;
         let ramp_time = match is_tx_prep {
             true => RampTime::Ramp40Us,   // for instance, prior to TX or CAD
             false => RampTime::Ramp200Us, // for instance, on initialization
         };
 
+        // PA-specific preconditions
         match self.config.chip.get_device_sel() {
             DeviceSel::LowPowerPA => {
-                const LOW_POWER_MIN: i32 = -17;
-                const LOW_POWER_MAX: i32 = 15;
-                // Clamp power between [-17, 15] dBm
-                let txp = output_power.clamp(LOW_POWER_MIN, LOW_POWER_MAX);
-
-                if txp == 15 {
+                // For SX1261 the +15 dBm row is only valid above 400 MHz
+                // (below, paDutyCycle must not exceed 0x04)
+                if output_power >= 15 {
                     if let Some(m_p) = mdltn_params {
                         if m_p.frequency_in_hz < 400_000_000 {
                             return Err(RadioError::InvalidOutputPowerForFrequency);
                         }
                     }
                 }
-
-                // For SX1261:
-                // if f < 400 MHz, paDutyCycle should not be higher than 0x04,
-                // if f > 400 Mhz, paDutyCycle should not be higher than 0x07.
-                // From Table 13-21: PA Operating Modes with Optimal Settings
-                match txp {
-                    LOW_POWER_MAX => {
-                        self.set_pa_config(0x06, 0x00, DeviceSel::LowPowerPA).await?;
-                        tx_params_power = 14;
-                    }
-                    11..=14 => {
-                        self.set_pa_config(0x04, 0x00, DeviceSel::LowPowerPA).await?;
-                        tx_params_power = txp as u8;
-                    }
-                    // 10 and less
-                    LOW_POWER_MIN..=10 => {
-                        self.set_pa_config(0x01, 0x00, DeviceSel::LowPowerPA).await?;
-                        // table indicates 10 dBm => txp = 13, therefore we add 3 to values below 10
-                        tx_params_power = txp as u8 + 3;
-                    }
-                    _ => unreachable!("Invalid output power value for low power PA!"),
-                }
             }
             DeviceSel::HighPowerPA => {
-                const HIGH_POWER_MIN: i32 = -9;
-                const HIGH_POWER_MAX: i32 = 22;
-                // Clamp power between [-9, 22] dBm
-                let txp = output_power.clamp(HIGH_POWER_MIN, HIGH_POWER_MAX);
-
                 // Provide better resistance of the SX1262 Tx to antenna mismatch
                 // Bits 4-1 must be set to `1111`
                 let tx_clamp_val = self.reg_r_8(Register::TxClampCfg).await?;
                 self.reg_w_8(Register::TxClampCfg, tx_clamp_val | 0b11110).await?;
-
-                // From Table 13-21: PA Operating Modes with Optimal Settings
-                match txp {
-                    21..=HIGH_POWER_MAX => {
-                        self.set_pa_config(0x04, 0x07, DeviceSel::HighPowerPA).await?;
-                        tx_params_power = 22;
-                    }
-                    18..=20 => {
-                        self.set_pa_config(0x03, 0x05, DeviceSel::HighPowerPA).await?;
-                        // table indicates 20 dBm => txp = 22, therefore we add 2 to this range
-                        tx_params_power = txp as u8 + 2;
-                    }
-                    15..=17 => {
-                        self.set_pa_config(0x02, 0x03, DeviceSel::HighPowerPA).await?;
-                        // table indicates 17 dBm => txp = 22, therefore we add 5 to this range
-                        tx_params_power = txp as u8 + 5;
-                    }
-                    HIGH_POWER_MIN..=14 => {
-                        self.set_pa_config(0x02, 0x02, DeviceSel::HighPowerPA).await?;
-                        // The only row where ST's table for the STM32WL (an
-                        // SX126x die integrated into ST's part) differs from
-                        // datasheet Table 13-21: same PA config, but ST
-                        // commands the target dBm directly where the
-                        // datasheet interpolates from its +22 setpoint
-                        // (table row: 14 dBm => SetTxParams +22, so add 8).
-                        // Each part takes the table it was characterized
-                        // with.
-                        // https://github.com/STMicroelectronics/STM32CubeWL/blob/139e8d28bcec6af78dec8b52a9b9f9057868cc2e/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L675
-                        tx_params_power = if self.config.chip.use_st_power_table() {
-                            txp as u8
-                        } else {
-                            (txp + 8) as u8
-                        };
-                    }
-                    _ => {
-                        unreachable!("Invalid output power value for high power PA!")
-                    }
-                }
             }
         }
+
+        // PA config and SetTxParams power come from the variant's const
+        // power table (datasheet Table 13-21 for discrete parts; boards
+        // with their own PA characterization supply their own table)
+        let (entry, tx_params_power) = self.config.chip.pa_table().lookup(output_power);
+        self.set_pa_config(entry.pa_duty_cycle, entry.hp_max, self.config.chip.get_device_sel())
+            .await?;
+
         let op_code_and_tx_params = [OpCode::SetTxParams.value(), tx_params_power, ramp_time.value()];
         self.intf.write(&op_code_and_tx_params, false).await
     }

--- a/lora-phy/src/sx126x/radio_kind_params.rs
+++ b/lora-phy/src/sx126x/radio_kind_params.rs
@@ -88,6 +88,9 @@ impl Register {
 }
 
 #[derive(Clone, Copy, PartialEq)]
+// `from_repr` lets the sx126x emulator dispatch a wire byte back to a variant
+#[cfg_attr(test, derive(strum::FromRepr))]
+#[repr(u8)]
 #[allow(dead_code)]
 pub enum OpCode {
     GetStatus = 0xC0,

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -3,6 +3,7 @@
 //! `Chip` handle to inject received packets and inspect transmitted ones.
 use crate::mod_params::RadioError;
 use crate::mod_traits::InterfaceVariant;
+use crate::sx126x::radio_kind_params::{IrqMask, OpCode};
 use crate::sx126x::{Config, Sx1261, Sx126x};
 use crate::test_fixtures::SpiError;
 use embedded_hal::spi::Operation;
@@ -12,30 +13,34 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::vec::Vec;
 
-// Opcodes as the chip sees them (subset the driver uses)
-const WRITE_REGISTER: u8 = 0x0D;
-const READ_REGISTER: u8 = 0x1D;
-const WRITE_BUFFER: u8 = 0x0E;
-const READ_BUFFER: u8 = 0x1E;
-const SET_SLEEP: u8 = 0x84;
-const SET_STANDBY: u8 = 0x80;
-const SET_TX: u8 = 0x83;
-const SET_RX: u8 = 0x82;
-const SET_RF_FREQUENCY: u8 = 0x86;
-const SET_PACKET_PARAMS: u8 = 0x8C;
-const SET_BUFFER_BASE_ADDRESS: u8 = 0x8F;
-const CFG_DIO_IRQ: u8 = 0x08;
-const GET_IRQ_STATUS: u8 = 0x12;
-const CLR_IRQ_STATUS: u8 = 0x02;
-const GET_RX_BUFFER_STATUS: u8 = 0x13;
-const GET_PACKET_STATUS: u8 = 0x14;
-const SET_CAD: u8 = 0xC5;
+// Dispatch constants derived from the driver's enums (enum variants can't
+// be `match` patterns against a raw byte, consts can). The byte values
+// themselves are pinned independently by the SWL2001 comparison suite, so
+// deriving from the driver here is not circular — the emulator's job is
+// behavior, not encoding.
+const WRITE_REGISTER: u8 = OpCode::WriteRegister as u8;
+const READ_REGISTER: u8 = OpCode::ReadRegister as u8;
+const WRITE_BUFFER: u8 = OpCode::WriteBuffer as u8;
+const READ_BUFFER: u8 = OpCode::ReadBuffer as u8;
+const SET_SLEEP: u8 = OpCode::SetSleep as u8;
+const SET_STANDBY: u8 = OpCode::SetStandby as u8;
+const SET_TX: u8 = OpCode::SetTx as u8;
+const SET_RX: u8 = OpCode::SetRx as u8;
+const SET_RF_FREQUENCY: u8 = OpCode::SetRFFrequency as u8;
+const SET_PACKET_PARAMS: u8 = OpCode::SetPacketParams as u8;
+const SET_BUFFER_BASE_ADDRESS: u8 = OpCode::SetBufferBaseAddress as u8;
+const CFG_DIO_IRQ: u8 = OpCode::CfgDIOIrq as u8;
+const GET_IRQ_STATUS: u8 = OpCode::GetIrqStatus as u8;
+const CLR_IRQ_STATUS: u8 = OpCode::ClrIrqStatus as u8;
+const GET_RX_BUFFER_STATUS: u8 = OpCode::GetRxBufferStatus as u8;
+const GET_PACKET_STATUS: u8 = OpCode::GetPacketStatus as u8;
+const SET_CAD: u8 = OpCode::SetCAD as u8;
 
-const IRQ_TX_DONE: u16 = 0x0001;
-const IRQ_RX_DONE: u16 = 0x0002;
-const IRQ_CAD_DONE: u16 = 0x0080;
-const IRQ_CAD_DETECTED: u16 = 0x0100;
-const IRQ_RX_TX_TIMEOUT: u16 = 0x0200;
+const IRQ_TX_DONE: u16 = IrqMask::TxDone as u16;
+const IRQ_RX_DONE: u16 = IrqMask::RxDone as u16;
+const IRQ_CAD_DONE: u16 = IrqMask::CADDone as u16;
+const IRQ_CAD_DETECTED: u16 = IrqMask::CADActivityDetected as u16;
+const IRQ_RX_TX_TIMEOUT: u16 = IrqMask::RxTxTimeout as u16;
 
 // No Tx variant: the model completes transmissions instantly inside SET_TX,
 // so the chip is never observable mid-transmit

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -35,6 +35,7 @@ const IRQ_TX_DONE: u16 = 0x0001;
 const IRQ_RX_DONE: u16 = 0x0002;
 const IRQ_CAD_DONE: u16 = 0x0080;
 const IRQ_CAD_DETECTED: u16 = 0x0100;
+const IRQ_RX_TX_TIMEOUT: u16 = 0x0200;
 
 // No Tx variant: the model completes transmissions instantly inside SET_TX,
 // so the chip is never observable mid-transmit
@@ -181,6 +182,15 @@ impl ChipModel {
                     self.registers.insert(REG_RSSI_SHADOW, (-2 * rx.rssi_dbm) as u8);
                     self.registers.insert(REG_SNR_SHADOW, (4 * rx.snr_db) as u8);
                     self.raise_irq(IRQ_RX_DONE);
+                } else if params[..3] != [0xFF, 0xFF, 0xFF] {
+                    // Anything but continuous mode times out when no packet
+                    // is pending. The wait is collapsed to zero — the model
+                    // has no clock, and nothing can arrive once SetRx has
+                    // executed — so this exercises the driver's timeout path
+                    // (single-mode symbol timeout and timed RX alike), not
+                    // timeout durations.
+                    self.mode = Mode::Standby;
+                    self.raise_irq(IRQ_RX_TX_TIMEOUT);
                 }
                 vec![]
             }

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -13,28 +13,10 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::vec::Vec;
 
-// Dispatch constants derived from the driver's enums (enum variants can't
-// be `match` patterns against a raw byte, consts can). The byte values
-// themselves are pinned independently by the SWL2001 comparison suite, so
-// deriving from the driver here is not circular — the emulator's job is
-// behavior, not encoding.
-const WRITE_REGISTER: u8 = OpCode::WriteRegister as u8;
-const READ_REGISTER: u8 = OpCode::ReadRegister as u8;
-const WRITE_BUFFER: u8 = OpCode::WriteBuffer as u8;
-const READ_BUFFER: u8 = OpCode::ReadBuffer as u8;
-const SET_SLEEP: u8 = OpCode::SetSleep as u8;
-const SET_STANDBY: u8 = OpCode::SetStandby as u8;
-const SET_TX: u8 = OpCode::SetTx as u8;
-const SET_RX: u8 = OpCode::SetRx as u8;
-const SET_RF_FREQUENCY: u8 = OpCode::SetRFFrequency as u8;
-const SET_PACKET_PARAMS: u8 = OpCode::SetPacketParams as u8;
-const SET_BUFFER_BASE_ADDRESS: u8 = OpCode::SetBufferBaseAddress as u8;
-const CFG_DIO_IRQ: u8 = OpCode::CfgDIOIrq as u8;
-const GET_IRQ_STATUS: u8 = OpCode::GetIrqStatus as u8;
-const CLR_IRQ_STATUS: u8 = OpCode::ClrIrqStatus as u8;
-const GET_RX_BUFFER_STATUS: u8 = OpCode::GetRxBufferStatus as u8;
-const GET_PACKET_STATUS: u8 = OpCode::GetPacketStatus as u8;
-const SET_CAD: u8 = OpCode::SetCAD as u8;
+// The wire byte is parsed back into an `OpCode` via `from_repr` and matched by
+// variant. The byte values themselves are pinned independently by the SWL2001
+// comparison suite, so dispatching on the driver's enum here is not circular:
+// the emulator's job is behavior, not encoding.
 
 const IRQ_TX_DONE: u16 = IrqMask::TxDone as u16;
 const IRQ_RX_DONE: u16 = IrqMask::RxDone as u16;
@@ -110,65 +92,65 @@ impl ChipModel {
     /// response bytes for opcodes the driver reads from (status byte first).
     fn execute(&mut self, opcode: u8, params: &[u8]) -> Vec<u8> {
         const STATUS_OK: u8 = 0x00;
-        match opcode {
-            WRITE_REGISTER => {
+        match OpCode::from_repr(opcode) {
+            Some(OpCode::WriteRegister) => {
                 let addr = u16::from_be_bytes([params[0], params[1]]);
                 for (i, b) in params[2..].iter().enumerate() {
                     self.registers.insert(addr + i as u16, *b);
                 }
                 vec![]
             }
-            READ_REGISTER => {
+            Some(OpCode::ReadRegister) => {
                 // params: addr(2) + nop; length comes from the driver's read buffer
                 let addr = u16::from_be_bytes([params[0], params[1]]);
                 (0..=u8::MAX).map(|i| self.reg_read(addr + i as u16)).collect()
             }
-            WRITE_BUFFER => {
+            Some(OpCode::WriteBuffer) => {
                 let offset = params[0] as usize;
                 self.buffer[offset..offset + params[1..].len()].copy_from_slice(&params[1..]);
                 vec![]
             }
-            READ_BUFFER => {
+            Some(OpCode::ReadBuffer) => {
                 // No status prefix: the driver reads this via plain read(),
                 // clocking the status byte out during its trailing nop write
                 let offset = params[0] as usize;
                 self.buffer[offset..].to_vec()
             }
-            SET_SLEEP => {
+            Some(OpCode::SetSleep) => {
                 self.mode = Mode::Sleep;
                 vec![]
             }
-            SET_STANDBY => {
+            Some(OpCode::SetStandby) => {
                 self.mode = Mode::Standby;
                 vec![]
             }
-            SET_RF_FREQUENCY => {
+            Some(OpCode::SetRFFrequency) => {
                 self.frequency_raw = u32::from_be_bytes([params[0], params[1], params[2], params[3]]);
                 vec![]
             }
-            SET_BUFFER_BASE_ADDRESS => {
+            Some(OpCode::SetBufferBaseAddress) => {
                 self.tx_base_addr = params[0];
                 vec![]
             }
-            SET_PACKET_PARAMS => {
+            Some(OpCode::SetPacketParams) => {
                 // LoRa: preamble(2), header type, payload length, crc, invert IQ
                 self.payload_length = params[3];
                 vec![]
             }
-            CFG_DIO_IRQ => {
+            Some(OpCode::CfgDIOIrq) => {
                 self.irq_mask = u16::from_be_bytes([params[0], params[1]]);
                 self.dio1_mask = u16::from_be_bytes([params[2], params[3]]);
                 vec![]
             }
-            CLR_IRQ_STATUS => {
+            Some(OpCode::ClrIrqStatus) => {
                 self.irq_status &= !u16::from_be_bytes([params[0], params[1]]);
                 vec![]
             }
-            GET_IRQ_STATUS => {
+            Some(OpCode::GetIrqStatus) => {
                 let [hi, lo] = self.irq_status.to_be_bytes();
                 vec![STATUS_OK, hi, lo]
             }
-            SET_TX => {
+            Some(OpCode::SetTx) => {
                 let base = self.tx_base_addr as usize;
                 self.tx_log.push(TxRecord {
                     frequency_raw: self.frequency_raw,
@@ -179,7 +161,7 @@ impl ChipModel {
                 self.raise_irq(IRQ_TX_DONE);
                 vec![]
             }
-            SET_RX => {
+            Some(OpCode::SetRx) => {
                 self.mode = Mode::Rx;
                 if let Some(rx) = self.pending_rx.take() {
                     self.buffer[..rx.payload.len()].copy_from_slice(&rx.payload);
@@ -199,14 +181,14 @@ impl ChipModel {
                 }
                 vec![]
             }
-            GET_RX_BUFFER_STATUS => vec![STATUS_OK, self.rx_len, 0x00],
-            GET_PACKET_STATUS => vec![
+            Some(OpCode::GetRxBufferStatus) => vec![STATUS_OK, self.rx_len, 0x00],
+            Some(OpCode::GetPacketStatus) => vec![
                 STATUS_OK,
                 self.reg_read(REG_RSSI_SHADOW),
                 self.reg_read(REG_SNR_SHADOW),
                 self.reg_read(REG_RSSI_SHADOW),
             ],
-            SET_CAD => {
+            Some(OpCode::SetCAD) => {
                 if self.cad_activity {
                     self.raise_irq(IRQ_CAD_DONE | IRQ_CAD_DETECTED);
                 } else {
@@ -214,7 +196,8 @@ impl ChipModel {
                 }
                 vec![]
             }
-            // Configuration commands the model accepts without side effects
+            // Configuration commands the model accepts without side effects,
+            // plus any opcode byte the driver never sends (from_repr → None)
             _ => vec![STATUS_OK; 16],
         }
     }

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -1,0 +1,327 @@
+//! A behavioral model of an sx126x chip driven over SPI. The real `Sx126x`
+//! driver and `LoRa` state machine run unmodified on top; tests hold a
+//! `Chip` handle to inject received packets and inspect transmitted ones.
+use crate::mod_params::RadioError;
+use crate::mod_traits::InterfaceVariant;
+use crate::sx126x::{Config, Sx1261, Sx126x};
+use crate::test_fixtures::SpiError;
+use embedded_hal::spi::Operation;
+use embedded_hal_async::delay::DelayNs;
+use embedded_hal_async::spi::SpiDevice;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::vec::Vec;
+
+// Opcodes as the chip sees them (subset the driver uses)
+const WRITE_REGISTER: u8 = 0x0D;
+const READ_REGISTER: u8 = 0x1D;
+const WRITE_BUFFER: u8 = 0x0E;
+const READ_BUFFER: u8 = 0x1E;
+const SET_SLEEP: u8 = 0x84;
+const SET_STANDBY: u8 = 0x80;
+const SET_TX: u8 = 0x83;
+const SET_RX: u8 = 0x82;
+const SET_RF_FREQUENCY: u8 = 0x86;
+const SET_PACKET_PARAMS: u8 = 0x8C;
+const SET_BUFFER_BASE_ADDRESS: u8 = 0x8F;
+const CFG_DIO_IRQ: u8 = 0x08;
+const GET_IRQ_STATUS: u8 = 0x12;
+const CLR_IRQ_STATUS: u8 = 0x02;
+const GET_RX_BUFFER_STATUS: u8 = 0x13;
+const GET_PACKET_STATUS: u8 = 0x14;
+const SET_CAD: u8 = 0xC5;
+
+const IRQ_TX_DONE: u16 = 0x0001;
+const IRQ_RX_DONE: u16 = 0x0002;
+const IRQ_CAD_DONE: u16 = 0x0080;
+const IRQ_CAD_DETECTED: u16 = 0x0100;
+
+// No Tx variant: the model completes transmissions instantly inside SET_TX,
+// so the chip is never observable mid-transmit
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Mode {
+    Standby,
+    Sleep,
+    Rx,
+}
+
+pub struct PendingRx {
+    pub payload: Vec<u8>,
+    pub rssi_dbm: i16,
+    pub snr_db: i16,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TxRecord {
+    pub frequency_raw: u32,
+    pub payload: Vec<u8>,
+}
+
+pub struct ChipModel {
+    pub mode: Mode,
+    pub registers: HashMap<u16, u8>,
+    pub buffer: [u8; 256],
+    tx_base_addr: u8,
+    payload_length: u8,
+    frequency_raw: u32,
+    irq_status: u16,
+    irq_mask: u16,
+    dio1_mask: u16,
+    rx_len: u8,
+    pub cad_activity: bool,
+    pub pending_rx: Option<PendingRx>,
+    pub tx_log: Vec<TxRecord>,
+}
+
+impl ChipModel {
+    fn new() -> Self {
+        Self {
+            mode: Mode::Standby,
+            registers: HashMap::new(),
+            buffer: [0; 256],
+            tx_base_addr: 0,
+            payload_length: 0,
+            frequency_raw: 0,
+            irq_status: 0,
+            irq_mask: 0,
+            dio1_mask: 0,
+            rx_len: 0,
+            cad_activity: false,
+            pending_rx: None,
+            tx_log: vec![],
+        }
+    }
+
+    fn raise_irq(&mut self, irq: u16) {
+        self.irq_status |= irq & self.irq_mask;
+    }
+
+    fn reg_read(&self, addr: u16) -> u8 {
+        *self.registers.get(&addr).unwrap_or(&0)
+    }
+
+    /// Execute one command; `params` excludes the opcode byte. Returns the
+    /// response bytes for opcodes the driver reads from (status byte first).
+    fn execute(&mut self, opcode: u8, params: &[u8]) -> Vec<u8> {
+        const STATUS_OK: u8 = 0x00;
+        match opcode {
+            WRITE_REGISTER => {
+                let addr = u16::from_be_bytes([params[0], params[1]]);
+                for (i, b) in params[2..].iter().enumerate() {
+                    self.registers.insert(addr + i as u16, *b);
+                }
+                vec![]
+            }
+            READ_REGISTER => {
+                // params: addr(2) + nop; length comes from the driver's read buffer
+                let addr = u16::from_be_bytes([params[0], params[1]]);
+                (0..=u8::MAX).map(|i| self.reg_read(addr + i as u16)).collect()
+            }
+            WRITE_BUFFER => {
+                let offset = params[0] as usize;
+                self.buffer[offset..offset + params[1..].len()].copy_from_slice(&params[1..]);
+                vec![]
+            }
+            READ_BUFFER => {
+                // No status prefix: the driver reads this via plain read(),
+                // clocking the status byte out during its trailing nop write
+                let offset = params[0] as usize;
+                self.buffer[offset..].to_vec()
+            }
+            SET_SLEEP => {
+                self.mode = Mode::Sleep;
+                vec![]
+            }
+            SET_STANDBY => {
+                self.mode = Mode::Standby;
+                vec![]
+            }
+            SET_RF_FREQUENCY => {
+                self.frequency_raw = u32::from_be_bytes([params[0], params[1], params[2], params[3]]);
+                vec![]
+            }
+            SET_BUFFER_BASE_ADDRESS => {
+                self.tx_base_addr = params[0];
+                vec![]
+            }
+            SET_PACKET_PARAMS => {
+                // LoRa: preamble(2), header type, payload length, crc, invert IQ
+                self.payload_length = params[3];
+                vec![]
+            }
+            CFG_DIO_IRQ => {
+                self.irq_mask = u16::from_be_bytes([params[0], params[1]]);
+                self.dio1_mask = u16::from_be_bytes([params[2], params[3]]);
+                vec![]
+            }
+            CLR_IRQ_STATUS => {
+                self.irq_status &= !u16::from_be_bytes([params[0], params[1]]);
+                vec![]
+            }
+            GET_IRQ_STATUS => {
+                let [hi, lo] = self.irq_status.to_be_bytes();
+                vec![STATUS_OK, hi, lo]
+            }
+            SET_TX => {
+                let base = self.tx_base_addr as usize;
+                self.tx_log.push(TxRecord {
+                    frequency_raw: self.frequency_raw,
+                    payload: self.buffer[base..base + self.payload_length as usize].to_vec(),
+                });
+                // Transmission completes instantly; chip falls back to standby
+                self.mode = Mode::Standby;
+                self.raise_irq(IRQ_TX_DONE);
+                vec![]
+            }
+            SET_RX => {
+                self.mode = Mode::Rx;
+                if let Some(rx) = self.pending_rx.take() {
+                    self.buffer[..rx.payload.len()].copy_from_slice(&rx.payload);
+                    self.rx_len = rx.payload.len() as u8;
+                    self.registers.insert(REG_RSSI_SHADOW, (-2 * rx.rssi_dbm) as u8);
+                    self.registers.insert(REG_SNR_SHADOW, (4 * rx.snr_db) as u8);
+                    self.raise_irq(IRQ_RX_DONE);
+                }
+                vec![]
+            }
+            GET_RX_BUFFER_STATUS => vec![STATUS_OK, self.rx_len, 0x00],
+            GET_PACKET_STATUS => vec![
+                STATUS_OK,
+                self.reg_read(REG_RSSI_SHADOW),
+                self.reg_read(REG_SNR_SHADOW),
+                self.reg_read(REG_RSSI_SHADOW),
+            ],
+            SET_CAD => {
+                if self.cad_activity {
+                    self.raise_irq(IRQ_CAD_DONE | IRQ_CAD_DETECTED);
+                } else {
+                    self.raise_irq(IRQ_CAD_DONE);
+                }
+                vec![]
+            }
+            // Configuration commands the model accepts without side effects
+            _ => vec![STATUS_OK; 16],
+        }
+    }
+}
+
+// Model-internal scratch space for rx metadata, outside the chip's real
+// register map (real addresses are all < 0x0A00)
+const REG_RSSI_SHADOW: u16 = 0xFF00;
+const REG_SNR_SHADOW: u16 = 0xFF01;
+
+/// Test handle to the chip shared by the fake SPI bus and IRQ lines.
+#[derive(Clone)]
+pub struct Chip(Arc<Mutex<ChipModel>>);
+
+impl Chip {
+    pub fn new() -> Self {
+        Chip(Arc::new(Mutex::new(ChipModel::new())))
+    }
+
+    pub fn inject_rx(&self, payload: &[u8], rssi_dbm: i16, snr_db: i16) {
+        self.0.lock().unwrap().pending_rx = Some(PendingRx {
+            payload: payload.to_vec(),
+            rssi_dbm,
+            snr_db,
+        });
+    }
+
+    pub fn with_model<R>(&self, f: impl FnOnce(&mut ChipModel) -> R) -> R {
+        f(&mut self.0.lock().unwrap())
+    }
+}
+
+/// SPI bus wired to the chip model: writes execute commands, reads drain the
+/// command's response bytes (status byte first, matching read_with_status).
+pub struct FakeSpi(pub Chip);
+
+impl embedded_hal::spi::ErrorType for FakeSpi {
+    type Error = SpiError;
+}
+
+impl SpiDevice<u8> for FakeSpi {
+    async fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        let mut cmd: Vec<u8> = Vec::new();
+        for op in operations.iter() {
+            if let Operation::Write(buf) = op {
+                cmd.extend_from_slice(buf);
+            }
+        }
+        let mut response = if cmd.is_empty() {
+            vec![]
+        } else {
+            self.0 .0.lock().unwrap().execute(cmd[0], &cmd[1..])
+        };
+        let mut cursor = response.drain(..);
+        for op in operations.iter_mut() {
+            if let Operation::Read(buf) = op {
+                for b in buf.iter_mut() {
+                    *b = cursor.next().unwrap_or(0);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn write(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        self.transaction(&mut [Operation::Write(buf)]).await
+    }
+
+    async fn read(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transfer(&mut self, _read: &mut [u8], _write: &[u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transfer_in_place(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+}
+
+/// IRQ/busy/reset lines wired to the same chip model.
+pub struct FakeIv(pub Chip);
+
+impl InterfaceVariant for FakeIv {
+    async fn reset(&mut self, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
+        self.0.with_model(|m| *m = ChipModel::new());
+        Ok(())
+    }
+    async fn wait_on_busy(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn await_irq(&mut self) -> Result<(), RadioError> {
+        for _ in 0..1000 {
+            if self.0.with_model(|m| m.irq_status & m.dio1_mask != 0) {
+                return Ok(());
+            }
+            tokio::task::yield_now().await;
+        }
+        // The chip model has no pending IRQ and nothing left to raise one
+        Err(RadioError::Irq)
+    }
+    async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn enable_rf_switch_tx(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+    async fn disable_rf_switch(&mut self) -> Result<(), RadioError> {
+        Ok(())
+    }
+}
+
+pub fn get_emulated_sx1261(chip: &Chip) -> Sx126x<FakeSpi, FakeIv, Sx1261> {
+    Sx126x::new(
+        FakeSpi(chip.clone()),
+        FakeIv(chip.clone()),
+        Config {
+            chip: Sx1261,
+            tcxo_ctrl: None,
+            use_dcdc: false,
+            rx_boost: true,
+        },
+    )
+}

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -17,9 +17,28 @@ pub struct TestFixture {
     read_responses: HashMap<Vec<u8>, Vec<u8>>,
 }
 
+/// Wire-canonical form of one SPI transaction: (written bytes with trailing
+/// NOPs trimmed, total bytes clocked). The two drivers split transactions
+/// differently — C sends `[opcode, NOP]` then reads N, ours sends `[opcode]`
+/// then reads status + N — but on the wire both clock the same bytes: MOSI
+/// idles at 0x00 during reads, so a trailing NOP write and a read byte are
+/// indistinguishable to the chip.
+fn canonical(ops: &[Ops]) -> Vec<(&[u8], usize)> {
+    ops.iter()
+        .map(|op| {
+            let (cmd, total) = match op {
+                Ops::Write(cmd) => (cmd, cmd.len()),
+                Ops::Read(cmd, read_len) => (cmd, cmd.len() + read_len),
+            };
+            let trimmed = cmd.len() - cmd.iter().rev().take_while(|b| **b == 0).count();
+            (&cmd[..trimmed], total)
+        })
+        .collect()
+}
+
 impl PartialEq for TestFixture {
     fn eq(&self, other: &Self) -> bool {
-        self.ops == other.ops
+        canonical(&self.ops) == canonical(&other.ops)
     }
 }
 impl Eq for TestFixture {}

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -1,0 +1,84 @@
+use crate::sx126x::{Config, Sx1261, Sx126x};
+pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
+use embedded_hal::spi::Operation;
+use embedded_hal_async::spi::SpiDevice;
+use std::vec::Vec;
+
+/// Records every SPI write so the byte stream of our driver can be compared
+/// against the byte stream of Semtech's reference driver. Implements both the
+/// blocking `SpiDevice` (for the reference driver, via smtc-modem-cores) and
+/// the async one (for lora-phy).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TestFixture {
+    pub ops: Vec<Ops>,
+}
+
+impl TestFixture {
+    pub fn new() -> Self {
+        Self { ops: vec![] }
+    }
+
+    fn record(&mut self, operations: &mut [Operation<'_, u8>]) {
+        let mut vec = Vec::new();
+        for op in operations {
+            match op {
+                Operation::Write(buf) => vec.extend_from_slice(buf),
+                _ => todo!(),
+            }
+        }
+        self.ops.push(Ops::Write(vec));
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Ops {
+    Write(Vec<u8>),
+}
+
+impl embedded_hal::spi::ErrorType for TestFixture {
+    type Error = SpiError;
+}
+
+impl embedded_hal::spi::SpiDevice for TestFixture {
+    fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        self.record(operations);
+        Ok(())
+    }
+}
+
+impl SpiDevice<u8> for TestFixture {
+    async fn write(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        self.ops.push(Ops::Write(buf.to_vec()));
+        Ok(())
+    }
+
+    async fn read(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        self.record(operations);
+        Ok(())
+    }
+
+    async fn transfer(&mut self, _read: &mut [u8], _write: &[u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    async fn transfer_in_place(&mut self, _buf: &mut [u8]) -> Result<(), Self::Error> {
+        todo!()
+    }
+}
+
+pub fn get_sx126x() -> Sx126x<TestFixture, DummyVariant, Sx1261> {
+    Sx126x::new(
+        TestFixture::new(),
+        DummyVariant,
+        Config {
+            chip: Sx1261,
+            tcxo_ctrl: None,
+            use_dcdc: false,
+            rx_boost: true,
+        },
+    )
+}

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -2,37 +2,76 @@ use crate::sx126x::{Config, Sx1261, Sx126x};
 pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
 use embedded_hal::spi::Operation;
 use embedded_hal_async::spi::SpiDevice;
+use std::collections::HashMap;
 use std::vec::Vec;
 
-/// Records every SPI write so the byte stream of our driver can be compared
-/// against the byte stream of Semtech's reference driver. Implements both the
-/// blocking `SpiDevice` (for the reference driver, via smtc-modem-cores) and
-/// the async one (for lora-phy).
-#[derive(Clone, PartialEq, Eq, Debug)]
+/// Records every SPI operation so the byte stream of our driver can be
+/// compared against the byte stream of Semtech's reference driver. Implements
+/// both the blocking `SpiDevice` (for the reference driver, via
+/// smtc-modem-cores) and the async one (for lora-phy). Reads answer from
+/// `read_responses` (zeros when unprimed) so read-modify-write command
+/// sequences stay comparable across the two drivers.
+#[derive(Clone, Debug)]
 pub struct TestFixture {
     pub ops: Vec<Ops>,
+    read_responses: HashMap<Vec<u8>, Vec<u8>>,
 }
+
+impl PartialEq for TestFixture {
+    fn eq(&self, other: &Self) -> bool {
+        self.ops == other.ops
+    }
+}
+impl Eq for TestFixture {}
 
 impl TestFixture {
     pub fn new() -> Self {
-        Self { ops: vec![] }
+        Self {
+            ops: vec![],
+            read_responses: HashMap::new(),
+        }
+    }
+
+    /// Canned response for a read identified by its full command bytes
+    pub fn prime_read(&mut self, command: &[u8], response: &[u8]) {
+        self.read_responses.insert(command.to_vec(), response.to_vec());
+    }
+
+    pub fn writes(&self) -> Vec<&Ops> {
+        self.ops.iter().filter(|op| matches!(op, Ops::Write(_))).collect()
     }
 
     fn record(&mut self, operations: &mut [Operation<'_, u8>]) {
-        let mut vec = Vec::new();
-        for op in operations {
+        let mut cmd = Vec::new();
+        let mut read_len = 0;
+        for op in operations.iter() {
             match op {
-                Operation::Write(buf) => vec.extend_from_slice(buf),
+                Operation::Write(buf) => cmd.extend_from_slice(buf),
+                Operation::Read(buf) => read_len += buf.len(),
                 _ => todo!(),
             }
         }
-        self.ops.push(Ops::Write(vec));
+        if read_len == 0 {
+            self.ops.push(Ops::Write(cmd));
+            return;
+        }
+        let response = self.read_responses.get(&cmd).cloned().unwrap_or_default();
+        let mut cursor = response.iter().copied();
+        for op in operations.iter_mut() {
+            if let Operation::Read(buf) = op {
+                for b in buf.iter_mut() {
+                    *b = cursor.next().unwrap_or(0);
+                }
+            }
+        }
+        self.ops.push(Ops::Read(cmd, read_len));
     }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Ops {
     Write(Vec<u8>),
+    Read(Vec<u8>, usize),
 }
 
 impl embedded_hal::spi::ErrorType for TestFixture {

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -2,7 +2,7 @@ use crate::sx126x::{Config, Sx1261, Sx1262, Sx126x};
 pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
 use embedded_hal::spi::Operation;
 use embedded_hal_async::spi::SpiDevice;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::vec::Vec;
 
 /// Records every SPI operation so the byte stream of our driver can be
@@ -14,7 +14,7 @@ use std::vec::Vec;
 #[derive(Clone, Debug)]
 pub struct TestFixture {
     pub ops: Vec<Ops>,
-    read_responses: HashMap<Vec<u8>, Vec<u8>>,
+    read_responses: HashMap<Vec<u8>, VecDeque<Vec<u8>>>,
 }
 
 /// Wire-canonical form of one SPI transaction: (written bytes with trailing
@@ -51,9 +51,14 @@ impl TestFixture {
         }
     }
 
-    /// Canned response for a read identified by its full command bytes
+    /// Canned response for a read identified by its full command bytes.
+    /// Priming the same command again queues a response for the next read
+    /// (read-modify-write sequences hit the same command repeatedly).
     pub fn prime_read(&mut self, command: &[u8], response: &[u8]) {
-        self.read_responses.insert(command.to_vec(), response.to_vec());
+        self.read_responses
+            .entry(command.to_vec())
+            .or_default()
+            .push_back(response.to_vec());
     }
 
     pub fn writes(&self) -> Vec<&Ops> {
@@ -74,7 +79,11 @@ impl TestFixture {
             self.ops.push(Ops::Write(cmd));
             return;
         }
-        let response = self.read_responses.get(&cmd).cloned().unwrap_or_default();
+        let response = self
+            .read_responses
+            .get_mut(&cmd)
+            .and_then(|queue| queue.pop_front())
+            .unwrap_or_default();
         let mut cursor = response.iter().copied();
         for op in operations.iter_mut() {
             if let Operation::Read(buf) = op {

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -1,4 +1,4 @@
-use crate::sx126x::{Config, Sx1261, Sx126x};
+use crate::sx126x::{Config, Sx1261, Sx1262, Sx126x};
 pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
 use embedded_hal::spi::Operation;
 use embedded_hal_async::spi::SpiDevice;
@@ -134,6 +134,19 @@ pub fn get_sx126x() -> Sx126x<TestFixture, DummyVariant, Sx1261> {
         DummyVariant,
         Config {
             chip: Sx1261,
+            tcxo_ctrl: None,
+            use_dcdc: false,
+            rx_boost: true,
+        },
+    )
+}
+
+pub fn get_sx1262() -> Sx126x<TestFixture, DummyVariant, Sx1262> {
+    Sx126x::new(
+        TestFixture::new(),
+        DummyVariant,
+        Config {
+            chip: Sx1262,
             tcxo_ctrl: None,
             use_dcdc: false,
             rx_boost: true,

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -6,11 +6,18 @@ mod fixtures;
 use emulator::{get_emulated_sx1261, Chip, Mode};
 use fixtures::{get_sx126x, Delayer, TestFixture};
 
-use crate::mod_params::RxMode;
+use crate::mod_params::{RadioMode, RxMode};
 use crate::mod_traits::RadioKind;
 use crate::LoRa;
 use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
-use smtc_modem_cores::sx126x::{Context, SleepCfg};
+use smtc_modem_cores::sx126x::{
+    sx126x_lora_bw_e, sx126x_lora_cr_e, sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t,
+    sx126x_pkt_params_lora_t, sx126x_standby_cfgs_e, Context, SleepCfg,
+};
+
+fn reference() -> Context<TestFixture> {
+    Context::new(TestFixture::new())
+}
 
 #[tokio::test]
 async fn test_sleep_cold_start() {
@@ -28,6 +35,159 @@ async fn test_sleep_warm_start() {
     let mut sx1261 = get_sx126x();
     sx1261.set_sleep(true, &mut Delayer).await.unwrap();
     assert_eq!(sx1261.take_spi(), smtc_sx126x.inner);
+}
+
+#[tokio::test]
+async fn test_standby() {
+    let mut reference = reference();
+    reference.set_standby(sx126x_standby_cfgs_e::SX126X_STANDBY_CFG_RC);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_standby().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_set_channel() {
+    for freq in [433_000_000u32, 868_100_000, TEST_FREQ_HZ] {
+        let mut reference = reference();
+        reference.set_rf_freq(freq);
+        let mut sx1261 = get_sx126x();
+        sx1261.set_channel(freq).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "freq {freq}");
+    }
+}
+
+#[tokio::test]
+async fn test_modulation_params() {
+    // Second case exercises the 500 kHz TxModulation workaround branch and
+    // the low-data-rate-optimize flag
+    let cases = [
+        (
+            SpreadingFactor::_7,
+            Bandwidth::_125KHz,
+            sx126x_lora_sf_e::SX126X_LORA_SF7,
+            sx126x_lora_bw_e::SX126X_LORA_BW_125,
+            0u8,
+        ),
+        (
+            SpreadingFactor::_12,
+            Bandwidth::_500KHz,
+            sx126x_lora_sf_e::SX126X_LORA_SF12,
+            sx126x_lora_bw_e::SX126X_LORA_BW_500,
+            0u8,
+        ),
+        (
+            SpreadingFactor::_11,
+            Bandwidth::_125KHz,
+            sx126x_lora_sf_e::SX126X_LORA_SF11,
+            sx126x_lora_bw_e::SX126X_LORA_BW_125,
+            1u8,
+        ),
+    ];
+    for (sf, bw, c_sf, c_bw, ldro) in cases {
+        let mut reference = reference();
+        reference.set_lora_mod_params(&sx126x_mod_params_lora_t {
+            sf: c_sf,
+            bw: c_bw,
+            cr: sx126x_lora_cr_e::SX126X_LORA_CR_4_5,
+            ldro,
+        });
+        let mut sx1261 = get_sx126x();
+        let mdltn_params = sx1261
+            .create_modulation_params(sf, bw, CodingRate::_4_5, TEST_FREQ_HZ)
+            .unwrap();
+        assert_eq!(mdltn_params.low_data_rate_optimize, ldro, "ldro for {sf:?}/{bw:?}");
+        sx1261.set_modulation_params(&mdltn_params).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "{sf:?}/{bw:?}");
+    }
+}
+
+#[tokio::test]
+async fn test_packet_params() {
+    for iq_inverted in [false, true] {
+        let mut reference = reference();
+        reference.set_lora_pkt_params(&sx126x_pkt_params_lora_t {
+            preamble_len_in_symb: 8,
+            header_type: sx126x_lora_pkt_len_modes_e::SX126X_LORA_PKT_EXPLICIT,
+            pld_len_in_bytes: 32,
+            crc_is_on: true,
+            invert_iq_is_on: iq_inverted,
+        });
+        let mut sx1261 = get_sx126x();
+        let mdltn_params = sx1261
+            .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, TEST_FREQ_HZ)
+            .unwrap();
+        let pkt_params = sx1261
+            .create_packet_params(8, false, 32, true, iq_inverted, &mdltn_params)
+            .unwrap();
+        sx1261.set_packet_params(&pkt_params).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "iq_inverted {iq_inverted}");
+    }
+}
+
+#[tokio::test]
+async fn test_sync_word() {
+    // Our driver skips the read-modify-write and writes the known reset
+    // values (0x14 0x24) with the sync nibbles applied; prime the reference
+    // with those reset values and both land on the same register write.
+    let mut fixture = TestFixture::new();
+    fixture.prime_read(&[0x1D, 0x07, 0x40, 0x00], &[0x14, 0x24]);
+    let mut reference = Context::new(fixture);
+    reference.set_lora_sync_word(0x34);
+    match reference.inner.writes()[..] {
+        [fixtures::Ops::Write(bytes)] => assert_eq!(bytes, &[0x0D, 0x07, 0x40, 0x34, 0x44]),
+        ref other => panic!("unexpected write stream {other:?}"),
+    }
+    // 0x34 -> [0x34, 0x44] is asserted against our driver in
+    // sx126x::tests::test_convert_sync_word
+}
+
+#[tokio::test]
+async fn test_buffer_base_address() {
+    let mut reference = reference();
+    reference.set_buffer_base_address(0, 0);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_tx_rx_buffer_base_address(0, 0).await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_write_buffer() {
+    let payload = b"hello reference driver";
+    let mut reference = reference();
+    reference.write_buffer(0, payload);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_payload(payload).await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_set_tx() {
+    let mut reference = reference();
+    reference.set_tx(0);
+    let mut sx1261 = get_sx126x();
+    sx1261.do_tx().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_dio_irq_params() {
+    // Transmit mode masks: TxDone | RxTxTimeout
+    let mask = 0x0201;
+    let mut reference = reference();
+    reference.set_dio_irq_params(mask, mask, 0, 0);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_irq_params(Some(RadioMode::Transmit)).await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_clear_irq_status() {
+    let mut reference = reference();
+    reference.clear_irq_status(0xFFFF);
+    let mut sx1261 = get_sx126x();
+    sx1261.clear_irq_status().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
 }
 
 const TEST_FREQ_HZ: u32 = 903_900_000;

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -559,3 +559,47 @@ async fn test_init_lora_composed() {
 
     assert_eq!(sx1261.take_spi().writes(), reference_radio.inner.writes());
 }
+
+#[tokio::test]
+async fn test_emulated_cad_end_to_end() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1261(&chip), true, Delayer).await.unwrap();
+
+    // Quiet channel
+    let mdltn_params = modulation(&mut lora);
+    lora.prepare_for_cad(&mdltn_params).await.unwrap();
+    assert!(!lora.cad(&mdltn_params).await.unwrap());
+
+    // Busy channel
+    chip.with_model(|m| m.cad_activity = true);
+    lora.prepare_for_cad(&mdltn_params).await.unwrap();
+    assert!(lora.cad(&mdltn_params).await.unwrap());
+}
+
+#[tokio::test]
+async fn test_emulated_rx_single_timeout() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1261(&chip), true, Delayer).await.unwrap();
+
+    // Nothing injected: single-mode reception must surface ReceiveTimeout
+    // (the model collapses the symbol-timeout wait to zero)
+    let mdltn_params = modulation(&mut lora);
+    let rx_pkt_params = lora
+        .create_rx_packet_params(8, false, 255, true, false, &mdltn_params)
+        .unwrap();
+    lora.prepare_for_rx(RxMode::Single(8), &mdltn_params, &rx_pkt_params)
+        .await
+        .unwrap();
+
+    let mut buf = [0u8; 255];
+    let result = lora.rx(&rx_pkt_params, &mut buf).await;
+    assert!(matches!(result, Err(crate::mod_params::RadioError::ReceiveTimeout)));
+
+    // The same radio still receives fine afterwards
+    lora.prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params)
+        .await
+        .unwrap();
+    chip.inject_rx(b"after-timeout", -90, 2);
+    let (len, _) = lora.rx(&rx_pkt_params, &mut buf).await.unwrap();
+    assert_eq!(&buf[..len as usize], b"after-timeout");
+}

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -4,7 +4,7 @@
 mod emulator;
 mod fixtures;
 use emulator::{get_emulated_sx1261, Chip, Mode};
-use fixtures::{get_sx126x, Delayer, TestFixture};
+use fixtures::{get_sx1262, get_sx126x, Delayer, TestFixture};
 
 use crate::mod_params::{RadioMode, RxMode};
 use crate::mod_traits::RadioKind;
@@ -12,8 +12,8 @@ use crate::LoRa;
 use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 use smtc_modem_cores::sx126x::{
     sx126x_cad_exit_modes_e, sx126x_cad_params_t, sx126x_cad_symbs_e, sx126x_lora_bw_e, sx126x_lora_cr_e,
-    sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t, sx126x_pkt_params_lora_t,
-    sx126x_standby_cfgs_e, Context, SleepCfg,
+    sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t, sx126x_pa_cfg_params_t,
+    sx126x_pkt_params_lora_t, sx126x_ramp_time_e, sx126x_standby_cfgs_e, Context, SleepCfg,
 };
 
 fn reference() -> Context<TestFixture> {
@@ -346,6 +346,97 @@ async fn test_tx_continuous_wave() {
     reference.set_tx_cw();
     let mut sx1261 = get_sx126x();
     sx1261.set_tx_continuous_wave_mode().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+/// Reference-side mirror of one row of datasheet Table 13-21 (PA Operating
+/// Modes with Optimal Settings): SetPaConfig values + the SetTxParams power
+/// the chip should be handed for a requested dBm. The table itself lives in
+/// our driver; SWL2001 leaves it to the BSP layer, so the C driver is fed
+/// these values and verifies the command encoding around them.
+fn reference_tx_power(
+    reference: &mut Context<TestFixture>,
+    pa_duty_cycle: u8,
+    hp_max: u8,
+    device_sel: u8,
+    tx_power: i8,
+    ramp: sx126x_ramp_time_e,
+) {
+    reference.set_pa_cfg(&sx126x_pa_cfg_params_t {
+        pa_duty_cycle,
+        hp_max,
+        device_sel,
+        pa_lut: 0x01,
+    });
+    reference.set_tx_params(tx_power, ramp);
+}
+
+#[tokio::test]
+async fn test_tx_power_sx1261() {
+    // (requested dBm, paDutyCycle, hpMax, SetTxParams power)
+    // -30 clamps to the low-power PA floor of -17
+    let cases = [
+        (15i32, 0x06u8, 0x00u8, 14i8),
+        (14, 0x04, 0x00, 14),
+        (10, 0x01, 0x00, 13),
+        (0, 0x01, 0x00, 3),
+        (-17, 0x01, 0x00, -14),
+        (-30, 0x01, 0x00, -14),
+    ];
+    for (dbm, duty, hp_max, tx_power) in cases {
+        let mut reference = reference();
+        reference_tx_power(
+            &mut reference,
+            duty,
+            hp_max,
+            1, // device_sel: SX1261
+            tx_power,
+            sx126x_ramp_time_e::SX126X_RAMP_40_US,
+        );
+        let mut sx1261 = get_sx126x();
+        sx1261.set_tx_power_and_ramp_time(dbm, None, true).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "{dbm} dBm");
+    }
+}
+
+#[tokio::test]
+async fn test_tx_power_sx1262() {
+    // The high-power path first applies the TX clamp workaround (datasheet
+    // §15.2), matching the reference's cfg_tx_clamp read-modify-write.
+    // 30 clamps to 22; 14 keeps txp per the STM32 reference driver (our
+    // driver's comment documents the datasheet table disagreement there).
+    let cases = [
+        (22i32, 0x04u8, 0x07u8, 22i8),
+        (30, 0x04, 0x07, 22),
+        (20, 0x03, 0x05, 22),
+        (17, 0x02, 0x03, 22),
+        (14, 0x02, 0x02, 14),
+        (-9, 0x02, 0x02, -9),
+    ];
+    for (dbm, duty, hp_max, tx_power) in cases {
+        let mut reference = reference();
+        reference.cfg_tx_clamp();
+        reference_tx_power(
+            &mut reference,
+            duty,
+            hp_max,
+            0, // device_sel: SX1262
+            tx_power,
+            sx126x_ramp_time_e::SX126X_RAMP_40_US,
+        );
+        let mut sx1262 = get_sx1262();
+        sx1262.set_tx_power_and_ramp_time(dbm, None, true).await.unwrap();
+        assert_eq!(sx1262.take_spi(), reference.inner, "{dbm} dBm");
+    }
+}
+
+#[tokio::test]
+async fn test_tx_power_init_ramp() {
+    // Outside TX prep (e.g. at init) the driver uses the slower 200 us ramp
+    let mut reference = reference();
+    reference_tx_power(&mut reference, 0x01, 0x00, 1, 3, sx126x_ramp_time_e::SX126X_RAMP_200_US);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_tx_power_and_ramp_time(0, None, false).await.unwrap();
     assert_eq!(sx1261.take_spi(), reference.inner);
 }
 

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -232,6 +232,123 @@ async fn test_do_cad() {
     assert_eq!(sx1261.take_spi(), reference.inner);
 }
 
+#[tokio::test]
+async fn test_get_rx_payload() {
+    // Chip reports 4 bytes at offset 0. Ours reads a status byte our
+    // reference discards via a NOP write; wire streams are canonically equal.
+    let mut sx1261 = get_sx126x();
+    sx1261.spi_mut().prime_read(&[0x13], &[0x00, 4, 0]);
+    let mdltn_params = sx1261
+        .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, TEST_FREQ_HZ)
+        .unwrap();
+    let pkt_params = sx1261
+        .create_packet_params(8, false, 255, true, false, &mdltn_params)
+        .unwrap();
+    let mut buf = [0u8; 255];
+    let len = sx1261.get_rx_payload(&pkt_params, &mut buf).await.unwrap();
+    assert_eq!(len, 4);
+
+    let mut reference = reference();
+    let (_, rx_status) = reference.get_rx_buffer_status();
+    let mut c_buf = [0u8; 4];
+    reference.read_buffer(rx_status.buffer_start_pointer, &mut c_buf);
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_get_packet_status() {
+    // Raw chip bytes: rssi 160, snr 20, signal rssi 162
+    let mut sx1261 = get_sx126x();
+    sx1261.spi_mut().prime_read(&[0x14], &[0x00, 160, 20, 162]);
+    let pkt_status = sx1261.get_rx_packet_status().await.unwrap();
+
+    let mut fixture = TestFixture::new();
+    fixture.prime_read(&[0x14, 0x00], &[160, 20, 162]);
+    let mut reference = Context::new(fixture);
+    let (_, c_status) = reference.get_lora_pkt_status();
+
+    // Byte streams and the decoded values both match the reference
+    assert_eq!(sx1261.take_spi(), reference.inner);
+    assert_eq!(pkt_status.rssi, c_status.rssi_pkt_in_dbm as i16);
+    assert_eq!(pkt_status.snr, c_status.snr_pkt_in_db as i16);
+}
+
+#[tokio::test]
+async fn test_get_rssi() {
+    let mut sx1261 = get_sx126x();
+    sx1261.spi_mut().prime_read(&[0x15], &[0x00, 161]);
+    let rssi = sx1261.get_rssi().await.unwrap();
+
+    let mut fixture = TestFixture::new();
+    fixture.prime_read(&[0x15, 0x00], &[161]);
+    let mut reference = Context::new(fixture);
+    let (_, c_rssi) = reference.get_rssi_inst();
+
+    assert_eq!(sx1261.take_spi(), reference.inner);
+    assert_eq!(rssi, c_rssi);
+}
+
+#[tokio::test]
+async fn test_get_irq_status() {
+    use crate::mod_traits::IrqState;
+    let mut sx1261 = get_sx126x();
+    sx1261.spi_mut().prime_read(&[0x12], &[0x00, 0x00, 0x01]); // TxDone
+    let state = sx1261
+        .process_irq_event(RadioMode::Transmit, None, false)
+        .await
+        .unwrap();
+    assert!(matches!(state, Some(IrqState::Done)));
+
+    let mut fixture = TestFixture::new();
+    fixture.prime_read(&[0x12, 0x00], &[0x00, 0x01]);
+    let mut reference = Context::new(fixture);
+    let (_, c_irq) = reference.get_irq_status();
+
+    assert_eq!(sx1261.take_spi(), reference.inner);
+    assert_eq!(c_irq, 0x0001);
+}
+
+#[tokio::test]
+async fn test_ensure_ready_after_sleep() {
+    // Waking from sleep: ours writes GetStatus + NOP, the reference reads one
+    // status byte after GetStatus — same bytes on the wire
+    let mut sx1261 = get_sx126x();
+    sx1261.ensure_ready(RadioMode::Sleep).await.unwrap();
+
+    let mut reference = reference();
+    reference.get_status();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_calibrate_image() {
+    // Our band table follows datasheet Table 9-2. The reference's Hz helper
+    // (cal_img_in_mhz) computes ceil(band_end/4) instead, which lands one
+    // step short of the table for most bands (e.g. 928 MHz -> 0xE8 vs 0xE9),
+    // so compare against cal_img with the table bytes.
+    let cases = [
+        (903_900_000u32, 0xE1u8, 0xE9u8),
+        (868_100_000, 0xD7, 0xDB),
+        (433_000_000, 0x6B, 0x6F),
+    ];
+    for (freq_hz, f1, f2) in cases {
+        let mut reference = reference();
+        reference.cal_img(f1, f2);
+        let mut sx1261 = get_sx126x();
+        sx1261.calibrate_image(freq_hz).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "freq {freq_hz}");
+    }
+}
+
+#[tokio::test]
+async fn test_tx_continuous_wave() {
+    let mut reference = reference();
+    reference.set_tx_cw();
+    let mut sx1261 = get_sx126x();
+    sx1261.set_tx_continuous_wave_mode().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
 const TEST_FREQ_HZ: u32 = 903_900_000;
 
 fn modulation(lora: &mut LoRa<impl RadioKind, Delayer>) -> crate::mod_params::ModulationParams {

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -1,0 +1,25 @@
+//! Compare this driver's SPI byte stream against Semtech's reference driver
+//! (SWL2001, via the smtc-modem-cores bindings).
+mod fixtures;
+use fixtures::{get_sx126x, Delayer, TestFixture};
+
+use crate::mod_traits::RadioKind;
+use smtc_modem_cores::sx126x::{Context, SleepCfg};
+
+#[tokio::test]
+async fn test_sleep_cold_start() {
+    let mut smtc_sx126x = Context::new(TestFixture::new());
+    smtc_sx126x.set_sleep(SleepCfg::ColdStart);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_sleep(false, &mut Delayer).await.unwrap();
+    assert_eq!(sx1261.take_spi(), smtc_sx126x.inner);
+}
+
+#[tokio::test]
+async fn test_sleep_warm_start() {
+    let mut smtc_sx126x = Context::new(TestFixture::new());
+    smtc_sx126x.set_sleep(SleepCfg::WarmStart);
+    let mut sx1261 = get_sx126x();
+    sx1261.set_sleep(true, &mut Delayer).await.unwrap();
+    assert_eq!(sx1261.take_spi(), smtc_sx126x.inner);
+}

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -11,8 +11,9 @@ use crate::mod_traits::RadioKind;
 use crate::LoRa;
 use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 use smtc_modem_cores::sx126x::{
-    sx126x_lora_bw_e, sx126x_lora_cr_e, sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t,
-    sx126x_pkt_params_lora_t, sx126x_standby_cfgs_e, Context, SleepCfg,
+    sx126x_cad_exit_modes_e, sx126x_cad_params_t, sx126x_cad_symbs_e, sx126x_lora_bw_e, sx126x_lora_cr_e,
+    sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t, sx126x_pkt_params_lora_t,
+    sx126x_standby_cfgs_e, Context, SleepCfg,
 };
 
 fn reference() -> Context<TestFixture> {
@@ -187,6 +188,47 @@ async fn test_clear_irq_status() {
     reference.clear_irq_status(0xFFFF);
     let mut sx1261 = get_sx126x();
     sx1261.clear_irq_status().await.unwrap();
+    assert_eq!(sx1261.take_spi(), reference.inner);
+}
+
+#[tokio::test]
+async fn test_do_rx() {
+    // (mode, symbol timeout the driver programs, SetRx timeout in rtc steps)
+    let cases = [
+        ("continuous", RxMode::Continuous, 0u8, 0xFFFFFF_u32),
+        ("single8", RxMode::Single(8), 8, 0),
+    ];
+    for (label, mode, symbs, rtc_timeout) in cases {
+        let mut reference = reference();
+        reference.stop_timer_on_preamble(true);
+        reference.set_lora_symb_nb_timeout(symbs);
+        reference.cfg_rx_boosted(true);
+        reference.set_rx_with_timeout_in_rtc_step(rtc_timeout);
+
+        let mut sx1261 = get_sx126x();
+        sx1261.do_rx(mode).await.unwrap();
+        assert_eq!(sx1261.take_spi(), reference.inner, "{label}");
+    }
+}
+
+#[tokio::test]
+async fn test_do_cad() {
+    let mut reference = reference();
+    reference.cfg_rx_boosted(true);
+    reference.set_cad_params(&sx126x_cad_params_t {
+        cad_symb_nb: sx126x_cad_symbs_e::SX126X_CAD_08_SYMB,
+        cad_detect_peak: 7 + 13, // SF7 + 13, per Semtech's CAD application note
+        cad_detect_min: 10,
+        cad_exit_mode: sx126x_cad_exit_modes_e::SX126X_CAD_ONLY,
+        cad_timeout: 0,
+    });
+    reference.set_cad();
+
+    let mut sx1261 = get_sx126x();
+    let mdltn_params = sx1261
+        .create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, TEST_FREQ_HZ)
+        .unwrap();
+    sx1261.do_cad(&mdltn_params).await.unwrap();
     assert_eq!(sx1261.take_spi(), reference.inner);
 }
 

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -407,9 +407,12 @@ async fn test_tx_power_sx1262() {
     // throughout: the 14 dBm-and-below rows keep PA config 0x02/0x02 and
     // interpolate SetTxParams from the +22 setpoint (txp + 8); the ST table
     // for that row belongs to the Stm32wl variant only.
+    // 21 interpolates within the +22 row (the old range code over-commanded
+    // 22 for a 21 dBm request)
     let cases = [
         (22i32, 0x04u8, 0x07u8, 22i8),
         (30, 0x04, 0x07, 22),
+        (21, 0x04, 0x07, 21),
         (20, 0x03, 0x05, 22),
         (17, 0x02, 0x03, 22),
         (14, 0x02, 0x02, 22),

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -1,9 +1,15 @@
 //! Compare this driver's SPI byte stream against Semtech's reference driver
-//! (SWL2001, via the smtc-modem-cores bindings).
+//! (SWL2001, via the smtc-modem-cores bindings), and run the full LoRa
+//! state machine against an emulated chip.
+mod emulator;
 mod fixtures;
+use emulator::{get_emulated_sx1261, Chip, Mode};
 use fixtures::{get_sx126x, Delayer, TestFixture};
 
+use crate::mod_params::RxMode;
 use crate::mod_traits::RadioKind;
+use crate::LoRa;
+use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 use smtc_modem_cores::sx126x::{Context, SleepCfg};
 
 #[tokio::test]
@@ -22,4 +28,87 @@ async fn test_sleep_warm_start() {
     let mut sx1261 = get_sx126x();
     sx1261.set_sleep(true, &mut Delayer).await.unwrap();
     assert_eq!(sx1261.take_spi(), smtc_sx126x.inner);
+}
+
+const TEST_FREQ_HZ: u32 = 903_900_000;
+
+fn modulation(lora: &mut LoRa<impl RadioKind, Delayer>) -> crate::mod_params::ModulationParams {
+    lora.create_modulation_params(SpreadingFactor::_7, Bandwidth::_125KHz, CodingRate::_4_5, TEST_FREQ_HZ)
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_emulated_tx_end_to_end() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1261(&chip), true, Delayer).await.unwrap();
+
+    let mdltn_params = modulation(&mut lora);
+    let mut tx_pkt_params = lora
+        .create_tx_packet_params(8, false, true, false, &mdltn_params)
+        .unwrap();
+
+    let payload = b"hello lora";
+    lora.prepare_for_tx(&mdltn_params, &mut tx_pkt_params, 10, payload)
+        .await
+        .unwrap();
+    lora.tx().await.unwrap();
+
+    chip.with_model(|m| {
+        assert_eq!(m.tx_log.len(), 1);
+        assert_eq!(m.tx_log[0].payload, payload);
+        assert_eq!(m.mode, Mode::Standby);
+
+        // Frequency round-trips through the chip's PLL-step encoding
+        let hz = (m.tx_log[0].frequency_raw as u64 * 32_000_000) >> 25;
+        assert!((hz as i64 - TEST_FREQ_HZ as i64).abs() <= 1, "freq {hz}");
+
+        // LoRa public network sync word 0x34 lands in register 0x0740 as 0x34 0x44
+        assert_eq!(m.registers[&0x0740], 0x34);
+        assert_eq!(m.registers[&0x0741], 0x44);
+    });
+}
+
+#[tokio::test]
+async fn test_emulated_rx_end_to_end() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1261(&chip), true, Delayer).await.unwrap();
+
+    let mdltn_params = modulation(&mut lora);
+    let rx_pkt_params = lora
+        .create_rx_packet_params(8, false, 255, true, false, &mdltn_params)
+        .unwrap();
+    lora.prepare_for_rx(RxMode::Continuous, &mdltn_params, &rx_pkt_params)
+        .await
+        .unwrap();
+
+    chip.inject_rx(b"ping", -80, 5);
+
+    let mut buf = [0u8; 255];
+    let (len, status) = lora.rx(&rx_pkt_params, &mut buf).await.unwrap();
+    assert_eq!(&buf[..len as usize], b"ping");
+    assert_eq!(status.rssi, -80);
+    assert_eq!(status.snr, 5);
+}
+
+#[tokio::test]
+async fn test_emulated_sleep_and_wake() {
+    let chip = Chip::new();
+    let mut lora = LoRa::new(get_emulated_sx1261(&chip), true, Delayer).await.unwrap();
+
+    lora.sleep(true).await.unwrap();
+    chip.with_model(|m| assert_eq!(m.mode, Mode::Sleep));
+
+    // Wake back up into a working tx
+    let mdltn_params = modulation(&mut lora);
+    let mut tx_pkt_params = lora
+        .create_tx_packet_params(8, false, true, false, &mdltn_params)
+        .unwrap();
+    lora.prepare_for_tx(&mdltn_params, &mut tx_pkt_params, 10, b"wake")
+        .await
+        .unwrap();
+    lora.tx().await.unwrap();
+    chip.with_model(|m| {
+        assert_eq!(m.tx_log.len(), 1);
+        assert_eq!(m.tx_log[0].payload, b"wake");
+    });
 }

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -13,7 +13,7 @@ use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 use smtc_modem_cores::sx126x::{
     sx126x_cad_exit_modes_e, sx126x_cad_params_t, sx126x_cad_symbs_e, sx126x_lora_bw_e, sx126x_lora_cr_e,
     sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t, sx126x_pa_cfg_params_t,
-    sx126x_pkt_params_lora_t, sx126x_ramp_time_e, sx126x_standby_cfgs_e, Context, SleepCfg,
+    sx126x_pkt_params_lora_t, sx126x_pkt_types_e, sx126x_ramp_time_e, sx126x_standby_cfgs_e, Context, SleepCfg,
 };
 
 fn reference() -> Context<TestFixture> {
@@ -521,4 +521,41 @@ async fn test_emulated_sleep_and_wake() {
         assert_eq!(m.tx_log.len(), 1);
         assert_eq!(m.tx_log[0].payload, b"wake");
     });
+}
+
+#[tokio::test]
+async fn test_init_lora_composed() {
+    // The whole init_lora sequence against the reference calls chained in
+    // the same order. Writes-only comparison, same as the single sync-word
+    // test: the C sync word setter is a read-modify-write where ours writes
+    // the known reset-derived values directly, so the read halves differ by
+    // design (primed with the reset values, the write halves converge).
+    const RETENTION_READ: [u8; 4] = [0x1D, 0x02, 0x9F, 0x00];
+    const RETENTION_AFTER_RX_GAIN: [u8; 9] = [1, 0x08, 0xAC, 0, 0, 0, 0, 0, 0];
+
+    let mut reference_radio = reference();
+    reference_radio.set_dio2_as_rf_sw_ctrl(true);
+    reference_radio.set_pkt_type(sx126x_pkt_types_e::SX126X_PKT_TYPE_LORA);
+    reference_radio
+        .inner
+        .prime_read(&[0x1D, 0x07, 0x40, 0x00], &[0x14, 0x24]);
+    reference_radio.set_lora_sync_word(0x34);
+    reference_radio.set_buffer_base_address(0, 0);
+    // Retention list, mirroring ours' one-register-at-a-time factoring; the
+    // queued second response lets the second add see the first (the batch
+    // form add_registers_to_retention_list(&[both]) would collapse this to
+    // one read + one write — a different transaction count by design)
+    reference_radio.inner.prime_read(&RETENTION_READ, &[0u8; 9]);
+    reference_radio.add_registers_to_retention_list(&[0x08AC]);
+    reference_radio
+        .inner
+        .prime_read(&RETENTION_READ, &RETENTION_AFTER_RX_GAIN);
+    reference_radio.add_registers_to_retention_list(&[0x0889]);
+
+    let mut sx1261 = get_sx126x();
+    sx1261.spi_mut().prime_read(&RETENTION_READ, &[0u8; 9]);
+    sx1261.spi_mut().prime_read(&RETENTION_READ, &RETENTION_AFTER_RX_GAIN);
+    sx1261.init_lora(0x34).await.unwrap();
+
+    assert_eq!(sx1261.take_spi().writes(), reference_radio.inner.writes());
 }

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -650,3 +650,66 @@ async fn test_tx_power_stm32wl() {
         assert_eq!(radio.take_spi(), reference.inner, "{dbm} dBm");
     }
 }
+
+/// Pin every `OpCode` discriminant to Semtech's SWL2001 command values
+/// (`sx126x_commands_e`, SWL2001 sx126x_driver/src/sx126x.c). The driver
+/// builds every SPI command from this enum and the emulator dispatches on
+/// it, so a wrong byte here silently talks to the wrong command on real
+/// hardware. The transaction-comparison tests above only pin the opcodes
+/// their flows exercise; this pins all of them in one place. The vendor
+/// values are transcribed independently of the driver enum, so a typo in
+/// either side won't match the other.
+#[test]
+fn opcodes_match_swl2001() {
+    use crate::sx126x::radio_kind_params::OpCode;
+    // (name, our driver's byte, SWL2001's byte)
+    let cases: &[(&str, u8, u8)] = &[
+        ("GetStatus", OpCode::GetStatus as u8, 0xC0),
+        ("WriteRegister", OpCode::WriteRegister as u8, 0x0D),
+        ("ReadRegister", OpCode::ReadRegister as u8, 0x1D),
+        ("WriteBuffer", OpCode::WriteBuffer as u8, 0x0E),
+        ("ReadBuffer", OpCode::ReadBuffer as u8, 0x1E),
+        ("SetSleep", OpCode::SetSleep as u8, 0x84),
+        ("SetStandby", OpCode::SetStandby as u8, 0x80),
+        ("SetFS", OpCode::SetFS as u8, 0xC1),
+        ("SetTx", OpCode::SetTx as u8, 0x83),
+        ("SetRx", OpCode::SetRx as u8, 0x82),
+        ("SetRxDutyCycle", OpCode::SetRxDutyCycle as u8, 0x94),
+        ("SetCAD", OpCode::SetCAD as u8, 0xC5),
+        ("SetTxContinuousWave", OpCode::SetTxContinuousWave as u8, 0xD1),
+        ("SetTxContinuousPremable", OpCode::SetTxContinuousPremable as u8, 0xD2),
+        ("SetPacketType", OpCode::SetPacketType as u8, 0x8A),
+        ("GetPacketType", OpCode::GetPacketType as u8, 0x11),
+        ("SetRFFrequency", OpCode::SetRFFrequency as u8, 0x86),
+        ("SetTxParams", OpCode::SetTxParams as u8, 0x8E),
+        ("SetPAConfig", OpCode::SetPAConfig as u8, 0x95),
+        ("SetCADParams", OpCode::SetCADParams as u8, 0x88),
+        ("SetBufferBaseAddress", OpCode::SetBufferBaseAddress as u8, 0x8F),
+        ("SetModulationParams", OpCode::SetModulationParams as u8, 0x8B),
+        ("SetPacketParams", OpCode::SetPacketParams as u8, 0x8C),
+        ("GetRxBufferStatus", OpCode::GetRxBufferStatus as u8, 0x13),
+        ("GetPacketStatus", OpCode::GetPacketStatus as u8, 0x14),
+        ("GetRSSIInst", OpCode::GetRSSIInst as u8, 0x15),
+        ("GetStats", OpCode::GetStats as u8, 0x10),
+        ("ResetStats", OpCode::ResetStats as u8, 0x00),
+        ("CfgDIOIrq", OpCode::CfgDIOIrq as u8, 0x08),
+        ("GetIrqStatus", OpCode::GetIrqStatus as u8, 0x12),
+        ("ClrIrqStatus", OpCode::ClrIrqStatus as u8, 0x02),
+        ("Calibrate", OpCode::Calibrate as u8, 0x89),
+        ("CalibrateImage", OpCode::CalibrateImage as u8, 0x98),
+        ("SetRegulatorMode", OpCode::SetRegulatorMode as u8, 0x96),
+        ("GetDeviceErrors", OpCode::GetDeviceErrors as u8, 0x17),
+        ("ClearDeviceErrors", OpCode::ClearDeviceErrors as u8, 0x07),
+        ("SetTCXOMode", OpCode::SetTCXOMode as u8, 0x97),
+        ("SetTxFallbackMode", OpCode::SetTxFallbackMode as u8, 0x93),
+        ("SetDIO2AsRfSwitchCtrl", OpCode::SetDIO2AsRfSwitchCtrl as u8, 0x9D),
+        ("SetStopRxTimerOnPreamble", OpCode::SetStopRxTimerOnPreamble as u8, 0x9F),
+        ("SetLoRaSymbTimeout", OpCode::SetLoRaSymbTimeout as u8, 0xA0),
+    ];
+    for (name, driver, vendor) in cases {
+        assert_eq!(
+            driver, vendor,
+            "OpCode::{name} = {driver:#04x}, SWL2001 = {vendor:#04x}"
+        );
+    }
+}

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -403,15 +403,17 @@ async fn test_tx_power_sx1261() {
 async fn test_tx_power_sx1262() {
     // The high-power path first applies the TX clamp workaround (datasheet
     // §15.2), matching the reference's cfg_tx_clamp read-modify-write.
-    // 30 clamps to 22; 14 keeps txp per the STM32 reference driver (our
-    // driver's comment documents the datasheet table disagreement there).
+    // 30 clamps to 22. The discrete SX1262 takes datasheet Table 13-21
+    // throughout: the 14 dBm-and-below rows keep PA config 0x02/0x02 and
+    // interpolate SetTxParams from the +22 setpoint (txp + 8); the ST table
+    // for that row belongs to the Stm32wl variant only.
     let cases = [
         (22i32, 0x04u8, 0x07u8, 22i8),
         (30, 0x04, 0x07, 22),
         (20, 0x03, 0x05, 22),
         (17, 0x02, 0x03, 22),
-        (14, 0x02, 0x02, 14),
-        (-9, 0x02, 0x02, -9),
+        (14, 0x02, 0x02, 22),
+        (-9, 0x02, 0x02, -1),
     ];
     for (dbm, duty, hp_max, tx_power) in cases {
         let mut reference = reference();
@@ -602,4 +604,46 @@ async fn test_emulated_rx_single_timeout() {
     chip.inject_rx(b"after-timeout", -90, 2);
     let (len, _) = lora.rx(&rx_pkt_params, &mut buf).await.unwrap();
     assert_eq!(&buf[..len as usize], b"after-timeout");
+}
+
+#[tokio::test]
+async fn test_tx_power_stm32wl() {
+    // The Stm32wl variant takes ST's table: identical to the datasheet on
+    // every row except 14 dBm and below, where ST commands the target dBm
+    // directly with the same 0x02/0x02 PA config (STM32CubeWL
+    // SUBGRF_SetTxParams). Each part uses the table it was characterized
+    // with — the STM32WL is an SX126x die integrated into ST's package.
+    use crate::sx126x::Stm32wl;
+    let cases = [
+        (22i32, 0x04u8, 0x07u8, 22i8),
+        (17, 0x02, 0x03, 22),
+        (14, 0x02, 0x02, 14),
+        (-9, 0x02, 0x02, -9),
+    ];
+    for (dbm, duty, hp_max, tx_power) in cases {
+        let mut reference = reference();
+        reference.cfg_tx_clamp();
+        reference_tx_power(
+            &mut reference,
+            duty,
+            hp_max,
+            0, // device_sel: high-power PA
+            tx_power,
+            sx126x_ramp_time_e::SX126X_RAMP_40_US,
+        );
+        let mut radio = crate::sx126x::Sx126x::new(
+            fixtures::TestFixture::new(),
+            fixtures::DummyVariant,
+            crate::sx126x::Config {
+                chip: Stm32wl {
+                    use_high_power_pa: true,
+                },
+                tcxo_ctrl: None,
+                use_dcdc: false,
+                rx_boost: true,
+            },
+        );
+        radio.set_tx_power_and_ramp_time(dbm, None, true).await.unwrap();
+        assert_eq!(radio.take_spi(), reference.inner, "{dbm} dBm");
+    }
 }

--- a/lora-phy/src/sx126x/variant.rs
+++ b/lora-phy/src/sx126x/variant.rs
@@ -1,5 +1,138 @@
 use super::DeviceSel;
 
+/// One row of a PA power table: the SetPaConfig values for a band of output
+/// powers, anchored at the row's highest power. Requests below the anchor
+/// interpolate by lowering SetTxParams one-for-one, per the datasheet's
+/// guidance for powers between the optimal settings.
+#[derive(Clone, Copy, Debug)]
+pub struct PaTableEntry {
+    /// Highest output power this row covers [dBm]
+    pub max_dbm: i8,
+    /// SetPaConfig paDutyCycle for this row
+    pub pa_duty_cycle: u8,
+    /// SetPaConfig hpMax for this row (0 on the low-power PA)
+    pub hp_max: u8,
+    /// SetTxParams power commanded at `max_dbm`; lower targets within the
+    /// row subtract the shortfall
+    pub tx_params_at_max: i8,
+}
+
+/// A PA power table: rows sorted by ascending `max_dbm`; requests clamp to
+/// `[min_dbm, last row's max_dbm]`. `&'static` tables live in flash — no RAM.
+#[derive(Debug)]
+pub struct PaTable {
+    /// Lowest supported output power [dBm]
+    pub min_dbm: i8,
+    /// Rows sorted by ascending `max_dbm`; must be non-empty
+    pub entries: &'static [PaTableEntry],
+}
+
+impl PaTable {
+    /// The row covering `dbm` (clamped) and the SetTxParams power for it
+    pub(crate) fn lookup(&self, dbm: i32) -> (&PaTableEntry, u8) {
+        let max = self.entries[self.entries.len() - 1].max_dbm;
+        let txp = dbm.clamp(self.min_dbm as i32, max as i32) as i8;
+        let entry = self
+            .entries
+            .iter()
+            .find(|e| e.max_dbm >= txp)
+            .unwrap_or(&self.entries[self.entries.len() - 1]);
+        (entry, (entry.tx_params_at_max - (entry.max_dbm - txp)) as u8)
+    }
+}
+
+/// SX1261 low-power PA rows from datasheet Table 13-21 (+15/+14/+10 dBm)
+pub const SX1261_PA_TABLE: PaTable = PaTable {
+    min_dbm: -17,
+    entries: &[
+        PaTableEntry {
+            max_dbm: 10,
+            pa_duty_cycle: 0x01,
+            hp_max: 0x00,
+            tx_params_at_max: 13,
+        },
+        PaTableEntry {
+            max_dbm: 14,
+            pa_duty_cycle: 0x04,
+            hp_max: 0x00,
+            tx_params_at_max: 14,
+        },
+        PaTableEntry {
+            max_dbm: 15,
+            pa_duty_cycle: 0x06,
+            hp_max: 0x00,
+            tx_params_at_max: 14,
+        },
+    ],
+};
+
+/// SX1262 high-power PA rows from datasheet Table 13-21 (+22/+20/+17/+14 dBm);
+/// every row commands SetTxParams +22 at its anchor
+pub const SX1262_PA_TABLE: PaTable = PaTable {
+    min_dbm: -9,
+    entries: &[
+        PaTableEntry {
+            max_dbm: 14,
+            pa_duty_cycle: 0x02,
+            hp_max: 0x02,
+            tx_params_at_max: 22,
+        },
+        PaTableEntry {
+            max_dbm: 17,
+            pa_duty_cycle: 0x02,
+            hp_max: 0x03,
+            tx_params_at_max: 22,
+        },
+        PaTableEntry {
+            max_dbm: 20,
+            pa_duty_cycle: 0x03,
+            hp_max: 0x05,
+            tx_params_at_max: 22,
+        },
+        PaTableEntry {
+            max_dbm: 22,
+            pa_duty_cycle: 0x04,
+            hp_max: 0x07,
+            tx_params_at_max: 22,
+        },
+    ],
+};
+
+/// ST's high-power table for the STM32WL (an SX126x die integrated into
+/// ST's package, characterized by ST in STM32CubeWL). Identical to
+/// [`SX1262_PA_TABLE`] except the 14 dBm-and-below row, where ST commands
+/// the target dBm directly instead of interpolating from +22.
+/// <https://github.com/STMicroelectronics/STM32CubeWL/blob/139e8d28bcec6af78dec8b52a9b9f9057868cc2e/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L675>
+pub const STM32WL_HP_PA_TABLE: PaTable = PaTable {
+    min_dbm: -9,
+    entries: &[
+        PaTableEntry {
+            max_dbm: 14,
+            pa_duty_cycle: 0x02,
+            hp_max: 0x02,
+            tx_params_at_max: 14,
+        },
+        PaTableEntry {
+            max_dbm: 17,
+            pa_duty_cycle: 0x02,
+            hp_max: 0x03,
+            tx_params_at_max: 22,
+        },
+        PaTableEntry {
+            max_dbm: 20,
+            pa_duty_cycle: 0x03,
+            hp_max: 0x05,
+            tx_params_at_max: 22,
+        },
+        PaTableEntry {
+            max_dbm: 22,
+            pa_duty_cycle: 0x04,
+            hp_max: 0x07,
+            tx_params_at_max: 22,
+        },
+    ],
+};
+
 /// Implement this trait on your custom variant or use provided impls
 pub trait Sx126xVariant {
     /// whether to use high or low power PA
@@ -10,14 +143,15 @@ pub trait Sx126xVariant {
         true
     }
 
-    /// Use ST's power table instead of the SX126x datasheet's. The STM32WL
-    /// is an SX126x die integrated into ST's package, characterized by ST
-    /// with its own table; discrete Semtech parts take the datasheet table
-    /// (Table 13-21). The two differ only in the high-power PA's 14 dBm-and-
-    /// below row: same PA config, but ST commands the target dBm directly
-    /// where the datasheet interpolates from a +22 setpoint.
-    fn use_st_power_table(&self) -> bool {
-        false
+    /// The PA power table for this variant. Defaults to the SX126x datasheet
+    /// tables (Table 13-21) for the selected PA. Boards with their own PA
+    /// characterization (e.g. the STM32WL) return a different `&'static`
+    /// table — compile-time data, no RAM cost.
+    fn pa_table(&self) -> &'static PaTable {
+        match self.get_device_sel() {
+            DeviceSel::LowPowerPA => &SX1261_PA_TABLE,
+            DeviceSel::HighPowerPA => &SX1262_PA_TABLE,
+        }
     }
 }
 
@@ -54,7 +188,11 @@ impl Sx126xVariant for Stm32wl {
     fn use_dio2_as_rfswitch(&self) -> bool {
         false
     }
-    fn use_st_power_table(&self) -> bool {
-        true
+    fn pa_table(&self) -> &'static PaTable {
+        if self.use_high_power_pa {
+            &STM32WL_HP_PA_TABLE
+        } else {
+            &SX1261_PA_TABLE
+        }
     }
 }

--- a/lora-phy/src/sx126x/variant.rs
+++ b/lora-phy/src/sx126x/variant.rs
@@ -9,6 +9,16 @@ pub trait Sx126xVariant {
     fn use_dio2_as_rfswitch(&self) -> bool {
         true
     }
+
+    /// Use ST's power table instead of the SX126x datasheet's. The STM32WL
+    /// is an SX126x die integrated into ST's package, characterized by ST
+    /// with its own table; discrete Semtech parts take the datasheet table
+    /// (Table 13-21). The two differ only in the high-power PA's 14 dBm-and-
+    /// below row: same PA config, but ST commands the target dBm directly
+    /// where the datasheet interpolates from a +22 setpoint.
+    fn use_st_power_table(&self) -> bool {
+        false
+    }
 }
 
 /// Sx1261 uses only LowPowerPA
@@ -43,5 +53,8 @@ impl Sx126xVariant for Stm32wl {
     }
     fn use_dio2_as_rfswitch(&self) -> bool {
         false
+    }
+    fn use_st_power_table(&self) -> bool {
+        true
     }
 }


### PR DESCRIPTION
Part of the #445 split, based on #455 (GitHub will retarget to main once that merges).

The sx126x suite: byte-level comparison tests that run our driver and Semtech's reference implementation (SWL2001, via the smtc-modem-cores bindings) against the same recording fixture and assert the SPI byte streams match. Covers the LoRa config surface, RX/CAD paths, TX power for all chips, read commands, image calibration and TX CW, plus an end-to-end init_lora sequence comparison.

Also included:
- a behavioral emulator (register file + state machine) so the full LoRa state machine can be driven under the async driver, including CAD end to end and RX timeout
- the PA power table rework the comparisons forced: the table becomes a const supplied by the variant, the discrete sx1262 and the STM32WL get their own tables, and the sx1262 14 dBm row is documented as a vendor disagreement
- a test pinning every OpCode discriminant to SWL2001's command values, so a wrong byte fails loudly instead of silently talking to the wrong command on hardware

Each commit builds and passes tests on its own.