### PR TITLE
Apply DLSettings from JoinAccept and check MIC before applying state

### DIFF
--- a/lorawan-device/src/async_device/test/mod.rs
+++ b/lorawan-device/src/async_device/test/mod.rs
@@ -100,6 +100,76 @@ async fn test_no_join_accept() {
 }
 
 #[tokio::test]
+async fn test_join_accept_dl_settings_applied() {
+    let (radio, timer, mut async_device) = setup();
+    // Run the device
+    let task = tokio::spawn(async move {
+        let response = async_device.join(&get_otaa_credentials()).await;
+        (async_device, response)
+    });
+
+    // Trigger beginning of RX1
+    timer.fire_most_recent().await;
+    // JoinAccept with RX1DROffset = 2 and RX2DataRate = DR10 (both valid for US915)
+    radio.handle_rxtx(handle_join_request_with_dl_settings::<5, 0x2A>).await;
+
+    let (device, response) = task.await.unwrap();
+    assert!(matches!(response, Ok(JoinResponse::JoinSuccess)));
+    assert_eq!(device.mac.configuration.rx1_dr_offset, 2);
+    assert_eq!(device.mac.configuration.rx2_data_rate, Some(region::DR::_10));
+}
+
+#[tokio::test]
+async fn test_join_accept_dl_settings_invalid_values_ignored() {
+    let (radio, timer, mut async_device) = setup();
+    // Run the device
+    let task = tokio::spawn(async move {
+        let response = async_device.join(&get_otaa_credentials()).await;
+        (async_device, response)
+    });
+
+    // Trigger beginning of RX1
+    timer.fire_most_recent().await;
+    // RX1DROffset = 7 (US915 max is 3) and RX2DataRate = DR7 (RFU in US915)
+    radio.handle_rxtx(handle_join_request_with_dl_settings::<6, 0x77>).await;
+
+    let (device, response) = task.await.unwrap();
+    assert!(matches!(response, Ok(JoinResponse::JoinSuccess)));
+    // Invalid values are ignored; defaults remain
+    assert_eq!(device.mac.configuration.rx1_dr_offset, 0);
+    assert_eq!(device.mac.configuration.rx2_data_rate, None);
+}
+
+#[tokio::test]
+async fn test_join_accept_bad_mic_changes_nothing() {
+    let (radio, timer, mut async_device) = setup();
+    let rx1_delay_default = async_device.mac.configuration.rx1_delay;
+    // Run the device
+    let task = tokio::spawn(async move {
+        let response = async_device.join(&get_otaa_credentials()).await;
+        (async_device, response)
+    });
+
+    // Trigger beginning of RX1
+    timer.fire_most_recent().await;
+    // JoinAccept built with the wrong key; carries RxDelay = 3 and DLSettings = 0x2A
+    radio.handle_rxtx(handle_join_request_bad_mic).await;
+    // Trigger end of RX1
+    radio.handle_timeout().await;
+    // Trigger start of RX2
+    timer.fire_most_recent().await;
+    // Trigger end of RX2
+    radio.handle_timeout().await;
+
+    let (device, response) = task.await.unwrap();
+    assert!(matches!(response, Ok(JoinResponse::NoJoinAccept)));
+    // The rejected accept must not have touched the configuration
+    assert_eq!(device.mac.configuration.rx1_delay, rx1_delay_default);
+    assert_eq!(device.mac.configuration.rx1_dr_offset, 0);
+    assert_eq!(device.mac.configuration.rx2_data_rate, None);
+}
+
+#[tokio::test]
 async fn test_unconfirmed_uplink_no_downlink() {
     let (radio, timer, mut async_device) = setup_with_session();
     let send_await_complete = Arc::new(Mutex::new(false));

--- a/lorawan-device/src/mac/otaa.rs
+++ b/lorawan-device/src/mac/otaa.rs
@@ -57,16 +57,21 @@ impl Otaa {
             lorawan_parse(rx.as_mut_for_read())
         {
             let decrypt = encrypted.decrypt(&self.network_credentials.appkey, &DefaultFactory);
-            region.process_join_accept(&decrypt);
-            // TODO: dlsettings (rx1_dr_offset / rx2_datarate)
-            configuration.rx1_delay = del_to_delay_ms(decrypt.rx_delay());
-            if decrypt.validate_mic(&self.network_credentials.appkey, &DefaultFactory) {
-                return Some(Session::derive_new(
-                    &decrypt,
-                    self.dev_nonce,
-                    &self.network_credentials,
-                ));
+            if !decrypt.validate_mic(&self.network_credentials.appkey, &DefaultFactory) {
+                return None;
             }
+            region.process_join_accept(&decrypt);
+            configuration.rx1_delay = del_to_delay_ms(decrypt.rx_delay());
+            let dl_settings = decrypt.dl_settings();
+            if let Some(rx1_dr_offset) = region.rx1_dr_offset_validate(dl_settings.rx1_dr_offset())
+            {
+                configuration.rx1_dr_offset = rx1_dr_offset;
+            }
+            let rx2_data_rate = dl_settings.rx2_data_rate();
+            if region.get_datarate(rx2_data_rate as u8).is_some() {
+                configuration.rx2_data_rate = Some(rx2_data_rate);
+            }
+            return Some(Session::derive_new(&decrypt, self.dev_nonce, &self.network_credentials));
         }
         None
     }

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -79,6 +79,15 @@ static SESSION: LazyLock<Mutex<HashMap<usize, Session>>> =
 /// Handle join request and pack a JoinAccept into RxBuffer
 pub fn handle_join_request<const I: usize>(
     uplink: Option<Uplink>,
+    config: RfConfig,
+    rx_buffer: &mut [u8],
+) -> usize {
+    handle_join_request_with_dl_settings::<I, 0>(uplink, config, rx_buffer)
+}
+
+/// Handle join request and pack a JoinAccept carrying the given DLSettings byte into RxBuffer
+pub fn handle_join_request_with_dl_settings<const I: usize, const DL_SETTINGS: u8>(
+    uplink: Option<Uplink>,
     _config: RfConfig,
     rx_buffer: &mut [u8],
 ) -> usize {
@@ -92,6 +101,7 @@ pub fn handle_join_request<const I: usize>(
             phy.set_app_nonce(&app_nonce_bytes);
             phy.set_net_id(&[1; 3]);
             phy.set_dev_addr(get_dev_addr());
+            phy.set_dl_settings(DL_SETTINGS);
             let finished = phy.build(&get_key().into(), &DefaultFactory).unwrap();
             rx_buffer[..finished.len()].copy_from_slice(finished);
 
@@ -174,6 +184,36 @@ pub fn handle_data_uplink_with_link_adr_req<const FCNT_UP: u16, const FCNT_DOWN:
         }
     } else {
         panic!("No uplink passed to handle_data_uplink_with_link_adr_req");
+    }
+}
+
+/// Handle join request and respond with a JoinAccept built with the wrong key, so its MIC is
+/// invalid. Sets RxDelay and DLSettings so tests can verify a rejected accept changes nothing.
+pub fn handle_join_request_bad_mic(
+    uplink: Option<Uplink>,
+    _config: RfConfig,
+    rx_buffer: &mut [u8],
+) -> usize {
+    if let Some(mut uplink) = uplink {
+        if let PhyPayload::JoinRequest(join_request) = uplink.get_payload() {
+            assert!(join_request.validate_mic(&get_key().into(), &DefaultFactory));
+            let mut buffer: [u8; 17] = [0; 17];
+            let mut phy = lorawan::creator::JoinAcceptCreator::new(&mut buffer[..]).unwrap();
+            let app_nonce_bytes = [1; 3];
+            phy.set_app_nonce(&app_nonce_bytes);
+            phy.set_net_id(&[1; 3]);
+            phy.set_dev_addr(get_dev_addr());
+            phy.set_dl_settings(0x2A);
+            phy.set_rx_delay(3);
+            let wrong_key = [1; 16];
+            let finished = phy.build(&wrong_key.into(), &DefaultFactory).unwrap();
+            rx_buffer[..finished.len()].copy_from_slice(finished);
+            finished.len()
+        } else {
+            panic!("Did not parse join request from uplink");
+        }
+    } else {
+        panic!("No uplink passed to handle_join_request_bad_mic");
     }
 }
 


### PR DESCRIPTION
Two fixes in JoinAccept handling:

1. The DLSettings byte (RX1DROffset and RX2DataRate) was parsed but never applied (the TODO in `otaa.rs`), so a server that configures either value in the accept was ignored and subsequent downlinks could be missed. Values are now validated against the region the same way RXParamSetupReq handling does it; invalid values keep the current settings.

2. The MIC was checked after region state was already updated: a JoinAccept that failed MIC validation still processed the CFList / channel mask and set RX1 delay. The MIC check now happens before any state changes. One of the new tests demonstrates the old behavior: a bad-MIC accept carrying RxDelay=3 moved rx1_delay from 1000 to 9000 ms even though the join was rejected.

Three new tests: valid DLSettings applied, invalid values ignored (defaults kept), bad-MIC accept changes nothing.