### PR TITLE
examples: update defmt to 1.x, defmt-rtt to 1.x, panic-probe to 1.0

### DIFF
--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -29,9 +29,9 @@ lorawan-device = { path = "../../lorawan-device", default-features = false, feat
     "defmt-03",
 ] }
 
-defmt = "0.3"
-defmt-rtt = "0.4"
-panic-probe = { version = "0.3", features = ["print-defmt"] }
+defmt = "1"
+defmt-rtt = "1"
+panic-probe = { version = "1", features = ["print-defmt"] }
 
 cortex-m = { version = "0.7.7", features = [
     "inline-asm",

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -29,9 +29,9 @@ lorawan-device = { path = "../../lorawan-device", features = [
     "defmt-03",
 ] }
 
-defmt = "0.3"
-defmt-rtt = "0.4"
-panic-probe = { version = "0.3", features = ["print-defmt"] }
+defmt = "1"
+defmt-rtt = "1"
+panic-probe = { version = "1", features = ["print-defmt"] }
 
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-rt = "0.7"

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -29,9 +29,9 @@ lorawan-device = { path = "../../lorawan-device", features = [
     "defmt-03",
 ] }
 
-defmt = "0.3"
-defmt-rtt = "0.4"
-panic-probe = { version = "0.3", features = ["print-defmt"] }
+defmt = "1"
+defmt-rtt = "1"
+panic-probe = { version = "1", features = ["print-defmt"] }
 
 cortex-m = { version = "0.7.6", features = [
     "inline-asm",

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -33,9 +33,9 @@ lorawan-device = { path = "../../lorawan-device", features = [
     "defmt-03",
 ] }
 
-defmt = "0.3"
-defmt-rtt = "0.4"
-panic-probe = { version = "0.3", features = ["print-defmt"] }
+defmt = "1"
+defmt-rtt = "1"
+panic-probe = { version = "1", features = ["print-defmt"] }
 
 cortex-m = { version = "0.7.6", features = [
     "inline-asm",


### PR DESCRIPTION
Updates the defmt logging cluster in the four examples still on the old line (nrf52840, rp, stm32l0, stm32wl):

- defmt 0.3 -> 1 (resolves to 1.1.1)
- defmt-rtt 0.4 -> 1 (resolves to 1.3.0)
- panic-probe 0.3 -> 1.0

No source changes were needed. The library crates stay on their defmt 0.3 requirement, which resolves to the 0.3.100 facade and links against the same defmt 1 code, so the defmt-03 features keep working unchanged. This matches what the stm32wba and stm32wle5cx examples already do.

Verified with cargo build --release in each of the four example crates.