### PR TITLE
fix crypto crate bump fallout in benches and warnings

### DIFF
--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 
 pub mod radio;
-use lorawan::default_crypto::DefaultFactory;
 
 #[cfg(feature = "embassy-time")]
 mod embassy_time;
@@ -25,6 +24,8 @@ pub use embassy_time::EmbassyTimer;
 
 #[cfg(feature = "multicast")]
 use crate::mac::multicast;
+#[cfg(feature = "multicast")]
+use lorawan::default_crypto::DefaultFactory;
 #[cfg(feature = "multicast")]
 pub use lorawan::{
     keys::{AppKey, AppSKey, GenAppKey, McAppSKey, McNetSKey, McRootKey},

--- a/lorawan-encoding/benches/lorawan.rs
+++ b/lorawan-encoding/benches/lorawan.rs
@@ -7,7 +7,7 @@
 // author: Ivaylo Petrov <ivajloip@gmail.com>
 
 use crate::CryptoFactory;
-use aes::cipher::{generic_array::GenericArray, KeyInit};
+use aes::cipher::KeyInit;
 use aes::Aes128;
 use criterion::{criterion_group, criterion_main, Criterion};
 use lorawan::maccommands::{DownlinkMacCommand, MacCommandIterator};
@@ -126,8 +126,8 @@ impl PartialEq for ConstFactory {
 impl ConstFactory {
     fn new(key: &AES128) -> Self {
         ConstFactory(
-            Aes128::new(GenericArray::from_slice(&key.0[..])),
-            Cmac::new((&key.0[..]).into()),
+            Aes128::new_from_slice(&key.0[..]).unwrap(),
+            Cmac::new_from_slice(&key.0[..]).unwrap(),
         )
     }
 }

--- a/lorawan-encoding/src/default_crypto.rs
+++ b/lorawan-encoding/src/default_crypto.rs
@@ -1,8 +1,7 @@
 //! Provides a default software implementation for LoRaWAN's cryptographic functions.
 use super::keys::*;
 use aes::cipher::{
-    Array as GenericArray, BlockCipherDecrypt as BlockDecrypt, BlockCipherEncrypt as BlockEncrypt,
-    KeyInit,
+    BlockCipherDecrypt as BlockDecrypt, BlockCipherEncrypt as BlockEncrypt, KeyInit,
 };
 use aes::Aes128;
 use cmac::Cmac as RustCmac;
@@ -33,13 +32,13 @@ impl CryptoFactory for DefaultFactory {
 
 impl Encrypter for Aes128 {
     fn encrypt_block(&self, block: &mut [u8]) {
-        BlockEncrypt::encrypt_block(self, GenericArray::from_mut_slice(block));
+        BlockEncrypt::encrypt_block(self, block.try_into().unwrap());
     }
 }
 
 impl Decrypter for Aes128 {
     fn decrypt_block(&self, block: &mut [u8]) {
-        BlockDecrypt::decrypt_block(self, GenericArray::from_mut_slice(block));
+        BlockDecrypt::decrypt_block(self, block.try_into().unwrap());
     }
 }
 


### PR DESCRIPTION
Cleanup from the rc to full-release crypto bump (#454), which moved `aes::cipher` from `generic_array` to its own `Array` type:

- The `lorawan-encoding` bench no longer compiled (`generic_array` import gone). CI does not build benches so this went unnoticed. Switched it to the same `new_from_slice` constructors the library itself uses.
- `default_crypto` used the now-deprecated `Array::from_mut_slice`; replaced with `TryFrom` conversions per the deprecation note.
- The `DefaultFactory` import in `async_device` is only used by the multicast key-derivation methods, so it now sits behind the `multicast` feature. Fixes the unused-import warning on default-feature builds.

No behavior changes. `cargo test --workspace` green, benches compile and run again.
