### PR TITLE
lorawan-device: reject out-of-range max data rate in NewChannelReq

### DIFF
--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -311,8 +311,12 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
 
         // Check if DataRateRange is valid and supported
         if let Some(r) = dr {
-            let dr_supported = (r.min_data_rate()..=r.max_data_rate())
-                .all(|c| (R::datarates()[c as usize]).is_some());
+            // max_data_rate() comes from a received NewChannelReq and can be up to 15
+            // (DR15 / RFU); datarates() only has NUM_DATARATES (15) entries, so an
+            // unchecked range would index past it. Reject anything out of range.
+            let dr_supported = r.max_data_rate() < NUM_DATARATES
+                && (r.min_data_rate()..=r.max_data_rate())
+                    .all(|c| (R::datarates()[c as usize]).is_some());
 
             if freq_valid && dr_supported {
                 self.channels[index as usize] = Some(Channel::new_with_dr(freq, r));
@@ -339,6 +343,7 @@ mod tests {
 
     // A valid EU868 channel frequency (863..=870 MHz), used to reach the indexing paths.
     const VALID_FREQ: u32 = 868_100_000;
+    const VALID_INDEX: u8 = 5;
 
     // NewChannelReq carries a raw u8 channel index. Indices beyond the channel plan
     // (NUM_CHANNELS_DYNAMIC) must be rejected, not used to index self.channels.
@@ -373,5 +378,26 @@ mod tests {
         let dr = Some(DataRateRange::new_range(DR::_0, DR::_5));
         let index = NUM_CHANNELS_DYNAMIC - 1;
         assert_eq!(config.handle_new_channel(index, VALID_FREQ, dr), (true, true));
+    }
+
+    // NewChannelReq encodes the DR range in one byte; the high nibble (max DR) can be
+    // up to 15, but datarates() only has NUM_DATARATES entries. A range reaching 15
+    // must be NAK'd, not used to index datarates().
+    #[test]
+    fn new_channel_out_of_range_data_rate_is_rejected() {
+        // 0xFF => min DR 15, max DR 15. DataRateRange::new accepts it (max >= min), and
+        // the range 15..=15 indexes datarates()[15] directly, past its length.
+        let dr = Some(DataRateRange::new_from_raw(0xFF));
+        let mut config = Configuration::new(Region::EU868);
+        // Must not panic; frequency is valid but the DR range is not supported.
+        assert_eq!(config.handle_new_channel(VALID_INDEX, VALID_FREQ, dr), (true, false));
+    }
+
+    // A supported DR range is still accepted and creates the channel.
+    #[test]
+    fn new_channel_in_range_data_rate_is_accepted() {
+        let dr = Some(DataRateRange::new_range(DR::_0, DR::_5));
+        let mut config = Configuration::new(Region::EU868);
+        assert_eq!(config.handle_new_channel(VALID_INDEX, VALID_FREQ, dr), (true, true));
     }
 }


### PR DESCRIPTION
## Problem

In dynamic-channel regions (EU868/EU433/AS923/IN865), `handle_new_channel` validates the DataRateRange from a received NewChannelReq by iterating `min..=max` and indexing `datarates()`, which has 15 entries (DR0..=DR14). `DataRateRange::can_build_from` only rejects `max < min`, so a range with max data rate 15 (for example wire byte 0xFF, meaning min 15 / max 15) indexes `datarates()[15]` and panics. A single crafted downlink can crash the device.

## Fix

Reject ranges whose max data rate is at or above `NUM_DATARATES` before iterating, and NAK the command.

## Tests

Regression test uses wire byte 0xFF (range 15..=15), which reaches the bad index directly. Note that 0xF0 (range 0..=15) does not trigger the panic on EU868 because the iteration short-circuits on DR6 being unsupported, so the test uses the direct trigger. Verified the test panics with an index-out-of-bounds on the code before the fix, plus an acceptance case for a supported range.