### PR TITLE
lorawan-device: reject out-of-range channel index in NewChannelReq/DlChannelReq

### DIFF
--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -261,6 +261,11 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
     /// Update channel's downlink frequency for RX1 slot
     fn channel_dl_update(&mut self, index: u8, freq: u32) -> (bool, bool) {
         let freq_valid = self.frequency_valid(freq);
+        // A crafted DlChannelReq can carry any index in 0..=255; reject anything
+        // past the channel plan before indexing self.channels (len NUM_CHANNELS_DYNAMIC).
+        if index >= NUM_CHANNELS_DYNAMIC {
+            return (freq_valid, false);
+        }
         if self.channel_mask.is_enabled(index as usize).is_ok()
             && self.channel_mask.is_enabled(index as usize).unwrap()
         {
@@ -291,6 +296,11 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
         if index < R::NUM_JOIN_CHANNELS {
             return (false, false);
         }
+        // A crafted NewChannelReq can carry any index in 0..=255; reject anything
+        // past the channel plan before indexing self.channels (len NUM_CHANNELS_DYNAMIC).
+        if index >= NUM_CHANNELS_DYNAMIC {
+            return (false, false);
+        }
         // Disable channel if frequency is 0
         if freq == 0 {
             self.channels[index as usize] = None;
@@ -319,5 +329,49 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
         } else {
             None
         }
+    }
+}
+
+#[cfg(all(test, feature = "region-eu868"))]
+mod tests {
+    use super::*;
+    use crate::region::{Configuration, Region};
+
+    // A valid EU868 channel frequency (863..=870 MHz), used to reach the indexing paths.
+    const VALID_FREQ: u32 = 868_100_000;
+
+    // NewChannelReq carries a raw u8 channel index. Indices beyond the channel plan
+    // (NUM_CHANNELS_DYNAMIC) must be rejected, not used to index self.channels.
+    #[test]
+    fn new_channel_index_out_of_range_is_rejected() {
+        let dr = Some(DataRateRange::new_range(DR::_0, DR::_5));
+        for index in NUM_CHANNELS_DYNAMIC..=u8::MAX {
+            let mut config = Configuration::new(Region::EU868);
+            // create path (freq != 0) must not panic and must NAK
+            assert_eq!(config.handle_new_channel(index, VALID_FREQ, dr), (false, false));
+            // disable path (freq == 0) must not panic and must NAK
+            assert_eq!(config.handle_new_channel(index, 0, dr), (false, false));
+        }
+    }
+
+    // DlChannelReq shares the same raw u8 index; an out-of-range index must not
+    // index self.channels either.
+    #[test]
+    fn channel_dl_update_index_out_of_range_is_rejected() {
+        for index in NUM_CHANNELS_DYNAMIC..=u8::MAX {
+            let mut config = Configuration::new(Region::EU868);
+            // frequency-valid flag may be true, but the update flag must be false
+            let (_freq_ack, updated) = config.channel_dl_update(index, VALID_FREQ);
+            assert!(!updated);
+        }
+    }
+
+    // In-range indices past the join channels still work as before.
+    #[test]
+    fn new_channel_in_range_index_is_accepted() {
+        let mut config = Configuration::new(Region::EU868);
+        let dr = Some(DataRateRange::new_range(DR::_0, DR::_5));
+        let index = NUM_CHANNELS_DYNAMIC - 1;
+        assert_eq!(config.handle_new_channel(index, VALID_FREQ, dr), (true, true));
     }
 }


### PR DESCRIPTION
## Problem

In dynamic-channel regions (EU868/EU433/AS923/IN865), `handle_new_channel` and `channel_dl_update` take the channel index straight from a received MAC command (a raw u8, 0..=255) and use it to index `self.channels`, which has 16 entries. Only a lower bound (the join channels) was checked, so any index in 16..=255 from a crafted NewChannelReq or DlChannelReq causes an out-of-bounds panic. A single downlink can crash the device.

## Fix

Reject indices at or above `NUM_CHANNELS_DYNAMIC` before indexing, and NAK the command.

## Tests

Regression tests cover the full out-of-range span (16..=255) for both commands, plus an in-range acceptance case. Verified the tests panic with an index-out-of-bounds on the code before the fix.