### PR TITLE
lorawan-encoding: replace CryptoFactory with key-bound Crypto traits

### DIFF
--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -25,7 +25,7 @@ pub use embassy_time::EmbassyTimer;
 #[cfg(feature = "multicast")]
 use crate::mac::multicast;
 #[cfg(feature = "multicast")]
-use lorawan::default_crypto::DefaultFactory;
+use lorawan::default_crypto::DefaultCrypto;
 #[cfg(feature = "multicast")]
 pub use lorawan::{
     keys::{AppKey, AppSKey, GenAppKey, McAppSKey, McNetSKey, McRootKey},
@@ -231,8 +231,8 @@ where
     #[cfg(feature = "multicast")]
     /// Set the McKEKey for multicast session key derivation by providing a McRootKey.
     pub fn set_multicast_ke_key(&mut self, mc_root_key: McRootKey) {
-        let crypto = DefaultFactory;
-        let key = lorawan::keys::McKEKey::derive_from(&crypto, &mc_root_key);
+        let crypto = DefaultCrypto::new(mc_root_key.inner());
+        let key = lorawan::keys::McKEKey::derive_from(&crypto);
         self.mac.multicast.mc_k_e_key = Some(key);
     }
 
@@ -241,8 +241,8 @@ where
     /// GenAppKey. The McRootKey is derived from this using `McRootKey = aes128_encrypt(GenAppKey, 0x00 | pad16) `
     /// and then the McKEKey is derived from the McRootKey.
     pub fn set_multicast_ke_key_from_gen_app_key(&mut self, key: GenAppKey) {
-        let crypto = DefaultFactory;
-        let mc_root_key = McRootKey::derive_from_gen_app_key(&crypto, &key);
+        let crypto = DefaultCrypto::new(key.inner());
+        let mc_root_key = McRootKey::derive_from_gen_app_key(&crypto);
         self.set_multicast_ke_key(mc_root_key);
     }
 
@@ -251,8 +251,8 @@ where
     /// GenAppKey. The McRootKey is derived from this using `McRootKey = aes128_encrypt(AppKey, 0x20 | pad16) `
     /// and then the McKEKey is derived from the McRootKey.
     pub fn set_multicast_ke_key_from_app_key(&mut self, key: AppKey) {
-        let crypto = DefaultFactory;
-        let mc_root_key = McRootKey::derive_from_app_key(&crypto, &key);
+        let crypto = DefaultCrypto::new(key.inner());
+        let mc_root_key = McRootKey::derive_from_app_key(&crypto);
         self.set_multicast_ke_key(mc_root_key);
     }
 

--- a/lorawan-device/src/async_device/test/certification/mod.rs
+++ b/lorawan-device/src/async_device/test/certification/mod.rs
@@ -3,10 +3,9 @@
 use super::util;
 use crate::async_device::SendResponse;
 use crate::radio::RfConfig;
-use crate::test_util::{get_dev_addr, get_key, Uplink};
+use crate::test_util::{get_crypto, get_dev_addr, Uplink};
 use core::num::NonZeroU8;
 use lorawan::creator::{DataFrame, Payload};
-use lorawan::default_crypto::DefaultFactory;
 use lorawan::parser::{self, DataFrameType, DecryptedDataPayload, PhyPayload};
 
 use std::sync::Arc;
@@ -27,19 +26,13 @@ fn decrypt_uplink(uplink: &mut Uplink) -> DecryptedDataPayload<'_> {
     let fcnt = match parser::parse(&*bytes) {
         Ok(PhyPayload::Data(data)) => {
             let fcnt = data.fhdr().fcnt() as u32;
-            assert!(data.validate_mic(&get_key().into(), fcnt, &DefaultFactory));
+            assert!(data.validate_mic(&get_crypto(), fcnt));
             fcnt
         }
         _ => panic!("expected a data frame"),
     };
-    DecryptedDataPayload::decrypt_in_place(
-        bytes,
-        Some(&get_key().into()),
-        Some(&get_key().into()),
-        fcnt,
-        &DefaultFactory,
-    )
-    .unwrap()
+    DecryptedDataPayload::decrypt_in_place(bytes, Some(&get_crypto()), Some(&get_crypto()), fcnt)
+        .unwrap()
 }
 
 fn _build(buf: &mut [u8], payload_in_hex: &str, fcnt: u16, fport: u8) -> usize {
@@ -55,8 +48,7 @@ fn _build(buf: &mut [u8], payload_in_hex: &str, fcnt: u16, fport: u8) -> usize {
         },
         ..Default::default()
     };
-    let finished =
-        frame.build_into(buf, &get_key().into(), Some(&get_key().into()), &DefaultFactory).unwrap();
+    let finished = frame.build_into(buf, &get_crypto(), Some(&get_crypto())).unwrap();
     finished.len()
 }
 
@@ -79,8 +71,7 @@ fn packet_with_mac(
         payload: Payload::Data { f_port: NonZeroU8::new(fport).unwrap(), data: &payload },
         ..Default::default()
     };
-    let finished =
-        frame.build_into(buf, &get_key().into(), Some(&get_key().into()), &DefaultFactory).unwrap();
+    let finished = frame.build_into(buf, &get_crypto(), Some(&get_crypto())).unwrap();
     finished.len()
 }
 

--- a/lorawan-device/src/async_device/test/class_c.rs
+++ b/lorawan-device/src/async_device/test/class_c.rs
@@ -1,10 +1,9 @@
 use super::util;
 use crate::async_device::{ListenResponse, SendResponse};
 use crate::radio::RfConfig;
-use crate::test_util::{get_dev_addr, get_key, Uplink};
+use crate::test_util::{get_crypto, get_dev_addr, Uplink};
 use core::num::NonZeroU8;
 use lorawan::creator::{DataFrame, Payload};
-use lorawan::default_crypto::DefaultFactory;
 use lorawan::parser::DataFrameType;
 
 pub fn class_c_downlink<const FCNT_DOWN: u32>(
@@ -19,9 +18,7 @@ pub fn class_c_downlink<const FCNT_DOWN: u32>(
         payload: Payload::Data { f_port: NonZeroU8::new(3).unwrap(), data: &[1, 2, 3] },
         ..Default::default()
     };
-    let finished = frame
-        .build_into(rx_buffer, &get_key().into(), Some(&get_key().into()), &DefaultFactory)
-        .unwrap();
+    let finished = frame.build_into(rx_buffer, &get_crypto(), Some(&get_crypto())).unwrap();
     finished.len()
 }
 #[tokio::test]

--- a/lorawan-device/src/async_device/test/maccommands.rs
+++ b/lorawan-device/src/async_device/test/maccommands.rs
@@ -1,10 +1,9 @@
 use super::util;
 use crate::async_device::SendResponse;
 use crate::radio::RfConfig;
-use crate::test_util::{get_key, Uplink};
+use crate::test_util::{get_crypto, Uplink};
 
 use lorawan::creator::{DataFrame, Payload};
-use lorawan::default_crypto::DefaultFactory;
 use lorawan::maccommands::parse_uplink_mac_commands;
 use lorawan::parser::DataFrameType;
 use lorawan::types::ChannelMask;
@@ -22,8 +21,7 @@ fn build_frm_payload(buf: &mut [u8], payload_in_hex: &str, fcnt: u32) -> usize {
         payload: Payload::MacCommands(&cmds),
         ..Default::default()
     };
-    let finished =
-        frame.build_into(buf, &get_key().into(), Some(&get_key().into()), &DefaultFactory).unwrap();
+    let finished = frame.build_into(buf, &get_crypto(), Some(&get_crypto())).unwrap();
     finished.len()
 }
 
@@ -516,9 +514,7 @@ async fn maccommands_in_frmpayload() {
             payload: Payload::MacCommands(&[6, 5, 2, 0xd2, 0xad, 0x84, 8, 1, 3, 0x50, 0, 0, 0x61]),
             ..Default::default()
         };
-        let finished = frame
-            .build_into(rx_buffer, &get_key().into(), Some(&get_key().into()), &DefaultFactory)
-            .unwrap();
+        let finished = frame.build_into(rx_buffer, &get_crypto(), Some(&get_crypto())).unwrap();
         finished.len()
     }
 

--- a/lorawan-device/src/async_device/test/mod.rs
+++ b/lorawan-device/src/async_device/test/mod.rs
@@ -4,7 +4,6 @@ use crate::{
     region,
     test_util::*,
 };
-use lorawan::default_crypto::DefaultFactory;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -343,9 +342,7 @@ async fn invalid_maccommands_in_frmpayload() {
             payload: lorawan::creator::Payload::MacCommands(&[3, 192, 0, 0, 0]),
             ..Default::default()
         };
-        let finished = frame
-            .build_into(rx_buffer, &get_key().into(), Some(&get_key().into()), &DefaultFactory)
-            .unwrap();
+        let finished = frame.build_into(rx_buffer, &get_crypto(), Some(&get_crypto())).unwrap();
         finished.len()
     }
 

--- a/lorawan-device/src/async_device/test/multicast.rs
+++ b/lorawan-device/src/async_device/test/multicast.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::async_device::McAddr;
 use core::num::NonZeroU8;
 use lorawan::creator::{DataFrame, Payload};
+use lorawan::default_crypto::DefaultNetworkCrypto;
 use lorawan::keys::{McKEKey, McKey};
 use lorawan::multicast::parse_uplink_multicast_commands;
 use lorawan::multicast::{McGroupDeleteReqCreator, McGroupSetupReqCreator, UplinkRemoteSetup};
@@ -19,7 +20,7 @@ fn handle_multicast_setup_req(
 
     req.mc_group_id_header(0x01);
     req.mc_addr(&mc_addr);
-    req.mc_key(&DefaultFactory, &mc_key, &mcke_key);
+    req.mc_key(&DefaultNetworkCrypto::new(mcke_key.inner()), &mc_key);
     req.min_mc_fcount(0x12345678);
     req.max_mc_fcount(0x87654321);
     let setup_req = req.build();
@@ -35,9 +36,7 @@ fn handle_multicast_setup_req(
         payload: Payload::Data { f_port: NonZeroU8::new(200).unwrap(), data: setup_req },
         ..Default::default()
     };
-    let finished = frame
-        .build_into(rx_buffer, &get_key().into(), Some(&get_key().into()), &DefaultFactory)
-        .unwrap();
+    let finished = frame.build_into(rx_buffer, &get_crypto(), Some(&get_crypto())).unwrap();
     finished.len()
 }
 
@@ -51,17 +50,16 @@ fn verify_multicast_message(
     let fcnt = match parser::parse(&*bytes) {
         Ok(parser::PhyPayload::Data(data)) => {
             let fcnt = data.fhdr().fcnt() as u32;
-            assert!(data.validate_mic(&get_key().into(), fcnt, &DefaultFactory));
+            assert!(data.validate_mic(&get_crypto(), fcnt));
             fcnt
         }
         _ => panic!("Expected encrypted data payload"),
     };
     let decrypted = DecryptedDataPayload::decrypt_in_place(
         bytes,
-        Some(&get_key().into()),
-        Some(&get_key().into()),
+        Some(&get_crypto()),
+        Some(&get_crypto()),
         fcnt,
-        &DefaultFactory,
     )
     .unwrap();
     assert_eq!(decrypted.f_port().unwrap(), expected_port);
@@ -147,9 +145,7 @@ fn handle_mc_group_delete_req<const GROUP_ID: u8>(
         payload: Payload::Data { f_port: NonZeroU8::new(200).unwrap(), data: setup_req },
         ..Default::default()
     };
-    let finished = frame
-        .build_into(rx_buffer, &get_key().into(), Some(&get_key().into()), &DefaultFactory)
-        .unwrap();
+    let finished = frame.build_into(rx_buffer, &get_crypto(), Some(&get_crypto())).unwrap();
     finished.len()
 }
 
@@ -185,9 +181,7 @@ fn handle_regular_downlink_msg<const FCNT: u32>(
         payload: Payload::Data { f_port: NonZeroU8::new(1).unwrap(), data: &[1, 2, 3] },
         ..Default::default()
     };
-    let finished = frame
-        .build_into(rx_buffer, &get_key().into(), Some(&get_key().into()), &DefaultFactory)
-        .unwrap();
+    let finished = frame.build_into(rx_buffer, &get_crypto(), Some(&get_crypto())).unwrap();
     finished.len()
 }
 

--- a/lorawan-device/src/async_device/test/util.rs
+++ b/lorawan-device/src/async_device/test/util.rs
@@ -1,11 +1,10 @@
 use crate::radio::RfConfig;
 use lorawan::creator::DataFrame;
-use lorawan::default_crypto::DefaultFactory;
 use lorawan::parser::{self, DataFrameType, DecryptedDataPayload, PhyPayload};
 
 use super::{get_dev_addr, get_key, radio::*, region, timer::*, Device};
 use crate::mac::Session;
-pub(crate) use crate::test_util::{handle_data_uplink_with_link_adr_req, Uplink};
+pub(crate) use crate::test_util::{get_crypto, handle_data_uplink_with_link_adr_req, Uplink};
 use crate::{AppSKey, NwkSKey};
 
 fn default_session() -> Session {
@@ -54,17 +53,16 @@ pub fn handle_class_c_uplink_after_join(
         let fcnt = match parser::parse(&*bytes) {
             Ok(PhyPayload::Data(data)) => {
                 let fcnt = data.fhdr().fcnt() as u32;
-                assert!(data.validate_mic(&get_key().into(), fcnt, &DefaultFactory));
+                assert!(data.validate_mic(&get_crypto(), fcnt));
                 fcnt
             }
             _ => panic!("Did not decode PhyPayload::Data!"),
         };
         let decrypted = DecryptedDataPayload::decrypt_in_place(
             bytes,
-            Some(&get_key().into()),
-            Some(&get_key().into()),
+            Some(&get_crypto()),
+            Some(&get_crypto()),
             fcnt,
-            &DefaultFactory,
         )
         .unwrap();
         assert_eq!(decrypted.fhdr().fcnt(), 0);
@@ -75,9 +73,7 @@ pub fn handle_class_c_uplink_after_join(
             ack: true,
             ..Default::default()
         };
-        let finished = frame
-            .build_into(rx_buffer, &get_key().into(), Some(&get_key().into()), &DefaultFactory)
-            .unwrap();
+        let finished = frame.build_into(rx_buffer, &get_crypto(), Some(&get_crypto())).unwrap();
         finished.len()
     } else {
         panic!("No uplink passed to handle_class_c_uplink_after_join");

--- a/lorawan-device/src/lib.rs
+++ b/lorawan-device/src/lib.rs
@@ -29,7 +29,7 @@ pub mod nb_device;
 use nb_device::state::State;
 
 pub use lorawan::{
-    keys::{AppEui, AppKey, AppSKey, CryptoFactory, DevEui, NwkSKey},
+    keys::{AppEui, AppKey, AppSKey, Crypto, DevEui, NwkSKey},
     parser::DevAddr,
 };
 

--- a/lorawan-device/src/mac/multicast.rs
+++ b/lorawan-device/src/mac/multicast.rs
@@ -4,7 +4,7 @@ use crate::Downlink;
 use crate::{async_device, mac};
 use core::fmt::Debug;
 use core::ops::RangeInclusive;
-use lorawan::default_crypto::DefaultFactory;
+use lorawan::default_crypto::DefaultCrypto;
 use lorawan::keys::McKEKey;
 use lorawan::multicast::parse_downlink_multicast_commands;
 pub use lorawan::multicast::{self, Session};
@@ -73,18 +73,19 @@ impl Multicast {
         let mc_addr = encrypted_data.fhdr().mc_addr();
         if let Some((group_id, session)) = self.matching_session(mc_addr) {
             let fcnt = encrypted_data.fhdr().fcnt() as u32;
-            if encrypted_data.validate_mic(session.mc_net_s_key().inner(), fcnt, &DefaultFactory)
+            let nwk_crypto = DefaultCrypto::new(session.mc_net_s_key().inner());
+            let app_crypto = DefaultCrypto::new(session.mc_app_s_key().inner());
+            if encrypted_data.validate_mic(&nwk_crypto, fcnt)
                 && (fcnt > session.fcnt_down || fcnt == 0)
             {
                 return {
                     session.fcnt_down = fcnt;
                     // We can safely unwrap here because we already validated the MIC
-                    let decrypted = DecryptedDataPayload::decrypt_in_place_with(
+                    let decrypted = DecryptedDataPayload::decrypt_in_place(
                         bytes,
-                        Some(session.mc_net_s_key().inner()),
-                        Some(session.mc_app_s_key().inner()),
+                        Some(&nwk_crypto),
+                        Some(&app_crypto),
                         session.fcnt_down,
-                        &DefaultFactory,
                     )
                     .unwrap();
                     if session.fcnt_down == session.max_fcnt_down() {
@@ -141,9 +142,8 @@ impl Multicast {
             };
             match message {
                 DownlinkRemoteSetup::McGroupSetupReq(mc_group_setup_req) => {
-                    let crypto = DefaultFactory;
-                    let (group_id, session) =
-                        mc_group_setup_req.derive_session(&crypto, mc_k_e_key);
+                    let crypto = DefaultCrypto::new(mc_k_e_key.inner());
+                    let (group_id, session) = mc_group_setup_req.derive_session(&crypto);
                     self.sessions[group_id as usize] = Some(session);
                     let mut ans = McGroupSetupAnsCreator::new();
                     ans.mc_group_id_header(group_id);

--- a/lorawan-device/src/mac/otaa.rs
+++ b/lorawan-device/src/mac/otaa.rs
@@ -3,7 +3,7 @@ use crate::radio::RadioBuffer;
 use crate::region::Configuration;
 use crate::{AppEui, AppKey, DevEui};
 use lorawan::creator::JoinRequest;
-use lorawan::default_crypto::DefaultFactory;
+use lorawan::default_crypto::DefaultCrypto;
 use lorawan::parser::DecryptedJoinAcceptPayload;
 use rand_core::RngCore;
 
@@ -40,10 +40,8 @@ impl Otaa {
             dev_eui: self.network_credentials.deveui.into(),
             dev_nonce: self.dev_nonce,
         };
-        let len = request
-            .build_into(buf.as_mut(), &self.network_credentials.appkey, &DefaultFactory)
-            .unwrap()
-            .len();
+        let crypto = DefaultCrypto::new(self.network_credentials.appkey.inner());
+        let len = request.build_into(buf.as_mut(), &crypto).unwrap().len();
         buf.set_pos(len);
         self.dev_nonce.value()
     }
@@ -56,8 +54,7 @@ impl Otaa {
     ) -> Option<Session> {
         if let Ok(decrypt) = DecryptedJoinAcceptPayload::check_mic_and_decrypt_in_place(
             rx.as_mut_for_read(),
-            &self.network_credentials.appkey,
-            &DefaultFactory,
+            &DefaultCrypto::new(self.network_credentials.appkey.inner()),
         ) {
             region.process_join_accept(decrypt.c_f_list().as_ref());
             configuration.rx1_delay = del_to_delay_ms(decrypt.rx_delay());

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -19,7 +19,7 @@ use lorawan::parser::{
     FrmPayload,
 };
 use lorawan::{
-    default_crypto::DefaultFactory,
+    default_crypto::DefaultCrypto,
     packet_length::phy::{MHDR_LEN, MIC_LEN},
     types::DR,
 };
@@ -74,8 +74,8 @@ impl Session {
         credentials: &NetworkCredentials,
     ) -> Self {
         Self::new(
-            decrypt.derive_nwkskey(devnonce, credentials.appkey(), &DefaultFactory),
-            decrypt.derive_appskey(devnonce, credentials.appkey(), &DefaultFactory),
+            decrypt.derive_nwkskey(devnonce, &DefaultCrypto::new(credentials.appkey().inner())),
+            decrypt.derive_appskey(devnonce, &DefaultCrypto::new(credentials.appkey().inner())),
             decrypt.dev_addr(),
         )
     }
@@ -175,15 +175,16 @@ impl Session {
             let Some(fcnt) = next_fcnt_down(self.fcnt_down, encrypted_data.fhdr().fcnt()) else {
                 return Response::NoUpdate;
             };
-            if encrypted_data.validate_mic(self.nwkskey().inner(), fcnt, &DefaultFactory) {
+            let nwk_crypto = DefaultCrypto::new(self.nwkskey.inner());
+            let app_crypto = DefaultCrypto::new(self.appskey.inner());
+            if encrypted_data.validate_mic(&nwk_crypto, fcnt) {
                 self.fcnt_down = Some(fcnt);
                 // We can safely unwrap here because we already validated the MIC
                 let decrypted = DecryptedDataPayload::decrypt_in_place(
                     bytes,
-                    Some(&self.nwkskey),
-                    Some(&self.appskey),
+                    Some(&nwk_crypto),
+                    Some(&app_crypto),
                     fcnt,
-                    &DefaultFactory,
                 )
                 .unwrap();
 
@@ -341,7 +342,9 @@ impl Session {
             f_opts,
             payload,
         };
-        match frame.build_into(&mut buf, &self.nwkskey, Some(&self.appskey), &DefaultFactory) {
+        let nwk_crypto = DefaultCrypto::new(self.nwkskey.inner());
+        let app_crypto = DefaultCrypto::new(self.appskey.inner());
+        match frame.build_into(&mut buf, &nwk_crypto, Some(&app_crypto)) {
             Ok(packet) => {
                 tx_buffer.clear();
                 tx_buffer.extend_from_slice(packet).unwrap();
@@ -558,7 +561,7 @@ mod tests {
     use super::{SendData, Session};
     use crate::radio::RadioBuffer;
     use crate::{AppSKey, NwkSKey};
-    use lorawan::default_crypto::DefaultFactory;
+    use lorawan::default_crypto::DefaultCrypto;
     use lorawan::maccommandcreator::LinkADRAnsCreator;
     use lorawan::parser::{DecryptedDataPayload, DevAddr, FrmPayload};
 
@@ -579,9 +582,9 @@ mod tests {
         session.prepare_buffer::<256>(&SendData { data: &[], fport: 0, confirmed: false }, &mut tx);
 
         let bytes = tx.as_mut_for_read();
+        let nwk_crypto = DefaultCrypto::new(nwkskey.inner());
         let decrypted =
-            DecryptedDataPayload::decrypt_in_place(bytes, Some(&nwkskey), None, 0, &DefaultFactory)
-                .unwrap();
+            DecryptedDataPayload::decrypt_in_place(bytes, Some(&nwk_crypto), None, 0).unwrap();
         assert_eq!(decrypted.fhdr().f_opts(), &[] as &[u8]);
         assert_eq!(decrypted.f_port(), Some(0));
         assert_eq!(decrypted.frm_payload(), FrmPayload::MacCommands(&expected[..]));

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -1,7 +1,7 @@
 use super::*;
 use core::num::NonZeroU8;
 use lorawan::creator::{DataFrame, JoinAccept, Payload};
-use lorawan::default_crypto::DefaultFactory;
+use lorawan::default_crypto::{DefaultCrypto, DefaultNetworkCrypto};
 use lorawan::maccommandcreator::LinkADRReqCreator;
 use lorawan::maccommands::parse_uplink_mac_commands;
 use lorawan::maccommands::UplinkMacCommand;
@@ -50,6 +50,16 @@ pub fn get_key() -> [u8; 16] {
     [0; 16]
 }
 
+/// Device-side crypto bound to the test key.
+pub fn get_crypto() -> DefaultCrypto {
+    DefaultCrypto::new(&get_key().into())
+}
+
+/// Network-side crypto bound to the test key, for JoinAccept creation.
+pub fn get_network_crypto() -> DefaultNetworkCrypto {
+    DefaultNetworkCrypto::new(&get_key().into())
+}
+
 pub fn get_dev_addr() -> DevAddr {
     DevAddr::from_value(0)
 }
@@ -92,7 +102,7 @@ pub fn handle_join_request_with_dl_settings<const I: usize, const DL_SETTINGS: u
     if let Some(mut uplink) = uplink {
         if let Ok(PhyPayload::JoinRequest(join_request)) = parser::parse(uplink.data_mut()) {
             let devnonce = join_request.dev_nonce();
-            assert!(join_request.validate_mic(&get_key().into(), &DefaultFactory));
+            assert!(join_request.validate_mic(&get_crypto()));
             let accept = JoinAccept {
                 join_nonce: JoinNonce::from_wire_bytes([1; 3]),
                 net_id: NetId::from_wire_bytes([1; 3]),
@@ -101,15 +111,13 @@ pub fn handle_join_request_with_dl_settings<const I: usize, const DL_SETTINGS: u
                 rx_delay: 0,
                 c_f_list: None,
             };
-            let finished =
-                accept.build_into(rx_buffer, &get_key().into(), &DefaultFactory).unwrap();
+            let finished = accept.build_into(rx_buffer, &get_network_crypto()).unwrap();
             let len = finished.len();
 
             let mut copy = finished.to_vec();
             let decrypt = DecryptedJoinAcceptPayload::check_mic_and_decrypt_in_place(
                 copy.as_mut_slice(),
-                &get_key().into(),
-                &DefaultFactory,
+                &get_crypto(),
             )
             .expect("Somehow unable to parse my own join accept?");
             let session = Session::derive_new(
@@ -145,17 +153,16 @@ pub fn handle_data_uplink_with_link_adr_req<const FCNT_UP: u16, const FCNT_DOWN:
         let (fcnt, confirmed) = match parser::parse(&*bytes) {
             Ok(PhyPayload::Data(data)) => {
                 let fcnt = data.fhdr().fcnt() as u32;
-                assert!(data.validate_mic(&get_key().into(), fcnt, &DefaultFactory));
+                assert!(data.validate_mic(&get_crypto(), fcnt));
                 (fcnt, data.is_confirmed())
             }
             _ => panic!("Did not decode PhyPayload::Data!"),
         };
         let decrypted = DecryptedDataPayload::decrypt_in_place(
             bytes,
-            Some(&get_key().into()),
-            Some(&get_key().into()),
+            Some(&get_crypto()),
+            Some(&get_crypto()),
             fcnt,
-            &DefaultFactory,
         )
         .unwrap();
         assert_eq!(decrypted.fhdr().fcnt(), FCNT_UP);
@@ -176,9 +183,7 @@ pub fn handle_data_uplink_with_link_adr_req<const FCNT_UP: u16, const FCNT_DOWN:
             payload: Payload::Data { f_port: NonZeroU8::new(4).unwrap(), data: &[3, 2, 1] },
             ..Default::default()
         };
-        let finished = frame
-            .build_into(rx_buffer, &get_key().into(), Some(&get_key().into()), &DefaultFactory)
-            .unwrap();
+        let finished = frame.build_into(rx_buffer, &get_crypto(), Some(&get_crypto())).unwrap();
         finished.len()
     } else {
         panic!("No uplink passed to handle_data_uplink_with_link_adr_req");
@@ -194,7 +199,7 @@ pub fn handle_join_request_bad_mic(
 ) -> usize {
     if let Some(mut uplink) = uplink {
         if let Ok(PhyPayload::JoinRequest(join_request)) = parser::parse(uplink.data_mut()) {
-            assert!(join_request.validate_mic(&get_key().into(), &DefaultFactory));
+            assert!(join_request.validate_mic(&get_crypto()));
             let accept = JoinAccept {
                 join_nonce: JoinNonce::from_wire_bytes([1; 3]),
                 net_id: NetId::from_wire_bytes([1; 3]),
@@ -204,8 +209,9 @@ pub fn handle_join_request_bad_mic(
                 c_f_list: None,
             };
             let wrong_key = [1; 16];
-            let finished =
-                accept.build_into(rx_buffer, &wrong_key.into(), &DefaultFactory).unwrap();
+            let finished = accept
+                .build_into(rx_buffer, &DefaultNetworkCrypto::new(&wrong_key.into()))
+                .unwrap();
             finished.len()
         } else {
             panic!("Did not parse join request from uplink");
@@ -240,7 +246,7 @@ pub fn handle_data_uplink_with_link_adr_ans(
         let (fcnt, confirmed) = match parser::parse(&*bytes) {
             Ok(PhyPayload::Data(data)) => {
                 let fcnt = data.fhdr().fcnt() as u32;
-                assert!(data.validate_mic(&get_key().into(), fcnt, &DefaultFactory));
+                assert!(data.validate_mic(&get_crypto(), fcnt));
                 (fcnt, data.is_confirmed())
             }
             _ => panic!(
@@ -249,10 +255,9 @@ pub fn handle_data_uplink_with_link_adr_ans(
         };
         let decrypted = DecryptedDataPayload::decrypt_in_place(
             bytes,
-            Some(&get_key().into()),
-            Some(&get_key().into()),
+            Some(&get_crypto()),
+            Some(&get_crypto()),
             fcnt,
-            &DefaultFactory,
         )
         .unwrap();
         let fhdr = decrypted.fhdr();
@@ -274,9 +279,7 @@ pub fn handle_data_uplink_with_link_adr_ans(
             fcnt: 1,
             ..Default::default()
         };
-        let finished = frame
-            .build_into(rx_buffer, &get_key().into(), Some(&get_key().into()), &DefaultFactory)
-            .unwrap();
+        let finished = frame.build_into(rx_buffer, &get_crypto(), Some(&get_crypto())).unwrap();
         finished.len()
     } else {
         panic!("No uplink passed to handle_data_uplink_with_link_adr_ans")

--- a/lorawan-encoding/README.md
+++ b/lorawan-encoding/README.md
@@ -26,7 +26,7 @@ lorawan = "0.9"
 ### Packet generation
 
 ```rust
-use lorawan::default_crypto::DefaultFactory;
+use lorawan::default_crypto::DefaultNetworkCrypto;
 use lorawan::keys::AppKey;
 use lorawan::types::DLSettings;
 use lorawan::creator::JoinAccept;
@@ -48,13 +48,15 @@ let accept = JoinAccept {
 };
 let mut data = [0; 33];
 let key = AppKey::from([1; 16]);
-let payload = accept.build_into(&mut data, &key, &DefaultFactory).unwrap();
+let crypto = DefaultNetworkCrypto::new(key.inner());
+let payload = accept.build_into(&mut data, &crypto).unwrap();
 println!("Payload: {:x?}", payload);
 ```
 
 ### Packet parsing
 
 ```rust
+use lorawan::default_crypto::DefaultCrypto;
 use lorawan::keys::AppSKey;
 use lorawan::parser::{parse, DecryptedDataPayload, FrmPayload, PhyPayload};
 
@@ -65,8 +67,9 @@ let Ok(PhyPayload::Data(phy)) = parse(&data) else {
     panic!("failed to parse data payload");
 };
 let key = AppSKey::from([1; 16]);
-let decrypted = DecryptedDataPayload::decrypt_in_place(
-    &mut data, None, Some(&key), 1, &lorawan::default_crypto::DefaultFactory).unwrap();
+let crypto = DefaultCrypto::new(key.inner());
+let decrypted =
+    DecryptedDataPayload::decrypt_in_place(&mut data, None, Some(&crypto), 1).unwrap();
 if let FrmPayload::Data(data_payload) = decrypted.frm_payload() {
     println!("{}", String::from_utf8_lossy(data_payload));
 }

--- a/lorawan-encoding/benches/README.md
+++ b/lorawan-encoding/benches/README.md
@@ -1,9 +1,23 @@
 # Benchmarks
 
-The code is in `benches/lorawan.rs`; run with `cargo bench -p lorawan`. All
-three benchmarks work on the same 18-byte unconfirmed data uplink: parse it,
-read the header fields, validate the MIC, or decrypt the FRMPayload. A
-tracking allocator reports heap usage per iteration (zero for all three).
+The code is in `benches/lorawan.rs`; run with `cargo bench -p lorawan`. The
+benchmarks work on the same 18-byte unconfirmed data uplink: parse it, read
+the header fields, validate the MIC, decrypt the FRMPayload, or build the
+frame from scratch. A tracking allocator reports heap usage per iteration
+(zero for all of them).
+
+## Reference numbers
+
+Measured on an AMD EPYC 7302 (AES-NI) with `rustc 1.97.1`, crypto bound to
+the session keys outside the loop (`DefaultCrypto` caches the AES key
+schedule per key):
+
+| benchmark                    |     time |
+|------------------------------|---------:|
+| data_payload_headers_parsing |  6.46 ns |
+| data_payload_mic_validation  | 116.8 ns |
+| data_payload_decrypt         |  41.1 ns |
+| data_payload_creation        | 173.6 ns |
 
 ## Comparison against ChirpStack's lrwn crate
 

--- a/lorawan-encoding/benches/lorawan.rs
+++ b/lorawan-encoding/benches/lorawan.rs
@@ -6,10 +6,8 @@
 //
 // author: Ivaylo Petrov <ivajloip@gmail.com>
 
-use crate::CryptoFactory;
-use aes::cipher::KeyInit;
-use aes::Aes128;
 use criterion::{criterion_group, criterion_main, Criterion};
+use lorawan::default_crypto::DefaultCrypto;
 use lorawan::maccommands::parse_downlink_mac_commands;
 use lorawan::maccommands::DownlinkMacCommand;
 use std::alloc::System;
@@ -71,8 +69,7 @@ fn bench_complete_data_payload_fhdr(c: &mut Criterion) {
 }
 
 fn bench_complete_data_payload_mic_validation(c: &mut Criterion) {
-    let mic_key = AES128([2; 16]);
-    let factory = ConstFactory::new(&mic_key);
+    let crypto = DefaultCrypto::new(&AES128([2; 16]));
     let cnt = AtomicUsize::new(0);
     GLOBAL.usage();
     c.bench_function("data_payload_mic_validation", |b| {
@@ -82,7 +79,7 @@ fn bench_complete_data_payload_mic_validation(c: &mut Criterion) {
             let phy = parse(&data).unwrap();
 
             if let PhyPayload::Data(data_payload) = phy {
-                assert!(data_payload.validate_mic(&mic_key, 1, &factory));
+                assert!(data_payload.validate_mic(&crypto, 1));
             } else {
                 panic!("failed to parse DataPayload");
             }
@@ -95,8 +92,7 @@ fn bench_complete_data_payload_mic_validation(c: &mut Criterion) {
 fn bench_complete_data_payload_decrypt(c: &mut Criterion) {
     let mut payload = Vec::new();
     payload.extend_from_slice(&String::from("hello").into_bytes()[..]);
-    let key = AppSKey::from([1; 16]);
-    let factory = ConstFactory::new(key.inner());
+    let crypto = DefaultCrypto::new(AppSKey::from([1; 16]).inner());
     let cnt = AtomicUsize::new(0);
     GLOBAL.usage();
     c.bench_function("data_payload_decrypt", |b| {
@@ -104,8 +100,7 @@ fn bench_complete_data_payload_decrypt(c: &mut Criterion) {
             cnt.fetch_add(1usize, Ordering::SeqCst);
             let mut data = data_payload();
             let dec =
-                DecryptedDataPayload::decrypt_in_place(&mut data, None, Some(&key), 1, &factory)
-                    .unwrap();
+                DecryptedDataPayload::decrypt_in_place(&mut data, None, Some(&crypto), 1).unwrap();
             assert_eq!(dec.frm_payload(), FrmPayload::Data(&payload[..]));
         })
     });
@@ -113,49 +108,39 @@ fn bench_complete_data_payload_decrypt(c: &mut Criterion) {
     println!("Approximate memory usage per iteration: {} from {}", GLOBAL.usage() / n, n);
 }
 
-pub type Cmac = cmac::Cmac<Aes128>;
+fn bench_complete_data_payload_creation(c: &mut Criterion) {
+    use core::num::NonZeroU8;
+    use lorawan::creator::{DataFrame, Payload};
+    use lorawan::parser::{DataFrameType, DevAddr};
 
-#[derive(Debug, Clone)]
-pub struct ConstFactory(Aes128, Cmac);
-
-impl PartialEq for ConstFactory {
-    fn eq(&self, _: &Self) -> bool {
-        true
-    }
-}
-
-impl ConstFactory {
-    fn new(key: &AES128) -> Self {
-        ConstFactory(
-            Aes128::new_from_slice(&key.0[..]).unwrap(),
-            Cmac::new_from_slice(&key.0[..]).unwrap(),
-        )
-    }
-}
-
-impl CryptoFactory for ConstFactory {
-    type E = Aes128;
-    type D = Aes128;
-    type M = Cmac;
-
-    fn new_enc(&self, _: &AES128) -> Self::E {
-        self.0.clone()
-    }
-
-    fn new_dec(&self, _: &AES128) -> Self::D {
-        self.0.clone()
-    }
-
-    fn new_mac(&self, _: &AES128) -> Self::M {
-        self.1.clone()
-    }
+    let nwk_crypto = DefaultCrypto::new(&AES128([2; 16]));
+    let app_crypto = DefaultCrypto::new(&AES128([1; 16]));
+    let cnt = AtomicUsize::new(0);
+    GLOBAL.usage();
+    c.bench_function("data_payload_creation", |b| {
+        b.iter(|| {
+            cnt.fetch_add(1usize, Ordering::SeqCst);
+            let frame = DataFrame {
+                frame_type: DataFrameType::UnconfirmedUp,
+                dev_addr: DevAddr::from_value(0x01020304),
+                fcnt: 76543,
+                payload: Payload::Data { f_port: NonZeroU8::new(42).unwrap(), data: b"hello lora" },
+                ..Default::default()
+            };
+            let mut buf = [0u8; 64];
+            frame.build_into(&mut buf, &nwk_crypto, Some(&app_crypto)).unwrap();
+        })
+    });
+    let n = cnt.load(Ordering::SeqCst);
+    println!("Approximate memory usage per iteration: {} from {}", GLOBAL.usage() / n, n);
 }
 
 criterion_group!(
     benches,
     bench_complete_data_payload_fhdr,
     bench_complete_data_payload_mic_validation,
-    bench_complete_data_payload_decrypt
+    bench_complete_data_payload_decrypt,
+    bench_complete_data_payload_creation
 );
 criterion_main!(benches);
 

--- a/lorawan-encoding/size-compare/src/lib.rs
+++ b/lorawan-encoding/size-compare/src/lib.rs
@@ -16,7 +16,7 @@
 
 #![no_std]
 
-use lorawan::keys::{AppKey, CryptoFactory, Decrypter, Encrypter, Mac, AES128};
+use lorawan::keys::Crypto;
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
@@ -25,54 +25,21 @@ fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
 
 // --- Dummy crypto: tiny, so the measurement is parser code, not AES ---
 
-struct DumEnc;
-impl Encrypter for DumEnc {
+struct DumCrypto;
+impl Crypto for DumCrypto {
     fn encrypt_block(&self, block: &mut [u8]) {
         for b in block {
             *b = b.wrapping_add(0x5a);
         }
     }
-}
-impl Decrypter for DumEnc {
-    fn decrypt_block(&self, block: &mut [u8]) {
-        for b in block {
-            *b = b.wrapping_sub(0x5a);
+    fn calculate_mic(&self, b0: &[u8], data: &[u8]) -> [u8; 4] {
+        let mut acc = 0u8;
+        for b in b0.iter().chain(data) {
+            acc ^= *b;
         }
+        [acc; 4]
     }
 }
-
-struct DumMac(u8);
-impl Mac for DumMac {
-    fn input(&mut self, data: &[u8]) {
-        for b in data {
-            self.0 ^= *b;
-        }
-    }
-    fn reset(&mut self) {
-        self.0 = 0;
-    }
-    fn result(self) -> [u8; 16] {
-        [self.0; 16]
-    }
-}
-
-struct DumFactory;
-impl CryptoFactory for DumFactory {
-    type E = DumEnc;
-    type D = DumEnc;
-    type M = DumMac;
-    fn new_enc(&self, _: &AES128) -> DumEnc {
-        DumEnc
-    }
-    fn new_dec(&self, _: &AES128) -> DumEnc {
-        DumEnc
-    }
-    fn new_mac(&self, _: &AES128) -> DumMac {
-        DumMac(0)
-    }
-}
-
-const KEY: AES128 = AES128([2; 16]);
 
 #[cfg(any(feature = "new1", feature = "new3"))]
 mod new {
@@ -85,18 +52,12 @@ mod new {
                 let mut acc = u32::from(p.fhdr().fcnt());
                 acc = acc.wrapping_add(p.fhdr().dev_addr().value());
                 acc = acc.wrapping_add(u32::from(p.f_port().unwrap_or(0)));
-                if p.validate_mic(&KEY, 1, &DumFactory) {
+                if p.validate_mic(&DumCrypto, 1) {
                     acc = acc.wrapping_add(1);
                 }
-                let nwk = lorawan::keys::NwkSKey::from(KEY.0);
-                let app = lorawan::keys::AppSKey::from(KEY.0);
-                if let Ok(d) = DecryptedDataPayload::decrypt_in_place(
-                    buf,
-                    Some(&nwk),
-                    Some(&app),
-                    1,
-                    &DumFactory,
-                ) {
+                if let Ok(d) =
+                    DecryptedDataPayload::decrypt_in_place(buf, Some(&DumCrypto), Some(&DumCrypto), 1)
+                {
                     if let FrmPayload::Data(pl) = d.frm_payload() {
                         for b in pl {
                             acc = acc.wrapping_add(u32::from(*b));
@@ -107,14 +68,13 @@ mod new {
             }
             Ok(PhyPayload::JoinRequest(jr)) => {
                 let mut acc = jr.dev_eui().value() as u32;
-                if jr.validate_mic(&AppKey::from(KEY.0), &DumFactory) {
+                if jr.validate_mic(&DumCrypto) {
                     acc = acc.wrapping_add(1);
                 }
                 acc
             }
             Ok(PhyPayload::JoinAccept(_)) => {
-                let key = AppKey::from(KEY.0);
-                match DecryptedJoinAcceptPayload::decrypt_in_place(buf, &key, &DumFactory) {
+                match DecryptedJoinAcceptPayload::decrypt_in_place(buf, &DumCrypto) {
                     Ok(d) => d.dev_addr().value().wrapping_add(u32::from(d.mic().0[0])),
                     Err(_) => 0,
                 }

--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -17,7 +17,7 @@
 
 use core::num::NonZeroU8;
 
-use crate::keys::{AppKey, AppSKey, CryptoFactory, Decrypter, NwkSKey};
+use crate::keys::{Crypto, NetworkCrypto};
 use crate::packet_length::phy::join::{
     JOIN_ACCEPT_LEN, JOIN_ACCEPT_WITH_CFLIST_LEN, JOIN_REQUEST_LEN,
 };
@@ -29,9 +29,9 @@ use crate::parser::{
     CfList, DataFrameType, DevAddr, DevEui, DevNonce, Error, JoinEui, JoinNonce, NetId,
 };
 
-fn write_mic<C: CryptoFactory>(out: &mut [u8], key: &crate::keys::AES128, crypto: &C) {
+fn write_mic(out: &mut [u8], crypto: &dyn Crypto) {
     let mic_offset = out.len() - MIC_LEN;
-    let mic = securityhelpers::calculate_mic(&out[..mic_offset], crypto.new_mac(key));
+    let mic = securityhelpers::calculate_mic(&out[..mic_offset], crypto);
     out[mic_offset..].copy_from_slice(&mic.0);
 }
 
@@ -47,10 +47,11 @@ pub struct JoinRequest {
 impl JoinRequest {
     /// Writes the frame into the front of `buf` with the MIC set, returning
     /// the built bytes.
-    pub fn build_into<'a, C: CryptoFactory>(
+    ///
+    /// `crypto` must be bound to the AppKey.
+    pub fn build_into<'a, C: Crypto>(
         &self,
         buf: &'a mut [u8],
-        key: &AppKey,
         crypto: &C,
     ) -> Result<&'a [u8], Error> {
         let out = buf.get_mut(..JOIN_REQUEST_LEN).ok_or(Error::BufferTooShort)?;
@@ -58,7 +59,7 @@ impl JoinRequest {
         out[1..9].copy_from_slice(self.join_eui.as_wire_bytes());
         out[9..17].copy_from_slice(self.dev_eui.as_wire_bytes());
         out[17..19].copy_from_slice(self.dev_nonce.as_wire_bytes());
-        write_mic(out, key.inner(), crypto);
+        write_mic(out, crypto);
         Ok(out)
     }
 }
@@ -82,10 +83,14 @@ pub struct JoinAccept {
 impl JoinAccept {
     /// Writes the encrypted frame into the front of `buf` with the MIC set,
     /// returning the built bytes.
-    pub fn build_into<'a, C: CryptoFactory>(
+    ///
+    /// `crypto` must be bound to the AppKey. This is the one creation path
+    /// that needs [`NetworkCrypto`]: the server encrypts with the AES decrypt
+    /// primitive, which device-side (encrypt-only) implementations do not
+    /// provide.
+    pub fn build_into<'a, C: NetworkCrypto>(
         &self,
         buf: &'a mut [u8],
-        key: &AppKey,
         crypto: &C,
     ) -> Result<&'a [u8], Error> {
         let len = if self.c_f_list.is_some() {
@@ -114,13 +119,12 @@ impl JoinAccept {
                 out[28] = 1; // CFList type
             }
         }
-        write_mic(out, key.inner(), crypto);
+        write_mic(out, crypto);
         // The server encrypts by running AES in *decrypt* mode so that the
         // device can decrypt with the cheaper encrypt mode. MHDR stays clear;
         // the MIC is inside the encrypted region.
-        let aes = crypto.new_dec(key.inner());
         for block in out[MHDR_LEN..].chunks_exact_mut(16) {
-            aes.decrypt_block(block);
+            crypto.decrypt_block(block);
         }
         Ok(out)
     }
@@ -210,23 +214,23 @@ impl DataFrame<'_> {
     /// Writes the encrypted frame into the front of `buf` with the MIC set,
     /// returning the built bytes.
     ///
-    /// `nwk_skey` is always required (MIC, and FPort-0 encryption);
-    /// `app_skey` only when the payload is [`Payload::Data`].
-    pub fn build_into<'a, C: CryptoFactory>(
+    /// `nwk_crypto` must be bound to the NwkSKey and is always required (MIC,
+    /// and FPort-0 encryption); `app_crypto` must be bound to the AppSKey and
+    /// only when the payload is [`Payload::Data`].
+    pub fn build_into<'a, C: Crypto>(
         &self,
         buf: &'a mut [u8],
-        nwk_skey: &NwkSKey,
-        app_skey: Option<&AppSKey>,
-        crypto: &C,
+        nwk_crypto: &C,
+        app_crypto: Option<&C>,
     ) -> Result<&'a [u8], Error> {
         if self.f_opts.len() > 15 {
             return Err(Error::FOptsTooLong);
         }
-        let (f_port, frm, enc_key) = match self.payload {
-            Payload::None => (None, &[][..], nwk_skey.inner()),
+        let (f_port, frm, enc_crypto) = match self.payload {
+            Payload::None => (None, &[][..], nwk_crypto),
             Payload::Data { f_port, data } => {
-                let key = app_skey.ok_or(Error::MissingKey)?;
-                (Some(f_port.get()), data, key.inner())
+                let crypto = app_crypto.ok_or(Error::MissingKey)?;
+                (Some(f_port.get()), data, crypto)
             }
             Payload::MacCommands(cmds) => {
                 // The spec forbids FPort 0 when FOpts is non-empty: MAC
@@ -234,7 +238,7 @@ impl DataFrame<'_> {
                 if !self.f_opts.is_empty() {
                     return Err(Error::FOptsWithFPortZero);
                 }
-                (Some(0), cmds, nwk_skey.inner())
+                (Some(0), cmds, nwk_crypto)
             }
         };
 
@@ -259,15 +263,11 @@ impl DataFrame<'_> {
                 cursor,
                 cursor + frm.len(),
                 self.fcnt,
-                &crypto.new_enc(enc_key),
+                enc_crypto,
             );
         }
         let mic_offset = total - MIC_LEN;
-        let mic = securityhelpers::calculate_data_mic(
-            &out[..mic_offset],
-            crypto.new_mac(nwk_skey.inner()),
-            self.fcnt,
-        );
+        let mic = securityhelpers::calculate_data_mic(&out[..mic_offset], nwk_crypto, self.fcnt);
         out[mic_offset..].copy_from_slice(&mic.0);
         Ok(out)
     }

--- a/lorawan-encoding/src/default_crypto.rs
+++ b/lorawan-encoding/src/default_crypto.rs
@@ -7,8 +7,6 @@ use aes::{Aes128, Aes128Enc};
 use cmac::digest::InnerInit;
 use cmac::Cmac as RustCmac;
 
-pub type Cmac = RustCmac<Aes128>;
-
 /// Default software implementation of the device-side [`Crypto`] primitives.
 ///
 /// Holds the expanded AES key schedule for the key it was constructed with,
@@ -156,53 +154,5 @@ mod test {
                 [0x07, 0x0a, 0x16, 0xb4]
             );
         }
-    }
-}
-
-/// Provides a default implementation for build object for using the crypto functions.
-#[derive(Default, Debug, PartialEq, Eq)]
-pub struct DefaultFactory;
-
-impl CryptoFactory for DefaultFactory {
-    type E = Aes128;
-    type D = Aes128;
-    type M = Cmac;
-
-    fn new_enc(&self, key: &AES128) -> Self::E {
-        Self::E::new_from_slice(&key.0[..]).unwrap()
-    }
-
-    fn new_dec(&self, key: &AES128) -> Self::D {
-        Self::D::new_from_slice(&key.0[..]).unwrap()
-    }
-
-    fn new_mac(&self, key: &AES128) -> Self::M {
-        Self::M::new_from_slice(&key.0[..]).unwrap()
-    }
-}
-
-impl Encrypter for Aes128 {
-    fn encrypt_block(&self, block: &mut [u8]) {
-        BlockEncrypt::encrypt_block(self, block.try_into().unwrap());
-    }
-}
-
-impl Decrypter for Aes128 {
-    fn decrypt_block(&self, block: &mut [u8]) {
-        BlockDecrypt::decrypt_block(self, block.try_into().unwrap());
-    }
-}
-
-impl Mac for Cmac {
-    fn input(&mut self, data: &[u8]) {
-        cmac::Mac::update(self, data);
-    }
-
-    fn reset(&mut self) {
-        cmac::Mac::reset(self);
-    }
-
-    fn result(self) -> [u8; 16] {
-        cmac::Mac::finalize(self).into_bytes().into()
     }
 }

--- a/lorawan-encoding/src/default_crypto.rs
+++ b/lorawan-encoding/src/default_crypto.rs
@@ -3,10 +3,161 @@ use super::keys::*;
 use aes::cipher::{
     BlockCipherDecrypt as BlockDecrypt, BlockCipherEncrypt as BlockEncrypt, KeyInit,
 };
-use aes::Aes128;
+use aes::{Aes128, Aes128Enc};
+use cmac::digest::InnerInit;
 use cmac::Cmac as RustCmac;
 
 pub type Cmac = RustCmac<Aes128>;
+
+/// Default software implementation of the device-side [`Crypto`] primitives.
+///
+/// Holds the expanded AES key schedule for the key it was constructed with,
+/// so repeated operations under the same key (every frame of a session) skip
+/// the key expansion. Only the encrypt schedule is kept; a device never needs
+/// the decrypt primitive.
+#[derive(Clone)]
+pub struct DefaultCrypto {
+    cipher: Aes128Enc,
+}
+
+impl DefaultCrypto {
+    pub fn new(key: &AES128) -> Self {
+        Self { cipher: Aes128Enc::new_from_slice(&key.0[..]).unwrap() }
+    }
+}
+
+impl From<AES128> for DefaultCrypto {
+    fn from(key: AES128) -> Self {
+        Self::new(&key)
+    }
+}
+
+impl core::fmt::Debug for DefaultCrypto {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("DefaultCrypto { .. }")
+    }
+}
+
+impl Crypto for DefaultCrypto {
+    fn encrypt_block(&self, block: &mut [u8]) {
+        BlockEncrypt::encrypt_block(&self.cipher, block.try_into().unwrap());
+    }
+
+    fn calculate_mic(&self, b0: &[u8], data: &[u8]) -> [u8; 4] {
+        calculate_mic(self.cipher.clone(), b0, data)
+    }
+}
+
+/// Default software implementation of the network-side [`NetworkCrypto`]
+/// primitives, holding both the encrypt and decrypt AES key schedules.
+#[derive(Clone)]
+pub struct DefaultNetworkCrypto {
+    cipher: Aes128,
+}
+
+impl DefaultNetworkCrypto {
+    pub fn new(key: &AES128) -> Self {
+        Self { cipher: Aes128::new_from_slice(&key.0[..]).unwrap() }
+    }
+}
+
+impl From<AES128> for DefaultNetworkCrypto {
+    fn from(key: AES128) -> Self {
+        Self::new(&key)
+    }
+}
+
+impl core::fmt::Debug for DefaultNetworkCrypto {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("DefaultNetworkCrypto { .. }")
+    }
+}
+
+impl Crypto for DefaultNetworkCrypto {
+    fn encrypt_block(&self, block: &mut [u8]) {
+        BlockEncrypt::encrypt_block(&self.cipher, block.try_into().unwrap());
+    }
+
+    fn calculate_mic(&self, b0: &[u8], data: &[u8]) -> [u8; 4] {
+        calculate_mic(self.cipher.clone(), b0, data)
+    }
+}
+
+impl NetworkCrypto for DefaultNetworkCrypto {
+    fn decrypt_block(&self, block: &mut [u8]) {
+        BlockDecrypt::decrypt_block(&self.cipher, block.try_into().unwrap());
+    }
+}
+
+fn calculate_mic<C>(cipher: C, b0: &[u8], data: &[u8]) -> [u8; 4]
+where
+    C: cmac::block_api::CmacCipher,
+{
+    // CMAC subkeys are derived from the cipher at finalization, so
+    // initializing from the cached key schedule skips the key expansion.
+    let mut mac = RustCmac::inner_init(cipher);
+    cmac::Mac::update(&mut mac, b0);
+    cmac::Mac::update(&mut mac, data);
+    let result = cmac::Mac::finalize(mac).into_bytes();
+    result[0..4].try_into().unwrap()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // NIST SP 800-38B / RFC 4493 test key and vectors.
+    const KEY: AES128 = AES128([
+        0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f,
+        0x3c,
+    ]);
+    const PLAINTEXT: [u8; 16] = [
+        0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96, 0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17,
+        0x2a,
+    ];
+    const CIPHERTEXT: [u8; 16] = [
+        0x3a, 0xd7, 0x7b, 0xb4, 0x0d, 0x7a, 0x36, 0x60, 0xa8, 0x9e, 0xca, 0xf3, 0x24, 0x66, 0xef,
+        0x97,
+    ];
+
+    #[test]
+    fn encrypt_block_known_answer() {
+        for crypto in [
+            &DefaultCrypto::new(&KEY) as &dyn Crypto,
+            &DefaultNetworkCrypto::new(&KEY) as &dyn Crypto,
+        ] {
+            let mut block = PLAINTEXT;
+            crypto.encrypt_block(&mut block);
+            assert_eq!(block, CIPHERTEXT);
+        }
+    }
+
+    #[test]
+    fn decrypt_block_inverts_encrypt() {
+        let crypto = DefaultNetworkCrypto::new(&KEY);
+        let mut block = CIPHERTEXT;
+        crypto.decrypt_block(&mut block);
+        assert_eq!(block, PLAINTEXT);
+    }
+
+    #[test]
+    fn calculate_mic_known_answer() {
+        // RFC 4493 example 2: 16-byte message, full tag starts with
+        // 070a16b4 6b4d4144.
+        for crypto in [
+            &DefaultCrypto::new(&KEY) as &dyn Crypto,
+            &DefaultNetworkCrypto::new(&KEY) as &dyn Crypto,
+        ] {
+            assert_eq!(crypto.calculate_mic(&[], &PLAINTEXT), [0x07, 0x0a, 0x16, 0xb4]);
+            // The MIC over split input must equal the MIC over the
+            // concatenation.
+            assert_eq!(
+                crypto.calculate_mic(&PLAINTEXT[..7], &PLAINTEXT[7..]),
+                [0x07, 0x0a, 0x16, 0xb4]
+            );
+        }
+    }
+}
 
 /// Provides a default implementation for build object for using the crypto functions.
 #[derive(Default, Debug, PartialEq, Eq)]

--- a/lorawan-encoding/src/keys.rs
+++ b/lorawan-encoding/src/keys.rs
@@ -91,22 +91,24 @@ lorawan_key!(
 /// It is NOT REQUIRED for ABP-only end-devices.
 impl McKey {
     /// McAppSKey = aes128_encrypt(McKey, 0x01 | McAddr | pad16)
-    pub fn derive_mc_app_s_key<F: CryptoFactory>(&self, crypto: &F, mc_addr: &McAddr) -> McAppSKey {
-        let aes_enc = crypto.new_enc(&self.0);
+    ///
+    /// `crypto` must be bound to the McKey.
+    pub fn derive_mc_app_s_key<C: Crypto>(crypto: &C, mc_addr: &McAddr) -> McAppSKey {
         let mut bytes: [u8; 16] = [0; 16];
         bytes[0] = 0x01;
         bytes[1..5].copy_from_slice(mc_addr.as_wire_bytes());
-        aes_enc.encrypt_block(&mut bytes);
+        crypto.encrypt_block(&mut bytes);
         McAppSKey::from(bytes)
     }
 
     /// McNetSKey = aes128_encrypt(McKey, 0x02 | McAddr | pad16)
-    pub fn derive_mc_net_s_key<F: CryptoFactory>(&self, crypto: &F, mc_addr: &McAddr) -> McNetSKey {
-        let aes_enc = crypto.new_enc(&self.0);
+    ///
+    /// `crypto` must be bound to the McKey.
+    pub fn derive_mc_net_s_key<C: Crypto>(crypto: &C, mc_addr: &McAddr) -> McNetSKey {
         let mut bytes: [u8; 16] = [0; 16];
         bytes[0] = 0x02;
         bytes[1..5].copy_from_slice(mc_addr.as_wire_bytes());
-        aes_enc.encrypt_block(&mut bytes);
+        crypto.encrypt_block(&mut bytes);
         McNetSKey::from(bytes)
     }
 }
@@ -157,29 +159,32 @@ lorawan_key!(
 
 impl McKEKey {
     /// McKEKey = aes128_encrypt(McRootKey, 0x00 | pad16)
-    pub fn derive_from<F: CryptoFactory>(crypto: &F, root_key: &McRootKey) -> Self {
-        let aes_enc = crypto.new_enc(&root_key.0);
+    ///
+    /// `crypto` must be bound to the McRootKey.
+    pub fn derive_from<C: Crypto>(crypto: &C) -> Self {
         let mut bytes: [u8; 16] = [0; 16];
-        aes_enc.encrypt_block(&mut bytes);
+        crypto.encrypt_block(&mut bytes);
         McKEKey::from(bytes)
     }
 }
 
 impl McRootKey {
     /// LoRaWAN 1.1.x: McRootKey = aes128_encrypt(AppKey, 0x20 | pad16)
-    pub fn derive_from_app_key<F: CryptoFactory>(crypto: &F, app_key: &AppKey) -> Self {
-        let aes_enc = crypto.new_enc(&app_key.0);
+    ///
+    /// `crypto` must be bound to the AppKey.
+    pub fn derive_from_app_key<C: Crypto>(crypto: &C) -> Self {
         let mut bytes: [u8; 16] = [0; 16];
         bytes[0] = 0x20;
-        aes_enc.encrypt_block(&mut bytes);
+        crypto.encrypt_block(&mut bytes);
         McRootKey::from(bytes)
     }
 
     /// LoRaWAN 1.0.x: McRootKey = aes128_encrypt(GenAppKey, 0x00 | pad16)
-    pub fn derive_from_gen_app_key<F: CryptoFactory>(crypto: &F, app_key: &GenAppKey) -> Self {
-        let aes_enc = crypto.new_enc(&app_key.0);
+    ///
+    /// `crypto` must be bound to the GenAppKey.
+    pub fn derive_from_gen_app_key<C: Crypto>(crypto: &C) -> Self {
         let mut bytes: [u8; 16] = [0; 16];
-        aes_enc.encrypt_block(&mut bytes);
+        crypto.encrypt_block(&mut bytes);
         McRootKey::from(bytes)
     }
 }
@@ -326,45 +331,10 @@ pub trait NetworkCrypto: Crypto {
     fn decrypt_block(&self, block: &mut [u8]);
 }
 
-/// Trait for implementations of AES128 encryption.
-pub trait Encrypter {
-    fn encrypt_block(&self, block: &mut [u8]);
-}
-
-/// Trait for implementations of AES128 decryption.
-pub trait Decrypter {
-    fn decrypt_block(&self, block: &mut [u8]);
-}
-
-/// Trait for implementations of CMAC (RFC4493).
-pub trait Mac {
-    fn input(&mut self, data: &[u8]);
-    fn reset(&mut self);
-    fn result(self) -> [u8; 16];
-}
-
-/// Represents an abstraction over the crypto functions.
-///
-/// This trait provides a way to pick a different implementation of the crypto primitives.
-pub trait CryptoFactory {
-    type E: Encrypter;
-    type D: Decrypter;
-    type M: Mac;
-
-    /// Method that creates an Encrypter.
-    fn new_enc(&self, key: &AES128) -> Self::E;
-
-    /// Method that creates a Decrypter.
-    fn new_dec(&self, key: &AES128) -> Self::D;
-
-    /// Method that creates a MAC calculator.
-    fn new_mac(&self, key: &AES128) -> Self::M;
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::default_crypto::DefaultFactory;
+    use crate::default_crypto::DefaultCrypto;
 
     const TEST_KEY: [u8; 16] = [4, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
@@ -372,7 +342,7 @@ mod test {
     #[test]
     fn mc_root_key_to_mc_ke_key() {
         let mc_root_key = McRootKey::from(TEST_KEY);
-        let mc_ke_key = McKEKey::derive_from(&DefaultFactory, &mc_root_key);
+        let mc_ke_key = McKEKey::derive_from(&DefaultCrypto::new(mc_root_key.inner()));
         assert_eq!(
             McKEKey(AES128([
                 0x90, 0x83, 0xbe, 0xbf, 0x70, 0x42, 0x57, 0x88, 0x31, 0x60, 0xdb, 0xfc, 0xde, 0x33,
@@ -385,8 +355,10 @@ mod test {
     #[test]
     fn mc_key_to_mc_app_s_key() {
         let mc_key = McKey::from(TEST_KEY);
-        let mc_app_s_key =
-            mc_key.derive_mc_app_s_key(&DefaultFactory, &McAddr::from_wire_bytes(ADDR));
+        let mc_app_s_key = McKey::derive_mc_app_s_key(
+            &DefaultCrypto::new(mc_key.inner()),
+            &McAddr::from_wire_bytes(ADDR),
+        );
         assert_eq!(
             McAppSKey(AES128([
                 0x50, 0xDF, 0x70, 0x27, 0xEF, 0xC6, 0xB4, 0x7D, 0xA8, 0x10, 0xEE, 0x3C, 0xCA, 0x0D,
@@ -399,8 +371,10 @@ mod test {
     #[test]
     fn mc_key_to_mc_net_s_key() {
         let mc_key = McKey::from(TEST_KEY);
-        let mc_net_s_key =
-            mc_key.derive_mc_net_s_key(&DefaultFactory, &McAddr::from_wire_bytes(ADDR));
+        let mc_net_s_key = McKey::derive_mc_net_s_key(
+            &DefaultCrypto::new(mc_key.inner()),
+            &McAddr::from_wire_bytes(ADDR),
+        );
         assert_eq!(
             McNetSKey(AES128([
                 0x8D, 0xF7, 0x07, 0x27, 0x36, 0x47, 0xE2, 0x2E, 0x4E, 0x27, 0xFE, 0x00, 0x4B, 0x99,

--- a/lorawan-encoding/src/keys.rs
+++ b/lorawan-encoding/src/keys.rs
@@ -286,6 +286,46 @@ impl From<[u8; 4]> for MIC {
     }
 }
 
+/// AES-128 crypto primitives bound to a single key.
+///
+/// The key is provided when the implementation is constructed. Whether the
+/// implementation caches the expanded AES key schedule (trading RAM for less
+/// work per operation) or recomputes it per call is the implementation's
+/// choice; [`crate::default_crypto::DefaultCrypto`] caches it.
+///
+/// A LoRaWAN device only ever needs the AES encrypt primitive: FRMPayload
+/// "decryption" is AES-CTR keystream generation using encrypt, and JoinAccept
+/// decryption is specified as an encrypt operation on the device side.
+/// Implementations backed by encrypt-only hardware can therefore implement
+/// this trait fully. The AES decrypt primitive is only needed by network-side
+/// payload creation; see [`NetworkCrypto`].
+pub trait Crypto {
+    /// Encrypts a single 16-byte block in place (AES-128 ECB).
+    ///
+    /// `block` must be exactly 16 bytes.
+    fn encrypt_block(&self, block: &mut [u8]);
+
+    /// Computes the AES-CMAC (RFC 4493) over `b0` followed by `data` and
+    /// returns the first four bytes, which form the LoRaWAN MIC.
+    ///
+    /// `b0` is the block B0 prepended for data payloads; it is empty for join
+    /// messages.
+    fn calculate_mic(&self, b0: &[u8], data: &[u8]) -> [u8; 4];
+}
+
+/// Network-side AES-128 crypto: everything a device needs plus the AES
+/// decrypt primitive.
+///
+/// Only payload creation performed by a network needs decrypt: JoinAccept
+/// creation and multicast McGroupSetupReq creation. Device-side code never
+/// requires this trait.
+pub trait NetworkCrypto: Crypto {
+    /// Decrypts a single 16-byte block in place (AES-128 ECB).
+    ///
+    /// `block` must be exactly 16 bytes.
+    fn decrypt_block(&self, block: &mut [u8]);
+}
+
 /// Trait for implementations of AES128 encryption.
 pub trait Encrypter {
     fn encrypt_block(&self, block: &mut [u8]);

--- a/lorawan-encoding/src/multicast/group_setup.rs
+++ b/lorawan-encoding/src/multicast/group_setup.rs
@@ -1,7 +1,6 @@
-use crate::keys::{CryptoFactory, McAppSKey, McKEKey, McKey, McNetSKey};
+use crate::keys::{Crypto, McAppSKey, McKey, McNetSKey, NetworkCrypto, AES128};
 use crate::multicast::McGroupSetupReqCreator;
 use crate::{
-    keys::{Decrypter, Encrypter},
     multicast::{McGroupSetupAnsCreator, McGroupSetupAnsPayload, McGroupSetupReqPayload},
     parser::McAddr,
 };
@@ -61,26 +60,39 @@ impl McGroupSetupReqPayload<'_> {
         &self.0[OFFSET..END]
     }
 
-    fn mc_key_decrypted<F: CryptoFactory>(&self, crypto: &F, key: &McKEKey) -> McKey {
-        let aes_enc = crypto.new_enc(&key.0);
+    /// Decrypts the McKey carried in the request.
+    ///
+    /// `crypto` must be bound to the McKEKey.
+    pub fn mc_key_decrypted<C: Crypto>(&self, crypto: &C) -> McKey {
         let mut bytes: [u8; 16] = self.mc_key_encrypted().try_into().unwrap();
-        aes_enc.encrypt_block(&mut bytes);
+        crypto.encrypt_block(&mut bytes);
         McKey::from(bytes)
     }
 
-    pub fn derive_session_keys<F: CryptoFactory>(
+    /// Derives the multicast session keys.
+    ///
+    /// `crypto` must be bound to the McKEKey. The `From<AES128>` bound is used to construct
+    /// the crypto for the McKey decrypted from the request; implementations that cannot be
+    /// built from a bare key can use [`Self::mc_key_decrypted`] and derive the session keys
+    /// through [`McKey::derive_mc_app_s_key`] and [`McKey::derive_mc_net_s_key`] directly.
+    pub fn derive_session_keys<C: Crypto + From<AES128>>(
         &self,
-        crypto: &F,
-        key: &McKEKey,
+        crypto: &C,
     ) -> (McAppSKey, McNetSKey) {
-        let mc_key = self.mc_key_decrypted(crypto, key);
+        let mc_key = self.mc_key_decrypted(crypto);
+        let mc_key_crypto = C::from(*mc_key.inner());
         let mc_addr = self.mc_addr();
-        (mc_key.derive_mc_app_s_key(crypto, &mc_addr), mc_key.derive_mc_net_s_key(crypto, &mc_addr))
+        (
+            McKey::derive_mc_app_s_key(&mc_key_crypto, &mc_addr),
+            McKey::derive_mc_net_s_key(&mc_key_crypto, &mc_addr),
+        )
     }
 
     /// Derives the multicast session and returns the assigned group ID.
-    pub fn derive_session<F: CryptoFactory>(&self, crypto: &F, key: &McKEKey) -> (u8, Session) {
-        let (mc_app_s_key, mc_net_s_key) = self.derive_session_keys(crypto, key);
+    ///
+    /// `crypto` must be bound to the McKEKey.
+    pub fn derive_session<C: Crypto + From<AES128>>(&self, crypto: &C) -> (u8, Session) {
+        let (mc_app_s_key, mc_net_s_key) = self.derive_session_keys(crypto);
         (
             self.mc_group_id_header(),
             Session {
@@ -145,19 +157,15 @@ impl McGroupSetupReqCreator {
         self
     }
 
-    pub fn mc_key<F: CryptoFactory>(
-        &mut self,
-        crypto: &F,
-        mc_key: &McKey,
-        mcke_key: &McKEKey,
-    ) -> &mut Self {
+    /// Encrypts the McKey into the request.
+    ///
+    /// `crypto` must be bound to the McKEKey.
+    pub fn mc_key<C: NetworkCrypto>(&mut self, crypto: &C, mc_key: &McKey) -> &mut Self {
         const OFFSET: usize = 2 + McAddr::BYTE_LEN;
         const END: usize = OFFSET + McKey::byte_len();
-        let aes_enc = crypto.new_dec(&mcke_key.0);
         let block = &mut self.data[OFFSET..END];
         block.copy_from_slice(mc_key.as_ref());
-        //println!("block: {block:?}");
-        aes_enc.decrypt_block(block);
+        crypto.decrypt_block(block);
         self
     }
 
@@ -179,7 +187,8 @@ impl McGroupSetupReqCreator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::default_crypto::DefaultFactory;
+    use crate::default_crypto::{DefaultCrypto, DefaultNetworkCrypto};
+    use crate::keys::McKEKey;
     use crate::multicast::parse_downlink_multicast_commands;
     use crate::multicast::DownlinkRemoteSetup;
 
@@ -193,7 +202,7 @@ mod tests {
 
         req.mc_group_id_header(0x01);
         req.mc_addr(&mc_addr);
-        req.mc_key(&DefaultFactory, &mc_key, &mcke_key);
+        req.mc_key(&DefaultNetworkCrypto::new(mcke_key.inner()), &mc_key);
         req.min_mc_fcount(0x12345678);
         req.max_mc_fcount(0x87654321);
         let messages = req.build();
@@ -205,7 +214,8 @@ mod tests {
         };
         assert_eq!(mc_group_setup_req.mc_group_id_header(), 1);
         assert_eq!(mc_group_setup_req.mc_addr(), mc_addr);
-        let decrypt_key = mc_group_setup_req.mc_key_decrypted(&DefaultFactory, &mcke_key);
+        let decrypt_key =
+            mc_group_setup_req.mc_key_decrypted(&DefaultCrypto::new(mcke_key.inner()));
         assert_eq!(decrypt_key.as_ref(), mc_key.as_ref());
         assert_eq!(mc_group_setup_req.min_mc_fcount(), 0x12345678);
         assert_eq!(mc_group_setup_req.max_mc_fcount(), 0x87654321);

--- a/lorawan-encoding/src/parser.rs
+++ b/lorawan-encoding/src/parser.rs
@@ -44,7 +44,7 @@
 //! by [`DevAddr`], verify the MIC, then decrypt in place.
 //!
 //! ```
-//! use lorawan::default_crypto::DefaultFactory;
+//! use lorawan::default_crypto::DefaultCrypto;
 //! use lorawan::keys::{AppSKey, NwkSKey};
 //! use lorawan::parser::{DecryptedDataPayload, DevAddr, EncryptedDataPayload, FrmPayload};
 //!
@@ -52,21 +52,16 @@
 //!     0x40, 0x04, 0x03, 0x02, 0x01, 0x80, 0x01, 0x00, 0x01, 0xa6, 0x94, 0x64, 0x26, 0x15,
 //!     0xd6, 0xc3, 0xb5, 0x82,
 //! ];
-//! let nwk_skey = NwkSKey::from([2; 16]);
-//! let app_skey = AppSKey::from([1; 16]);
+//! let nwk_crypto = DefaultCrypto::new(NwkSKey::from([2; 16]).inner());
+//! let app_crypto = DefaultCrypto::new(AppSKey::from([1; 16]).inner());
 //!
 //! let phy = EncryptedDataPayload::parse(&buf).unwrap();
 //! assert_eq!(phy.fhdr().dev_addr(), DevAddr::from_value(0x01020304));
-//! assert!(phy.validate_mic(nwk_skey.inner(), 1, &DefaultFactory));
+//! assert!(phy.validate_mic(&nwk_crypto, 1));
 //!
-//! let decrypted = DecryptedDataPayload::decrypt_in_place(
-//!     &mut buf,
-//!     Some(&nwk_skey),
-//!     Some(&app_skey),
-//!     1,
-//!     &DefaultFactory,
-//! )
-//! .unwrap();
+//! let decrypted =
+//!     DecryptedDataPayload::decrypt_in_place(&mut buf, Some(&nwk_crypto), Some(&app_crypto), 1)
+//!         .unwrap();
 //! assert_eq!(decrypted.frm_payload(), FrmPayload::Data(b"hello"));
 //! ```
 //!
@@ -75,7 +70,7 @@
 //!
 //! ```
 //! use core::num::NonZeroU8;
-//! use lorawan::default_crypto::DefaultFactory;
+//! use lorawan::default_crypto::DefaultCrypto;
 //! use lorawan::keys::{AppSKey, NwkSKey};
 //! use lorawan::creator::{DataFrame, Payload};
 //! use lorawan::parser::{DataFrameType, DevAddr};
@@ -89,13 +84,13 @@
 //!     ..Default::default()
 //! };
 //! let mut buf = [0u8; 64];
-//! let bytes = frame
-//!     .build_into(&mut buf, &NwkSKey::from([2; 16]), Some(&AppSKey::from([1; 16])), &DefaultFactory)
-//!     .unwrap();
+//! let nwk_crypto = DefaultCrypto::new(NwkSKey::from([2; 16]).inner());
+//! let app_crypto = DefaultCrypto::new(AppSKey::from([1; 16]).inner());
+//! let bytes = frame.build_into(&mut buf, &nwk_crypto, Some(&app_crypto)).unwrap();
 //! assert_eq!(bytes.len(), 18);
 //! ```
 
-use crate::keys::{AppKey, AppSKey, CryptoFactory, Encrypter, NwkSKey, AES128, MIC};
+use crate::keys::{AppSKey, Crypto, NwkSKey, AES128, MIC};
 use crate::packet_length::phy::join::{
     JOIN_ACCEPT_LEN, JOIN_ACCEPT_WITH_CFLIST_LEN, JOIN_REQUEST_LEN,
 };
@@ -372,11 +367,13 @@ impl<'a> EncryptedDataPayload<'a> {
 
     data_view_accessors!();
 
-    /// Whether the MIC matches under `key` and the given 32-bit frame counter.
+    /// Whether the MIC matches under the given 32-bit frame counter.
+    ///
+    /// `crypto` must be bound to the NwkSKey (or McNetSKey for multicast).
     #[inline]
-    pub fn validate_mic<C: CryptoFactory>(&self, key: &AES128, fcnt: u32, crypto: &C) -> bool {
+    pub fn validate_mic<C: Crypto>(&self, crypto: &C, fcnt: u32) -> bool {
         let without_mic = &self.bytes[..self.bytes.len() - MIC_LEN];
-        self.mic() == securityhelpers::calculate_data_mic(without_mic, crypto.new_mac(key), fcnt)
+        self.mic() == securityhelpers::calculate_data_mic(without_mic, crypto, fcnt)
     }
 }
 
@@ -409,47 +406,27 @@ impl<'a> DecryptedDataPayload<'a> {
     /// unless the MIC was already checked via
     /// [`EncryptedDataPayload::validate_mic`].
     ///
-    /// Key selection follows the spec: `app_skey` decrypts FPort > 0,
-    /// `nwk_skey` decrypts FPort 0 (MAC commands). Only the key the frame
-    /// actually needs must be present. `fcnt` supplies the upper 16 bits of
-    /// the frame counter; the lower 16 come from the wire.
+    /// Key selection follows the spec: `app_crypto` (bound to the AppSKey, or
+    /// McAppSKey for multicast) decrypts FPort > 0, `nwk_crypto` (bound to
+    /// the NwkSKey or McNetSKey) decrypts FPort 0 (MAC commands). Only the
+    /// crypto the frame actually needs must be present. `fcnt` supplies the
+    /// upper 16 bits of the frame counter; the lower 16 come from the wire.
     #[inline]
-    pub fn decrypt_in_place<C: CryptoFactory>(
+    pub fn decrypt_in_place<C: Crypto>(
         buf: &'a mut [u8],
-        nwk_skey: Option<&NwkSKey>,
-        app_skey: Option<&AppSKey>,
+        nwk_crypto: Option<&C>,
+        app_crypto: Option<&C>,
         fcnt: u32,
-        crypto: &C,
-    ) -> Result<Self, Error> {
-        Self::decrypt_in_place_with(
-            buf,
-            nwk_skey.map(|k| k.inner()),
-            app_skey.map(|k| k.inner()),
-            fcnt,
-            crypto,
-        )
-    }
-
-    /// Like [`Self::decrypt_in_place`], but takes raw AES keys. For sessions
-    /// whose keys are not the unicast [`NwkSKey`]/[`AppSKey`] pair, such as
-    /// multicast sessions (`McNetSKey`/`McAppSKey`).
-    #[inline]
-    pub fn decrypt_in_place_with<C: CryptoFactory>(
-        buf: &'a mut [u8],
-        nwk_key: Option<&AES128>,
-        app_key: Option<&AES128>,
-        fcnt: u32,
-        crypto: &C,
     ) -> Result<Self, Error> {
         let layout = Layout::validate(buf)?;
         if layout.frm_start < layout.frm_end {
             let uses_app_key = matches!(layout.f_port_offset, Some(off) if buf[off] != 0);
-            let key = if uses_app_key {
-                app_key
+            let crypto = if uses_app_key {
+                app_crypto
             } else {
-                nwk_key
+                nwk_crypto
             };
-            let key = key.ok_or(Error::MissingKey)?;
+            let crypto = crypto.ok_or(Error::MissingKey)?;
             let wire_fcnt = u16::from_le_bytes([buf[6], buf[7]]);
             let full_fcnt = ((fcnt >> 16) << 16) | u32::from(wire_fcnt);
             securityhelpers::encrypt_frm_data_payload(
@@ -457,7 +434,7 @@ impl<'a> DecryptedDataPayload<'a> {
                 layout.frm_start,
                 layout.frm_end,
                 full_fcnt,
-                &crypto.new_enc(key),
+                crypto,
             );
         }
         Ok(Self { bytes: buf, layout })
@@ -468,17 +445,16 @@ impl<'a> DecryptedDataPayload<'a> {
     /// The MIC is checked before anything is written, so on `InvalidMic` the
     /// buffer still holds the received bytes unchanged.
     #[inline]
-    pub fn check_mic_and_decrypt_in_place<C: CryptoFactory>(
+    pub fn check_mic_and_decrypt_in_place<C: Crypto>(
         buf: &'a mut [u8],
-        nwk_skey: &NwkSKey,
-        app_skey: Option<&AppSKey>,
+        nwk_crypto: &C,
+        app_crypto: Option<&C>,
         fcnt: u32,
-        crypto: &C,
     ) -> Result<Self, Error> {
-        if !EncryptedDataPayload::parse(buf)?.validate_mic(nwk_skey.inner(), fcnt, crypto) {
+        if !EncryptedDataPayload::parse(buf)?.validate_mic(nwk_crypto, fcnt) {
             return Err(Error::InvalidMic);
         }
-        Self::decrypt_in_place(buf, Some(nwk_skey), app_skey, fcnt, crypto)
+        Self::decrypt_in_place(buf, Some(nwk_crypto), app_crypto, fcnt)
     }
 
     data_view_accessors!();
@@ -556,10 +532,12 @@ impl<'a> JoinRequestPayload<'a> {
     }
 
     /// Whether the MIC matches under the device's root key.
+    ///
+    /// `crypto` must be bound to the AppKey.
     #[inline]
-    pub fn validate_mic<C: CryptoFactory>(&self, key: &AppKey, crypto: &C) -> bool {
+    pub fn validate_mic<C: Crypto>(&self, crypto: &C) -> bool {
         let without_mic = &self.bytes[..JOIN_REQUEST_LEN - MIC_LEN];
-        self.mic() == securityhelpers::calculate_mic(without_mic, crypto.new_mac(key.inner()))
+        self.mic() == securityhelpers::calculate_mic(without_mic, crypto)
     }
 
     /// The raw frame bytes.
@@ -624,17 +602,12 @@ impl<'a> DecryptedJoinAcceptPayload<'a> {
     /// Does NOT verify the MIC (it only becomes readable after decryption);
     /// prefer [`Self::check_mic_and_decrypt_in_place`].
     #[inline]
-    pub fn decrypt_in_place<C: CryptoFactory>(
-        buf: &'a mut [u8],
-        key: &AppKey,
-        crypto: &C,
-    ) -> Result<Self, Error> {
+    pub fn decrypt_in_place<C: Crypto>(buf: &'a mut [u8], crypto: &C) -> Result<Self, Error> {
         validate_join_accept_structure(buf)?;
         // The device side runs AES *encryption* to invert the server's
         // decrypt-mode transformation, per the spec.
-        let aes = crypto.new_enc(key.inner());
         for block in buf[1..].chunks_exact_mut(16) {
-            aes.encrypt_block(block);
+            crypto.encrypt_block(block);
         }
         Ok(Self { bytes: buf })
     }
@@ -648,23 +621,24 @@ impl<'a> DecryptedJoinAcceptPayload<'a> {
     /// untouched. Callers that want to retry with another key or log the
     /// original frame must keep a copy.
     #[inline]
-    pub fn check_mic_and_decrypt_in_place<C: CryptoFactory>(
+    pub fn check_mic_and_decrypt_in_place<C: Crypto>(
         buf: &'a mut [u8],
-        key: &AppKey,
         crypto: &C,
     ) -> Result<Self, Error> {
-        let decrypted = Self::decrypt_in_place(buf, key, crypto)?;
-        if !decrypted.validate_mic(key, crypto) {
+        let decrypted = Self::decrypt_in_place(buf, crypto)?;
+        if !decrypted.validate_mic(crypto) {
             return Err(Error::InvalidMic);
         }
         Ok(decrypted)
     }
 
     /// Whether the MIC matches under the device's root key.
+    ///
+    /// `crypto` must be bound to the AppKey.
     #[inline]
-    pub fn validate_mic<C: CryptoFactory>(&self, key: &AppKey, crypto: &C) -> bool {
+    pub fn validate_mic<C: Crypto>(&self, crypto: &C) -> bool {
         let without_mic = &self.bytes[..self.bytes.len() - MIC_LEN];
-        self.mic() == securityhelpers::calculate_mic(without_mic, crypto.new_mac(key.inner()))
+        self.mic() == securityhelpers::calculate_mic(without_mic, crypto)
     }
 
     /// The server nonce (called AppNonce before LoRaWAN 1.0.4).
@@ -729,41 +703,33 @@ impl<'a> DecryptedJoinAcceptPayload<'a> {
     }
 
     /// Derives the network session key for this join.
+    ///
+    /// `crypto` must be bound to the AppKey.
     #[inline]
-    pub fn derive_nwkskey<C: CryptoFactory>(
-        &self,
-        dev_nonce: DevNonce,
-        key: &AppKey,
-        crypto: &C,
-    ) -> NwkSKey {
-        NwkSKey(self.derive_session_key(0x01, dev_nonce, key, crypto))
+    pub fn derive_nwkskey<C: Crypto>(&self, dev_nonce: DevNonce, crypto: &C) -> NwkSKey {
+        NwkSKey(self.derive_session_key(0x01, dev_nonce, crypto))
     }
 
     /// Derives the application session key for this join.
+    ///
+    /// `crypto` must be bound to the AppKey.
     #[inline]
-    pub fn derive_appskey<C: CryptoFactory>(
-        &self,
-        dev_nonce: DevNonce,
-        key: &AppKey,
-        crypto: &C,
-    ) -> AppSKey {
-        AppSKey(self.derive_session_key(0x02, dev_nonce, key, crypto))
+    pub fn derive_appskey<C: Crypto>(&self, dev_nonce: DevNonce, crypto: &C) -> AppSKey {
+        AppSKey(self.derive_session_key(0x02, dev_nonce, crypto))
     }
 
-    fn derive_session_key<C: CryptoFactory>(
+    fn derive_session_key<C: Crypto>(
         &self,
         first_byte: u8,
         dev_nonce: DevNonce,
-        key: &AppKey,
         crypto: &C,
     ) -> AES128 {
-        let cipher = crypto.new_enc(key.inner());
         let mut block = [0u8; 16];
         block[0] = first_byte;
         block[1..4].copy_from_slice(self.join_nonce().as_wire_bytes());
         block[4..7].copy_from_slice(self.net_id().as_wire_bytes());
         block[7..9].copy_from_slice(dev_nonce.as_wire_bytes());
-        cipher.encrypt_block(&mut block);
+        crypto.encrypt_block(&mut block);
         AES128(block)
     }
 }

--- a/lorawan-encoding/src/securityhelpers.rs
+++ b/lorawan-encoding/src/securityhelpers.rs
@@ -1,14 +1,14 @@
-use super::keys;
+use super::keys::{Crypto, MIC};
 
 /// calculate_data_mic computes the MIC of a correct data packet.
-pub fn calculate_data_mic<M: keys::Mac>(data: &[u8], key: M, fcnt: u32) -> keys::MIC {
-    let mut header = [0; 16];
+pub fn calculate_data_mic(data: &[u8], crypto: &dyn Crypto, fcnt: u32) -> MIC {
+    let mut b0 = [0; 16];
 
     // compute b0 from the spec
-    generate_helper_block(data, 0x49, fcnt, &mut header[..16]);
-    header[15] = data.len() as u8;
+    generate_helper_block(data, 0x49, fcnt, &mut b0[..16]);
+    b0[15] = data.len() as u8;
 
-    calculate_mic_with_header(&header[..], data, key)
+    MIC(crypto.calculate_mic(&b0[..], data))
 }
 
 fn generate_helper_block(data: &[u8], first: u8, fcnt: u32, res: &mut [u8]) {
@@ -25,21 +25,9 @@ fn generate_helper_block(data: &[u8], first: u8, fcnt: u32, res: &mut [u8]) {
     // res[15] is to be set later
 }
 
-fn calculate_mic_with_header<M: keys::Mac>(header: &[u8], data: &[u8], mic: M) -> keys::MIC {
-    let mut cipher = mic;
-    cipher.input(header);
-    cipher.input(data);
-    let result = cipher.result();
-
-    let mut mic = [0u8; 4];
-    mic.copy_from_slice(&result[0..4]);
-
-    keys::MIC(mic)
-}
-
 /// calculate_mic computes the MIC of a correct data packet.
-pub fn calculate_mic<M: keys::Mac>(data: &[u8], key: M) -> keys::MIC {
-    calculate_mic_with_header(&[], data, key)
+pub fn calculate_mic(data: &[u8], crypto: &dyn Crypto) -> MIC {
+    MIC(crypto.calculate_mic(&[], data))
 }
 
 /// encrypt_frm_data_payload encrypts bytes
@@ -48,7 +36,7 @@ pub fn encrypt_frm_data_payload(
     start: usize,
     end: usize,
     fcnt: u32,
-    aes_enc: &dyn keys::Encrypter,
+    crypto: &dyn Crypto,
 ) {
     let len = end - start;
 
@@ -64,7 +52,7 @@ pub fn encrypt_frm_data_payload(
             a[15] = ctr;
             ctr += 1;
             s = a;
-            aes_enc.encrypt_block(&mut s);
+            crypto.encrypt_block(&mut s);
         }
         phy_payload[start + i] ^= s[j]
     }

--- a/lorawan-encoding/tests/lorawan.rs
+++ b/lorawan-encoding/tests/lorawan.rs
@@ -6,7 +6,7 @@
 //! remnants of that comparison.
 
 use lorawan::creator::{DataFrame, JoinAccept, JoinRequest, Payload};
-use lorawan::default_crypto::DefaultFactory;
+use lorawan::default_crypto::{DefaultCrypto, DefaultNetworkCrypto};
 use lorawan::keys::{AppKey, AppSKey, NwkSKey, AES128, MIC};
 use lorawan::parser::*;
 
@@ -149,13 +149,13 @@ fn f_port_present_with_empty_frm_payload() {
 fn validate_mic_matches_old_parser() {
     let buf = phy_dataup_payload();
     let phy = EncryptedDataPayload::parse(&buf).unwrap();
-    let key = AES128([2; 16]);
-    assert!(phy.validate_mic(&key, 1, &DefaultFactory));
+    let crypto = DefaultCrypto::new(&AES128([2; 16]));
+    assert!(phy.validate_mic(&crypto, 1));
 
     let mut tampered = phy_dataup_payload();
     tampered[8] = 0xee;
     let phy = EncryptedDataPayload::parse(&tampered).unwrap();
-    assert!(!phy.validate_mic(&key, 1, &DefaultFactory));
+    assert!(!phy.validate_mic(&crypto, 1));
 }
 
 // ---------------------------------------------------------------------------
@@ -165,10 +165,8 @@ fn validate_mic_matches_old_parser() {
 #[test]
 fn decrypt_in_place_app_payload() {
     let mut buf = phy_dataup_payload();
-    let app_skey = AppSKey::from([1; 16]);
-    let dec =
-        DecryptedDataPayload::decrypt_in_place(&mut buf, None, Some(&app_skey), 1, &DefaultFactory)
-            .unwrap();
+    let app_crypto = DefaultCrypto::new(&AES128([1; 16]));
+    let dec = DecryptedDataPayload::decrypt_in_place(&mut buf, None, Some(&app_crypto), 1).unwrap();
     assert_eq!(dec.frm_payload(), FrmPayload::Data(b"hello"));
     // Header accessors still work on the decrypted view.
     assert_eq!(dec.fhdr().dev_addr(), DevAddr::from_value(0x01020304));
@@ -178,31 +176,23 @@ fn decrypt_in_place_app_payload() {
 #[test]
 fn decrypt_in_place_downlink() {
     let mut buf = phy_datadown_payload();
-    let app_skey = AppSKey::from([1; 16]);
-    let dec = DecryptedDataPayload::decrypt_in_place(
-        &mut buf,
-        None,
-        Some(&app_skey),
-        76543,
-        &DefaultFactory,
-    )
-    .unwrap();
+    let app_crypto = DefaultCrypto::new(&AES128([1; 16]));
+    let dec =
+        DecryptedDataPayload::decrypt_in_place(&mut buf, None, Some(&app_crypto), 76543).unwrap();
     assert_eq!(dec.frm_payload(), FrmPayload::Data(b"hello lora"));
 }
 
 #[test]
 fn decrypt_fport_zero_uses_nwk_key_and_yields_mac_commands() {
     let mut buf = data_payload_with_fport_zero();
-    let nwk_skey = NwkSKey::from([2; 16]);
+    let nwk_crypto = DefaultCrypto::new(&AES128([2; 16]));
 
     // Missing the required key is an error, not a silent wrong decrypt.
-    let err = DecryptedDataPayload::decrypt_in_place(&mut buf, None, None, 0, &DefaultFactory)
+    let err = DecryptedDataPayload::decrypt_in_place::<DefaultCrypto>(&mut buf, None, None, 0)
         .unwrap_err();
     assert_eq!(err, Error::MissingKey);
 
-    let dec =
-        DecryptedDataPayload::decrypt_in_place(&mut buf, Some(&nwk_skey), None, 0, &DefaultFactory)
-            .unwrap();
+    let dec = DecryptedDataPayload::decrypt_in_place(&mut buf, Some(&nwk_crypto), None, 0).unwrap();
     match dec.frm_payload() {
         FrmPayload::MacCommands(cmds) => assert!(!cmds.is_empty()),
         other => panic!("expected MAC commands, got {other:?}"),
@@ -211,16 +201,15 @@ fn decrypt_fport_zero_uses_nwk_key_and_yields_mac_commands() {
 
 #[test]
 fn check_mic_and_decrypt_in_place() {
-    let nwk_skey = NwkSKey::from([2; 16]);
-    let app_skey = AppSKey::from([1; 16]);
+    let nwk_crypto = DefaultCrypto::new(&AES128([2; 16]));
+    let app_crypto = DefaultCrypto::new(&AES128([1; 16]));
 
     let mut buf = phy_dataup_payload();
     let dec = DecryptedDataPayload::check_mic_and_decrypt_in_place(
         &mut buf,
-        &nwk_skey,
-        Some(&app_skey),
+        &nwk_crypto,
+        Some(&app_crypto),
         1,
-        &DefaultFactory,
     )
     .unwrap();
     assert_eq!(dec.frm_payload(), FrmPayload::Data(b"hello"));
@@ -229,10 +218,9 @@ fn check_mic_and_decrypt_in_place() {
     tampered[9] ^= 0xff;
     let err = DecryptedDataPayload::check_mic_and_decrypt_in_place(
         &mut tampered,
-        &nwk_skey,
-        Some(&app_skey),
+        &nwk_crypto,
+        Some(&app_crypto),
         1,
-        &DefaultFactory,
     )
     .unwrap_err();
     assert_eq!(err, Error::InvalidMic);
@@ -244,7 +232,7 @@ fn check_mic_and_decrypt_in_place() {
 fn decrypt_without_frm_payload_needs_no_key() {
     // MHDR + FHDR(7) + MIC: no FPort, no FRMPayload.
     let mut no_fport = [0x40, 0x04, 0x03, 0x02, 0x01, 0x00, 0x07, 0x00, 0xde, 0xad, 0xbe, 0xef];
-    let dec = DecryptedDataPayload::decrypt_in_place(&mut no_fport, None, None, 0, &DefaultFactory)
+    let dec = DecryptedDataPayload::decrypt_in_place::<DefaultCrypto>(&mut no_fport, None, None, 0)
         .unwrap();
     assert_eq!(dec.frm_payload(), FrmPayload::None);
 
@@ -252,7 +240,7 @@ fn decrypt_without_frm_payload_needs_no_key() {
     let mut empty_frm =
         [0x40, 0x04, 0x03, 0x02, 0x01, 0x00, 0x07, 0x00, 42, 0xde, 0xad, 0xbe, 0xef];
     let dec =
-        DecryptedDataPayload::decrypt_in_place(&mut empty_frm, None, None, 0, &DefaultFactory)
+        DecryptedDataPayload::decrypt_in_place::<DefaultCrypto>(&mut empty_frm, None, None, 0)
             .unwrap();
     assert_eq!(dec.f_port(), Some(42));
     assert_eq!(dec.frm_payload(), FrmPayload::Data(&[]));
@@ -269,22 +257,18 @@ fn inspect_then_decrypt_flow() {
     let mut buf = phy_dataup_payload();
 
     // Phase 1: read-only borrow to route the frame.
-    let (nwk, app) = {
+    let (nwk_crypto, app_crypto) = {
         let phy = EncryptedDataPayload::parse(&buf).unwrap();
         let session = sessions.get(&phy.fhdr().dev_addr()).expect("unknown device");
-        assert!(phy.validate_mic(session.0.inner(), 1, &DefaultFactory));
-        (session.0, session.1) // keys are Copy
+        let nwk_crypto = DefaultCrypto::new(session.0.inner());
+        assert!(phy.validate_mic(&nwk_crypto, 1));
+        (nwk_crypto, DefaultCrypto::new(session.1.inner()))
     };
 
     // Phase 2: mutable handoff, decrypt in place.
-    let dec = DecryptedDataPayload::decrypt_in_place(
-        &mut buf,
-        Some(&nwk),
-        Some(&app),
-        1,
-        &DefaultFactory,
-    )
-    .unwrap();
+    let dec =
+        DecryptedDataPayload::decrypt_in_place(&mut buf, Some(&nwk_crypto), Some(&app_crypto), 1)
+            .unwrap();
     assert_eq!(dec.frm_payload(), FrmPayload::Data(b"hello"));
 }
 
@@ -299,20 +283,13 @@ fn decrypt_in_place_is_an_involution() {
         (phy_datadown_payload(), 76543),
         (data_payload_with_fport_zero(), 0),
     ];
-    let nwk = NwkSKey::from([2; 16]);
-    let app = AppSKey::from([1; 16]);
+    let nwk = DefaultCrypto::new(&AES128([2; 16]));
+    let app = DefaultCrypto::new(&AES128([1; 16]));
 
     for (bytes, fcnt) in vectors {
         let mut buf = bytes.clone();
         for _ in 0..2 {
-            DecryptedDataPayload::decrypt_in_place(
-                &mut buf,
-                Some(&nwk),
-                Some(&app),
-                fcnt,
-                &DefaultFactory,
-            )
-            .unwrap();
+            DecryptedDataPayload::decrypt_in_place(&mut buf, Some(&nwk), Some(&app), fcnt).unwrap();
         }
         assert_eq!(buf, bytes);
     }
@@ -390,8 +367,8 @@ fn join_request_field_extraction() {
 fn join_request_mic_validation() {
     let data = phy_join_request_payload();
     let jr = JoinRequestPayload::parse(&data).unwrap();
-    assert!(jr.validate_mic(&AppKey::from([1; 16]), &DefaultFactory));
-    assert!(!jr.validate_mic(&AppKey::from([2; 16]), &DefaultFactory));
+    assert!(jr.validate_mic(&DefaultCrypto::new(&AES128([1; 16]))));
+    assert!(!jr.validate_mic(&DefaultCrypto::new(&AES128([2; 16]))));
 }
 
 #[test]
@@ -407,19 +384,19 @@ fn join_request_parse_validates() {
 /// Round trip: build a JoinRequest, parse and validate it.
 #[test]
 fn join_request_round_trip() {
-    let key = AppKey::from([7; 16]);
+    let crypto = DefaultCrypto::new(AppKey::from([7; 16]).inner());
     let mut buf = [0u8; 23];
     let built = JoinRequest {
         join_eui: JoinEui::from_wire_bytes([1, 2, 3, 4, 5, 6, 7, 8]),
         dev_eui: DevEui::from_wire_bytes([8, 7, 6, 5, 4, 3, 2, 1]),
         dev_nonce: DevNonce::from_wire_bytes([0xcc, 0xdd]),
     }
-    .build_into(&mut buf, &key, &DefaultFactory)
+    .build_into(&mut buf, &crypto)
     .unwrap()
     .to_vec();
 
     let jr = JoinRequestPayload::parse(&built).unwrap();
-    assert!(jr.validate_mic(&key, &DefaultFactory));
+    assert!(jr.validate_mic(&crypto));
     assert_eq!(jr.join_eui(), JoinEui::from_wire_bytes([1, 2, 3, 4, 5, 6, 7, 8]));
     assert_eq!(jr.dev_eui(), DevEui::from_wire_bytes([8, 7, 6, 5, 4, 3, 2, 1]));
     assert_eq!(jr.dev_nonce(), DevNonce::from_wire_bytes([0xcc, 0xdd]));
@@ -445,10 +422,8 @@ fn join_accept_parse_validates() {
 #[test]
 fn join_accept_decrypt_and_mic() {
     let mut buf = phy_join_accept_payload_with_c_f_list();
-    let key = AppKey::from([1; 16]);
-    let ja =
-        DecryptedJoinAcceptPayload::check_mic_and_decrypt_in_place(&mut buf, &key, &DefaultFactory)
-            .unwrap();
+    let crypto = DefaultCrypto::new(&AES128([1; 16]));
+    let ja = DecryptedJoinAcceptPayload::check_mic_and_decrypt_in_place(&mut buf, &crypto).unwrap();
 
     assert_eq!(ja.join_nonce(), JoinNonce::from_wire_bytes([3, 2, 1]));
     assert_eq!(ja.rx_delay(), 3);
@@ -469,8 +444,7 @@ fn join_accept_wrong_key_is_invalid_mic() {
     let mut buf = phy_join_accept_payload_with_c_f_list();
     let err = DecryptedJoinAcceptPayload::check_mic_and_decrypt_in_place(
         &mut buf,
-        &AppKey::from([2; 16]),
-        &DefaultFactory,
+        &DefaultCrypto::new(&AES128([2; 16])),
     )
     .unwrap_err();
     assert_eq!(err, Error::InvalidMic);
@@ -481,8 +455,7 @@ fn join_accept_without_c_f_list() {
     let mut buf = phy_join_accept_payload();
     let ja = DecryptedJoinAcceptPayload::check_mic_and_decrypt_in_place(
         &mut buf,
-        &app_key(),
-        &DefaultFactory,
+        &DefaultCrypto::new(app_key().inner()),
     )
     .unwrap();
     assert_eq!(ja.c_f_list(), None);
@@ -492,11 +465,11 @@ fn join_accept_without_c_f_list() {
 /// (originally cross-checked byte-for-byte against the retired parser).
 #[test]
 fn join_accept_decryption_and_derived_keys() {
-    let key = app_key();
+    let crypto = DefaultCrypto::new(app_key().inner());
     let dev_nonce = DevNonce::from_wire_bytes([0xcc, 0xdd]);
 
     let mut buf = phy_join_accept_payload();
-    let ja = DecryptedJoinAcceptPayload::decrypt_in_place(&mut buf, &key, &DefaultFactory).unwrap();
+    let ja = DecryptedJoinAcceptPayload::decrypt_in_place(&mut buf, &crypto).unwrap();
 
     assert_eq!(
         ja.as_bytes(),
@@ -506,14 +479,14 @@ fn join_accept_decryption_and_derived_keys() {
         ]
     );
     assert_eq!(
-        ja.derive_nwkskey(dev_nonce, &key, &DefaultFactory),
+        ja.derive_nwkskey(dev_nonce, &crypto),
         NwkSKey::from([
             0x40, 0x6b, 0x13, 0x37, 0xd8, 0x07, 0x53, 0x82, 0x05, 0x40, 0xe2, 0x80, 0xf8, 0x12,
             0x99, 0xe9,
         ])
     );
     assert_eq!(
-        ja.derive_appskey(dev_nonce, &key, &DefaultFactory),
+        ja.derive_appskey(dev_nonce, &crypto),
         AppSKey::from([
             0x4f, 0x5c, 0x40, 0x97, 0x51, 0x84, 0x1b, 0x6d, 0xfe, 0xcb, 0xd3, 0x84, 0x02, 0x23,
             0x79, 0x42,
@@ -601,17 +574,17 @@ mod creators {
 
     #[test]
     fn join_request_builds_and_validates() {
-        let key = AppKey::from([7; 16]);
+        let crypto = DefaultCrypto::new(AppKey::from([7; 16]).inner());
         let jr = JoinRequest {
             join_eui: JoinEui::from_wire_bytes([1; 8]),
             dev_eui: DevEui::from_wire_bytes([2; 8]),
             dev_nonce: DevNonce::from_wire_bytes([3, 3]),
         };
         let mut buf = [0u8; 23];
-        let built = jr.build_into(&mut buf, &key, &DefaultFactory).unwrap().to_vec();
+        let built = jr.build_into(&mut buf, &crypto).unwrap().to_vec();
 
         let parsed = JoinRequestPayload::parse(&built).unwrap();
-        assert!(parsed.validate_mic(&key, &DefaultFactory));
+        assert!(parsed.validate_mic(&crypto));
         assert_eq!(parsed.join_eui(), jr.join_eui);
         assert_eq!(parsed.dev_eui(), jr.dev_eui);
         assert_eq!(parsed.dev_nonce(), jr.dev_nonce);
@@ -619,7 +592,8 @@ mod creators {
 
     #[test]
     fn join_accept_round_trips() {
-        let key = AppKey::from([1; 16]);
+        let network_crypto = DefaultNetworkCrypto::new(&AES128([1; 16]));
+        let device_crypto = DefaultCrypto::new(&AES128([1; 16]));
         let ja = JoinAccept {
             join_nonce: JoinNonce::from_wire_bytes([1, 1, 1]),
             net_id: NetId::from_wire_bytes([1, 1, 1]),
@@ -635,16 +609,13 @@ mod creators {
             ])),
         };
         let mut buf = [0u8; 33];
-        let built = ja.build_into(&mut buf, &key, &DefaultFactory).unwrap().to_vec();
+        let built = ja.build_into(&mut buf, &network_crypto).unwrap().to_vec();
 
         // Round trip through the parser.
         let mut rt = built.clone();
-        let parsed = DecryptedJoinAcceptPayload::check_mic_and_decrypt_in_place(
-            &mut rt,
-            &key,
-            &DefaultFactory,
-        )
-        .unwrap();
+        let parsed =
+            DecryptedJoinAcceptPayload::check_mic_and_decrypt_in_place(&mut rt, &device_crypto)
+                .unwrap();
         assert_eq!(parsed.join_nonce(), ja.join_nonce);
         assert_eq!(parsed.net_id(), ja.net_id);
         assert_eq!(parsed.dev_addr(), ja.dev_addr);
@@ -668,9 +639,8 @@ mod creators {
         let built = frame
             .build_into(
                 &mut buf,
-                &NwkSKey::from([2; 16]),
-                Some(&AppSKey::from([1; 16])),
-                &DefaultFactory,
+                &DefaultCrypto::new(&AES128([2; 16])),
+                Some(&DefaultCrypto::new(&AES128([1; 16]))),
             )
             .unwrap();
         assert_eq!(built, &phy_dataup_payload()[..]);
@@ -692,9 +662,8 @@ mod creators {
         let built = frame
             .build_into(
                 &mut buf,
-                &NwkSKey::from([2; 16]),
-                Some(&AppSKey::from([1; 16])),
-                &DefaultFactory,
+                &DefaultCrypto::new(&AES128([2; 16])),
+                Some(&DefaultCrypto::new(&AES128([1; 16]))),
             )
             .unwrap();
         assert_eq!(built, &phy_datadown_payload()[..]);
@@ -704,16 +673,9 @@ mod creators {
     fn data_frame_round_trips_mac_commands_vector() {
         // Decrypt the fport-0 vector with the old API to recover the MAC
         // command plaintext, rebuild it with the new creator, and compare.
-        let nwk = NwkSKey::from([1; 16]);
+        let nwk = DefaultCrypto::new(&AES128([1; 16]));
         let mut plain = data_payload_with_fport_zero();
-        let dec = DecryptedDataPayload::decrypt_in_place(
-            &mut plain,
-            Some(&nwk),
-            None,
-            0,
-            &DefaultFactory,
-        )
-        .unwrap();
+        let dec = DecryptedDataPayload::decrypt_in_place(&mut plain, Some(&nwk), None, 0).unwrap();
         let FrmPayload::MacCommands(cmds) = dec.frm_payload() else {
             panic!("expected MAC commands");
         };
@@ -727,7 +689,7 @@ mod creators {
             ..Default::default()
         };
         let mut buf = [0u8; 64];
-        let built = frame.build_into(&mut buf, &nwk, None, &DefaultFactory).unwrap();
+        let built = frame.build_into(&mut buf, &nwk, None).unwrap();
         assert_eq!(built, &data_payload_with_fport_zero()[..]);
     }
 
@@ -743,45 +705,36 @@ mod creators {
         };
         let mut buf = [0u8; 64];
         let built =
-            frame.build_into(&mut buf, &NwkSKey::from([1; 16]), None, &DefaultFactory).unwrap();
+            frame.build_into(&mut buf, &DefaultCrypto::new(&AES128([1; 16])), None).unwrap();
         assert_eq!(built, &data_payload_with_f_opts()[..]);
     }
 
     #[test]
     fn data_frame_build_validation() {
-        let nwk = NwkSKey::from([2; 16]);
-        let app = AppSKey::from([1; 16]);
+        let nwk = DefaultCrypto::new(&AES128([2; 16]));
+        let app = DefaultCrypto::new(&AES128([1; 16]));
         let base = DataFrame { dev_addr: DevAddr::from_value(1), ..Default::default() };
         let mut buf = [0u8; 64];
 
         // FOpts limited to 15 bytes.
         let frame = DataFrame { f_opts: &[0; 16], ..base };
-        assert_eq!(
-            frame.build_into(&mut buf, &nwk, None, &DefaultFactory).unwrap_err(),
-            Error::FOptsTooLong
-        );
+        assert_eq!(frame.build_into(&mut buf, &nwk, None).unwrap_err(), Error::FOptsTooLong);
 
         // FPort 0 with non-empty FOpts is forbidden.
         let frame = DataFrame { f_opts: &[0x02], payload: Payload::MacCommands(&[0x02]), ..base };
-        assert_eq!(
-            frame.build_into(&mut buf, &nwk, None, &DefaultFactory).unwrap_err(),
-            Error::FOptsWithFPortZero
-        );
+        assert_eq!(frame.build_into(&mut buf, &nwk, None).unwrap_err(), Error::FOptsWithFPortZero);
 
         // App data needs the AppSKey.
         let frame = DataFrame {
             payload: Payload::Data { f_port: NonZeroU8::new(1).unwrap(), data: b"x" },
             ..base
         };
-        assert_eq!(
-            frame.build_into(&mut buf, &nwk, None, &DefaultFactory).unwrap_err(),
-            Error::MissingKey
-        );
+        assert_eq!(frame.build_into(&mut buf, &nwk, None).unwrap_err(), Error::MissingKey);
 
         // Output buffer too small.
         let mut small = [0u8; 12];
         assert_eq!(
-            frame.build_into(&mut small, &nwk, Some(&app), &DefaultFactory).unwrap_err(),
+            frame.build_into(&mut small, &nwk, Some(&app)).unwrap_err(),
             Error::BufferTooShort
         );
     }
@@ -789,8 +742,8 @@ mod creators {
     /// Full new-API round trip: build, parse, MIC-check, decrypt, compare.
     #[test]
     fn build_parse_decrypt_round_trip() {
-        let nwk = NwkSKey::from([3; 16]);
-        let app = AppSKey::from([4; 16]);
+        let nwk = DefaultCrypto::new(&AES128([3; 16]));
+        let app = DefaultCrypto::new(&AES128([4; 16]));
         let frame = DataFrame {
             frame_type: DataFrameType::ConfirmedUp,
             dev_addr: DevAddr::from_value(0xdeadbeef),
@@ -802,8 +755,7 @@ mod creators {
             ..Default::default()
         };
         let mut buf = [0u8; 64];
-        let built_len =
-            frame.build_into(&mut buf, &nwk, Some(&app), &DefaultFactory).unwrap().len();
+        let built_len = frame.build_into(&mut buf, &nwk, Some(&app)).unwrap().len();
 
         let mut rt = buf[..built_len].to_vec();
         let dec = DecryptedDataPayload::check_mic_and_decrypt_in_place(
@@ -811,7 +763,6 @@ mod creators {
             &nwk,
             Some(&app),
             0x0004_0007,
-            &DefaultFactory,
         )
         .unwrap();
         assert_eq!(dec.frame_type(), DataFrameType::ConfirmedUp);
@@ -941,7 +892,7 @@ mod certification {
 // ---------------------------------------------------------------------------
 
 mod multicast {
-    use lorawan::default_crypto::DefaultFactory;
+    use lorawan::default_crypto::{DefaultCrypto, DefaultNetworkCrypto};
     use lorawan::keys::{McKEKey, McKey};
     use lorawan::maccommands::ParseError as MacError;
     use lorawan::multicast::{
@@ -980,7 +931,7 @@ mod multicast {
         let mut creator = McGroupSetupReqCreator::new();
         creator.mc_group_id_header(0x01);
         creator.mc_addr(&mc_addr);
-        creator.mc_key(&DefaultFactory, &mc_key, &mcke_key);
+        creator.mc_key(&DefaultNetworkCrypto::new(mcke_key.inner()), &mc_key);
         creator.min_mc_fcount(7);
         creator.max_mc_fcount(1000);
         let bytes = creator.build().to_vec();
@@ -990,14 +941,15 @@ mod multicast {
         let [DownlinkRemoteSetup::McGroupSetupReq(req)] = &cmds[..] else {
             panic!("expected McGroupSetupReq");
         };
-        let (group_id, session) = req.derive_session(&DefaultFactory, &mcke_key);
+        let (group_id, session) = req.derive_session(&DefaultCrypto::new(mcke_key.inner()));
         assert_eq!(group_id, 1);
         assert_eq!(session.multicast_addr(), mc_addr);
         assert_eq!(session.fcnt_down, 7);
         assert_eq!(session.max_fcnt_down(), 1000);
         // Keys must match direct derivation from McKey.
-        assert_eq!(session.mc_app_s_key(), mc_key.derive_mc_app_s_key(&DefaultFactory, &mc_addr));
-        assert_eq!(session.mc_net_s_key(), mc_key.derive_mc_net_s_key(&DefaultFactory, &mc_addr));
+        let mc_key_crypto = DefaultCrypto::new(mc_key.inner());
+        assert_eq!(session.mc_app_s_key(), McKey::derive_mc_app_s_key(&mc_key_crypto, &mc_addr));
+        assert_eq!(session.mc_net_s_key(), McKey::derive_mc_net_s_key(&mc_key_crypto, &mc_addr));
     }
 
     /// McGroupStatusAns is variable length, driven by a bitmask in its first


### PR DESCRIPTION
Implements the remaining work of #347: simplify the crypto abstraction and reuse cipher state instead of re-instantiating per operation.

## The new traits

`CryptoFactory` (three associated types, key passed on every call) is replaced by two small traits in `lorawan::keys`:

```rust
pub trait Crypto {
    fn encrypt_block(&self, block: &mut [u8]);                  // AES-128 ECB, one block
    fn calculate_mic(&self, b0: &[u8], data: &[u8]) -> [u8; 4]; // AES-CMAC; b0 empty for join frames
}
pub trait NetworkCrypto: Crypto {
    fn decrypt_block(&self, block: &mut [u8]);
}
```

The key is bound at construction. Whether an implementation caches the expanded key schedule or recomputes it per call is its own choice, which is what makes the cipher-reuse part of #347 fall out naturally: `DefaultCrypto` caches an encrypt-only `Aes128Enc` schedule, `DefaultNetworkCrypto` holds the full `Aes128`. Both are covered by FIPS-197 / RFC 4493 known-answer tests.

As discussed in the issue, a device only ever needs the AES encrypt primitive, so the device path compiles against `Crypto` alone and an encrypt-only hardware AES implementation is enough. The only entry points requiring `NetworkCrypto` are `JoinAccept::build_into` and `McGroupSetupReqCreator::mc_key`, both network-side creation.

`calculate_mic` takes two slices because the data MIC is CMAC(B0 || frame); this avoids both streaming MAC state (soft CMAC needs a reset per MIC anyway) and a concat buffer. Both traits are dyn-safe.

## API changes

* All creator/parser/derivation entry points take key-bound crypto instead of a (key, factory) pair: `validate_mic(&crypto, fcnt)`, `decrypt_in_place(buf, Some(&nwk_crypto), Some(&app_crypto), fcnt)`, `DataFrame::build_into(&mut buf, &nwk_crypto, Some(&app_crypto))`, `derive_nwkskey(dev_nonce, &crypto)`, and so on. The required key role is documented per method.
* `Encrypter`, `Decrypter`, `Mac`, `CryptoFactory` and `DefaultFactory` are removed. No migration shim; pre-1.0 break.
* `decrypt_in_place_with` is folded into `decrypt_in_place`: the typed-key vs raw-key split existed for multicast sessions whose keys are not `NwkSKey`/`AppSKey`, but a key-bound crypto carries no key type, so one entry point serves both. When both crypto arguments are `None` (a frame with no FRMPayload) the type parameter needs a turbofish.
* `McGroupSetupReqPayload::derive_session_keys` takes a `C: Crypto + From<AES128>` bound to build crypto for the McKey it decrypts out of the request; `mc_key_decrypted` is now public as the escape hatch for implementations that cannot be built from a bare key.
* lorawan-device's external API is unchanged apart from re-exporting `Crypto` instead of `CryptoFactory`; it constructs `DefaultCrypto` per call at each site. Holding the crypto for the session lifetime is a possible follow-up (it costs ~700 bytes of RAM per session on soft-AES targets, so it wants its own discussion).

## Benchmarks

x86-64 with AES-NI, against `CryptoFactory` at the same base (table also added to `benches/README.md`, plus a new `data_payload_creation` bench):

| benchmark | CryptoFactory | Crypto | change |
|---|--:|--:|--|
| data_payload_creation | 223.7 ns | 173.6 ns | -22% |
| data_payload_mic_validation | 136.9 ns | 116.8 ns | -15% |
| data_payload_decrypt | 50.9 ns | 41.1 ns | -19% |
| data_payload_headers_parsing | 6.47 ns | 6.46 ns | parity |

MIC and decrypt improve even against a factory returning pre-instantiated ciphers: the new path clones only the encrypt schedule and initializes the CMAC from it directly.

Closes #347.