### PR TITLE
examples: update embedded-hal-bus to 0.3

### DIFF
--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -38,7 +38,7 @@ cortex-m = { version = "0.7.7", features = [
     "critical-section-single-core",
 ] }
 cortex-m-rt = "0.7.3"
-embedded-hal-bus = { version = "0.2", features = ["async"] }
+embedded-hal-bus = { version = "0.3", features = ["async"] }
 rand = { version = "0.8.4", default-features = false }
 
 [profile.release]

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -35,7 +35,7 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-rt = "0.7"
-embedded-hal-bus = { version = "0.2", features = ["async"] }
+embedded-hal-bus = { version = "0.3", features = ["async"] }
 
 static_cell = { version = "2.0.0" }
 portable-atomic = { version = "1.5", features = [

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -41,7 +41,7 @@ cortex-m-rt = "0.7.0"
 portable-atomic = { version = "1.10.0", features = [
     "unsafe-assume-single-core",
 ] }
-embedded-hal-bus = { version = "0.2.0", features = ["async"] }
+embedded-hal-bus = { version = "0.3", features = ["async"] }
 
 [profile.release]
 debug = 2

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -44,7 +44,7 @@ cortex-m = { version = "0.7.6", features = [
 cortex-m-rt = "0.7.0"
 embedded-hal = { version = "1.0.0" }
 embedded-hal-async = { version = "1.0.0" }
-embedded-hal-bus = { version = "0.2.0", features = ["async"] }
+embedded-hal-bus = { version = "0.3", features = ["async"] }
 
 [profile.release]
 debug = 2


### PR DESCRIPTION
Bumps embedded-hal-bus from 0.2 to 0.3 in the four examples still on the old version (nrf52840, rp, stm32l0, stm32wl), keeping the async feature. stm32wba and stm32wle5cx are already on 0.3.

No source changes were needed; the examples already use the ExclusiveDevice::new(...).unwrap() idiom that 0.3 expects.

Verified with cargo build --release in each of the four example crates.