### PR TITLE
examples: update embassy to latest (embassy-stm32 0.6, executor 0.10, time 0.5, sync 0.8)

### DIFF
--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -5,16 +5,16 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-executor = { version = "0.7", features = [
-    "arch-cortex-m",
+embassy-executor = { version = "0.10", features = [
+    "platform-cortex-m",
     "executor-thread",
     "defmt",
 ] }
-embassy-time = { version = "0.4", features = [
+embassy-time = { version = "0.5", features = [
     "defmt",
     "defmt-timestamp-uptime",
 ] }
-embassy-nrf = { version = "0.3", features = [
+embassy-nrf = { version = "0.11", features = [
     "defmt",
     "nrf52840",
     "time-driver-rtc1",

--- a/examples/nrf52840/src/bin/lora_cad.rs
+++ b/examples/nrf52840/src/bin/lora_cad.rs
@@ -6,7 +6,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pin as _, Pull};
+use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pull};
 use embassy_nrf::{bind_interrupts, peripherals, spim};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
@@ -26,12 +26,12 @@ bind_interrupts!(struct Irqs {
 async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
 
-    let nss = Output::new(p.P1_10.degrade(), Level::High, OutputDrive::Standard);
-    let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
-    let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
-    let busy = Input::new(p.P1_14.degrade(), Pull::None);
-    let rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
-    let rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
+    let nss = Output::new(p.P1_10, Level::High, OutputDrive::Standard);
+    let reset = Output::new(p.P1_06, Level::High, OutputDrive::Standard);
+    let dio1 = Input::new(p.P1_15, Pull::Down);
+    let busy = Input::new(p.P1_14, Pull::None);
+    let rf_switch_rx = Output::new(p.P1_05, Level::Low, OutputDrive::Standard);
+    let rf_switch_tx = Output::new(p.P1_07, Level::Low, OutputDrive::Standard);
 
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;

--- a/examples/nrf52840/src/bin/lora_get_rssi.rs
+++ b/examples/nrf52840/src/bin/lora_get_rssi.rs
@@ -6,7 +6,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pin as _, Pull};
+use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pull};
 use embassy_nrf::{bind_interrupts, peripherals, spim};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
@@ -27,12 +27,12 @@ bind_interrupts!(struct Irqs {
 async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
 
-    let nss = Output::new(p.P1_10.degrade(), Level::High, OutputDrive::Standard);
-    let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
-    let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
-    let busy = Input::new(p.P1_14.degrade(), Pull::None);
-    let _rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
-    let _rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
+    let nss = Output::new(p.P1_10, Level::High, OutputDrive::Standard);
+    let reset = Output::new(p.P1_06, Level::High, OutputDrive::Standard);
+    let dio1 = Input::new(p.P1_15, Pull::Down);
+    let busy = Input::new(p.P1_14, Pull::None);
+    let _rf_switch_rx = Output::new(p.P1_05, Level::Low, OutputDrive::Standard);
+    let _rf_switch_tx = Output::new(p.P1_07, Level::Low, OutputDrive::Standard);
 
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;

--- a/examples/nrf52840/src/bin/lora_lorawan.rs
+++ b/examples/nrf52840/src/bin/lora_lorawan.rs
@@ -6,7 +6,8 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pin as _, Pull};
+use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pull};
+use embassy_nrf::mode::Async;
 use embassy_nrf::rng::Rng;
 use embassy_nrf::{bind_interrupts, peripherals, rng, spim};
 use embassy_time::{Delay, Duration, Timer};
@@ -39,7 +40,7 @@ bind_interrupts!(struct Irqs {
 });
 
 // Generate "jittered" delay for retry attempts up to maximum of 1 hour
-pub fn generate_delay(rng: &mut Rng<'static, peripherals::RNG>, retries: u16) -> u16 {
+pub fn generate_delay(rng: &mut Rng<'static, Async>, retries: u16) -> u16 {
     let base = core::cmp::min(10 + (10 * retries), 3600);
     let jitter = base / 5;
     (base - jitter).saturating_add(rng.gen_range(jitter..=2 * jitter))
@@ -49,12 +50,12 @@ pub fn generate_delay(rng: &mut Rng<'static, peripherals::RNG>, retries: u16) ->
 async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
 
-    let nss = Output::new(p.P1_10.degrade(), Level::High, OutputDrive::Standard);
-    let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
-    let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
-    let busy = Input::new(p.P1_14.degrade(), Pull::None);
-    let rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
-    let rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
+    let nss = Output::new(p.P1_10, Level::High, OutputDrive::Standard);
+    let reset = Output::new(p.P1_06, Level::High, OutputDrive::Standard);
+    let dio1 = Input::new(p.P1_15, Pull::Down);
+    let busy = Input::new(p.P1_14, Pull::None);
+    let rf_switch_rx = Output::new(p.P1_05, Level::Low, OutputDrive::Standard);
+    let rf_switch_tx = Output::new(p.P1_07, Level::Low, OutputDrive::Standard);
 
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;

--- a/examples/nrf52840/src/bin/lora_p2p_receive.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive.rs
@@ -6,7 +6,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pin as _, Pull};
+use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pull};
 use embassy_nrf::{bind_interrupts, peripherals, spim};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
@@ -26,12 +26,12 @@ bind_interrupts!(struct Irqs {
 async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
 
-    let nss = Output::new(p.P1_10.degrade(), Level::High, OutputDrive::Standard);
-    let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
-    let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
-    let busy = Input::new(p.P1_14.degrade(), Pull::None);
-    let rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
-    let rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
+    let nss = Output::new(p.P1_10, Level::High, OutputDrive::Standard);
+    let reset = Output::new(p.P1_06, Level::High, OutputDrive::Standard);
+    let dio1 = Input::new(p.P1_15, Pull::Down);
+    let busy = Input::new(p.P1_14, Pull::None);
+    let rf_switch_rx = Output::new(p.P1_05, Level::Low, OutputDrive::Standard);
+    let rf_switch_tx = Output::new(p.P1_07, Level::Low, OutputDrive::Standard);
 
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;

--- a/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
@@ -6,7 +6,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pin as _, Pull};
+use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pull};
 use embassy_nrf::{bind_interrupts, peripherals, spim};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
@@ -26,12 +26,12 @@ bind_interrupts!(struct Irqs {
 async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
 
-    let nss = Output::new(p.P1_10.degrade(), Level::High, OutputDrive::Standard);
-    let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
-    let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
-    let busy = Input::new(p.P1_14.degrade(), Pull::None);
-    let rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
-    let rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
+    let nss = Output::new(p.P1_10, Level::High, OutputDrive::Standard);
+    let reset = Output::new(p.P1_06, Level::High, OutputDrive::Standard);
+    let dio1 = Input::new(p.P1_15, Pull::Down);
+    let busy = Input::new(p.P1_14, Pull::None);
+    let rf_switch_rx = Output::new(p.P1_05, Level::Low, OutputDrive::Standard);
+    let rf_switch_tx = Output::new(p.P1_07, Level::Low, OutputDrive::Standard);
 
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;

--- a/examples/nrf52840/src/bin/lora_p2p_send.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_send.rs
@@ -6,7 +6,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pin as _, Pull};
+use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pull};
 use embassy_nrf::{bind_interrupts, peripherals, spim};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
@@ -26,12 +26,12 @@ bind_interrupts!(struct Irqs {
 async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
 
-    let nss = Output::new(p.P1_10.degrade(), Level::High, OutputDrive::Standard);
-    let reset = Output::new(p.P1_06.degrade(), Level::High, OutputDrive::Standard);
-    let dio1 = Input::new(p.P1_15.degrade(), Pull::Down);
-    let busy = Input::new(p.P1_14.degrade(), Pull::None);
-    let rf_switch_rx = Output::new(p.P1_05.degrade(), Level::Low, OutputDrive::Standard);
-    let rf_switch_tx = Output::new(p.P1_07.degrade(), Level::Low, OutputDrive::Standard);
+    let nss = Output::new(p.P1_10, Level::High, OutputDrive::Standard);
+    let reset = Output::new(p.P1_06, Level::High, OutputDrive::Standard);
+    let dio1 = Input::new(p.P1_15, Pull::Down);
+    let busy = Input::new(p.P1_14, Pull::None);
+    let rf_switch_rx = Output::new(p.P1_05, Level::Low, OutputDrive::Standard);
+    let rf_switch_tx = Output::new(p.P1_07, Level::Low, OutputDrive::Standard);
 
     let mut spi_config = spim::Config::default();
     spi_config.frequency = spim::Frequency::M16;

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -5,17 +5,17 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-executor = { version = "0.7", features = [
-    "arch-cortex-m",
+embassy-executor = { version = "0.10", features = [
+    "platform-cortex-m",
     "executor-thread",
     "defmt",
 ] }
-embassy-time = { version = "0.4", features = [
+embassy-time = { version = "0.5", features = [
     "defmt",
     "defmt-timestamp-uptime",
 ] }
-embassy-sync = { version = "0.6", features = ["defmt"] }
-embassy-rp = { version = "0.3", features = [
+embassy-sync = { version = "0.8", features = ["defmt"] }
+embassy-rp = { version = "0.10", features = [
     "defmt",
     "unstable-pac",
     "time-driver",

--- a/examples/rp/src/bin/lora_lorawan.rs
+++ b/examples/rp/src/bin/lora_lorawan.rs
@@ -6,8 +6,9 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::gpio::{Input, Level, Output, Pin, Pull};
+use embassy_rp::gpio::{Input, Level, Output, Pull};
 use embassy_rp::spi::{Config, Spi};
+use embassy_rp::{bind_interrupts, dma, peripherals};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
@@ -18,6 +19,10 @@ use lorawan_device::async_device::{region, Device, EmbassyTimer, JoinMode};
 use lorawan_device::{AppEui, AppKey, DevEui};
 use {defmt_rtt as _, panic_probe as _};
 
+bind_interrupts!(struct Irqs {
+    DMA_IRQ_0 => dma::InterruptHandler<peripherals::DMA_CH0>, dma::InterruptHandler<peripherals::DMA_CH1>;
+});
+
 // warning: set these appropriately for the region
 const LORAWAN_REGION: region::Region = region::Region::EU868;
 const MAX_TX_POWER: u8 = 14;
@@ -26,10 +31,10 @@ const MAX_TX_POWER: u8 = 14;
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
 
-    let nss = Output::new(p.PIN_3.degrade(), Level::High);
-    let reset = Output::new(p.PIN_15.degrade(), Level::High);
-    let dio1 = Input::new(p.PIN_20.degrade(), Pull::None);
-    let busy = Input::new(p.PIN_2.degrade(), Pull::None);
+    let nss = Output::new(p.PIN_3, Level::High);
+    let reset = Output::new(p.PIN_15, Level::High);
+    let dio1 = Input::new(p.PIN_20, Pull::None);
+    let busy = Input::new(p.PIN_2, Pull::None);
 
     let spi = Spi::new(
         p.SPI1,
@@ -38,6 +43,7 @@ async fn main(_spawner: Spawner) {
         p.PIN_12,
         p.DMA_CH0,
         p.DMA_CH1,
+        Irqs,
         Config::default(),
     );
     let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
@@ -53,8 +59,7 @@ async fn main(_spawner: Spawner) {
 
     let radio: LorawanRadio<_, _, MAX_TX_POWER> = lora.into();
     let region: region::Configuration = region::Configuration::new(LORAWAN_REGION);
-    let mut device: Device<_, _, _> =
-        Device::new(region, radio, EmbassyTimer::new(), embassy_rp::clocks::RoscRng);
+    let mut device: Device<_, _, _> = Device::new(region, radio, EmbassyTimer::new(), embassy_rp::clocks::RoscRng);
 
     defmt::info!("Joining LoRaWAN network");
 

--- a/examples/rp/src/bin/lora_p2p_receive.rs
+++ b/examples/rp/src/bin/lora_p2p_receive.rs
@@ -6,8 +6,9 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::gpio::{Input, Level, Output, Pin, Pull};
+use embassy_rp::gpio::{Input, Level, Output, Pull};
 use embassy_rp::spi::{Config, Spi};
+use embassy_rp::{bind_interrupts, dma, peripherals};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
@@ -16,16 +17,20 @@ use lora_phy::{mod_params::*, sx126x};
 use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
 
+bind_interrupts!(struct Irqs {
+    DMA_IRQ_0 => dma::InterruptHandler<peripherals::DMA_CH0>, dma::InterruptHandler<peripherals::DMA_CH1>;
+});
+
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
 
-    let nss = Output::new(p.PIN_3.degrade(), Level::High);
-    let reset = Output::new(p.PIN_15.degrade(), Level::High);
-    let dio1 = Input::new(p.PIN_20.degrade(), Pull::None);
-    let busy = Input::new(p.PIN_2.degrade(), Pull::None);
+    let nss = Output::new(p.PIN_3, Level::High);
+    let reset = Output::new(p.PIN_15, Level::High);
+    let dio1 = Input::new(p.PIN_20, Pull::None);
+    let busy = Input::new(p.PIN_2, Pull::None);
 
     let spi = Spi::new(
         p.SPI1,
@@ -34,6 +39,7 @@ async fn main(_spawner: Spawner) {
         p.PIN_12,
         p.DMA_CH0,
         p.DMA_CH1,
+        Irqs,
         Config::default(),
     );
     let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();

--- a/examples/rp/src/bin/lora_p2p_send.rs
+++ b/examples/rp/src/bin/lora_p2p_send.rs
@@ -6,8 +6,9 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::gpio::{Input, Level, Output, Pin, Pull};
+use embassy_rp::gpio::{Input, Level, Output, Pull};
 use embassy_rp::spi::{Config, Spi};
+use embassy_rp::{bind_interrupts, dma, peripherals};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx126xInterfaceVariant;
@@ -16,16 +17,20 @@ use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx126x};
 use {defmt_rtt as _, panic_probe as _};
 
+bind_interrupts!(struct Irqs {
+    DMA_IRQ_0 => dma::InterruptHandler<peripherals::DMA_CH0>, dma::InterruptHandler<peripherals::DMA_CH1>;
+});
+
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
 
-    let nss = Output::new(p.PIN_3.degrade(), Level::High);
-    let reset = Output::new(p.PIN_15.degrade(), Level::High);
-    let dio1 = Input::new(p.PIN_20.degrade(), Pull::None);
-    let busy = Input::new(p.PIN_2.degrade(), Pull::None);
+    let nss = Output::new(p.PIN_3, Level::High);
+    let reset = Output::new(p.PIN_15, Level::High);
+    let dio1 = Input::new(p.PIN_20, Pull::None);
+    let busy = Input::new(p.PIN_2, Pull::None);
 
     let spi = Spi::new(
         p.SPI1,
@@ -34,6 +39,7 @@ async fn main(_spawner: Spawner) {
         p.PIN_12,
         p.DMA_CH0,
         p.DMA_CH1,
+        Irqs,
         Config::default(),
     );
     let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();

--- a/examples/rp/src/bin/lora_p2p_send_multicore.rs
+++ b/examples/rp/src/bin/lora_p2p_send_multicore.rs
@@ -6,10 +6,11 @@
 
 use defmt::*;
 use embassy_executor::Executor;
-use embassy_rp::gpio::{Input, Level, Output, Pin, Pull};
+use embassy_rp::gpio::{Input, Level, Output, Pull};
 use embassy_rp::multicore::{spawn_core1, Stack};
 use embassy_rp::peripherals::SPI1;
 use embassy_rp::spi::{Async, Config, Spi};
+use embassy_rp::{bind_interrupts, dma, peripherals};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_time::{Delay, Timer};
@@ -20,6 +21,10 @@ use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx126x};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    DMA_IRQ_0 => dma::InterruptHandler<peripherals::DMA_CH0>, dma::InterruptHandler<peripherals::DMA_CH1>;
+});
 
 static mut CORE1_STACK: Stack<4096> = Stack::new();
 static EXECUTOR0: StaticCell<Executor> = StaticCell::new();
@@ -32,10 +37,10 @@ const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriatel
 fn main() -> ! {
     let p = embassy_rp::init(Default::default());
 
-    let nss = Output::new(p.PIN_3.degrade(), Level::High);
-    let reset = Output::new(p.PIN_15.degrade(), Level::High);
-    let dio1 = Input::new(p.PIN_20.degrade(), Pull::None);
-    let busy = Input::new(p.PIN_2.degrade(), Pull::None);
+    let nss = Output::new(p.PIN_3, Level::High);
+    let reset = Output::new(p.PIN_15, Level::High);
+    let dio1 = Input::new(p.PIN_20, Pull::None);
+    let busy = Input::new(p.PIN_2, Pull::None);
 
     let spi = Spi::new(
         p.SPI1,
@@ -44,6 +49,7 @@ fn main() -> ! {
         p.PIN_12,
         p.DMA_CH0,
         p.DMA_CH1,
+        Irqs,
         Config::default(),
     );
     let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
@@ -55,12 +61,12 @@ fn main() -> ! {
         unsafe { &mut *core::ptr::addr_of_mut!(CORE1_STACK) },
         move || {
             let executor1 = EXECUTOR1.init(Executor::new());
-            executor1.run(|spawner| unwrap!(spawner.spawn(core1_task(spi, iv))));
+            executor1.run(|spawner| spawner.spawn(unwrap!(core1_task(spi, iv))));
         },
     );
 
     let executor0 = EXECUTOR0.init(Executor::new());
-    executor0.run(|spawner| unwrap!(spawner.spawn(core0_task())));
+    executor0.run(|spawner| spawner.spawn(unwrap!(core0_task())));
 }
 
 #[embassy_executor::task]

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -6,19 +6,19 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Change stm32l072cz to your chip name, if necessary. Also change it in .cargo/config.toml
-embassy-stm32 = { version = "0.2.0", features = [
+embassy-stm32 = { version = "0.6.0", features = [
     "defmt",
     "stm32l072cz",
     "time-driver-any",
     "exti",
     "memory-x",
 ] }
-embassy-executor = { version = "0.7.0", features = [
-    "arch-cortex-m",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-cortex-m",
     "executor-thread",
     "defmt",
 ] }
-embassy-time = { version = "0.4.0", features = [
+embassy-time = { version = "0.5.0", features = [
     "defmt",
     "defmt-timestamp-uptime",
 ] }

--- a/examples/stm32l0/src/bin/lora_cad.rs
+++ b/examples/stm32l0/src/bin/lora_cad.rs
@@ -5,10 +5,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
-use embassy_stm32::spi;
+use embassy_stm32::exti::{self, ExtiInput};
+use embassy_stm32::gpio::{Level, Output, Pull, Speed};
 use embassy_stm32::time::khz;
+use embassy_stm32::{bind_interrupts, dma, peripherals, spi};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
@@ -16,6 +16,11 @@ use lora_phy::sx127x::{Sx1276, Sx127x};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx127x};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    EXTI4_15 => exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI4_15>;
+    DMA1_CHANNEL2_3 => dma::InterruptHandler<peripherals::DMA1_CH2>, dma::InterruptHandler<peripherals::DMA1_CH3>;
+});
 
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
 
@@ -26,13 +31,13 @@ async fn main(_spawner: Spawner) {
     config.rcc.sys = embassy_stm32::rcc::Sysclk::HSI;
     let p = embassy_stm32::init(config);
 
-    let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
-    let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);
-    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up);
+    let nss = Output::new(p.PA15, Level::High, Speed::Low);
+    let reset = Output::new(p.PC0, Level::High, Speed::Low);
+    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up, Irqs);
 
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);
-    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
+    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, Irqs, spi_config);
     let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx127x::Config {

--- a/examples/stm32l0/src/bin/lora_get_rssi.rs
+++ b/examples/stm32l0/src/bin/lora_get_rssi.rs
@@ -5,10 +5,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
-use embassy_stm32::spi;
+use embassy_stm32::exti::{self, ExtiInput};
+use embassy_stm32::gpio::{Level, Output, Pull, Speed};
 use embassy_stm32::time::khz;
+use embassy_stm32::{bind_interrupts, dma, peripherals, spi};
 use embassy_time::{Delay, Duration, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
@@ -16,6 +16,11 @@ use lora_phy::sx127x::{Sx1276, Sx127x};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx127x};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    EXTI4_15 => exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI4_15>;
+    DMA1_CHANNEL2_3 => dma::InterruptHandler<peripherals::DMA1_CH2>, dma::InterruptHandler<peripherals::DMA1_CH3>;
+});
 
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
 
@@ -26,13 +31,13 @@ async fn main(_spawner: Spawner) {
     config.rcc.sys = embassy_stm32::rcc::Sysclk::HSI;
     let p = embassy_stm32::init(config);
 
-    let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
-    let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);
-    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up);
+    let nss = Output::new(p.PA15, Level::High, Speed::Low);
+    let reset = Output::new(p.PC0, Level::High, Speed::Low);
+    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up, Irqs);
 
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);
-    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
+    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, Irqs, spi_config);
     let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx127x::Config {

--- a/examples/stm32l0/src/bin/lora_lorawan.rs
+++ b/examples/stm32l0/src/bin/lora_lorawan.rs
@@ -5,11 +5,11 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
+use embassy_stm32::exti::{self, ExtiInput};
+use embassy_stm32::gpio::{Level, Output, Pull, Speed};
 use embassy_stm32::rng::Rng;
 use embassy_stm32::time::khz;
-use embassy_stm32::{bind_interrupts, peripherals, rng, spi};
+use embassy_stm32::{bind_interrupts, dma, peripherals, rng, spi};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
@@ -22,6 +22,8 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     RNG_LPUART1 => rng::InterruptHandler<peripherals::RNG>;
+    EXTI4_15 => exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI4_15>;
+    DMA1_CHANNEL2_3 => dma::InterruptHandler<peripherals::DMA1_CH2>, dma::InterruptHandler<peripherals::DMA1_CH3>;
 });
 
 // warning: set these appropriately for the region
@@ -35,13 +37,13 @@ async fn main(_spawner: Spawner) {
     config.rcc.sys = embassy_stm32::rcc::Sysclk::HSI;
     let p = embassy_stm32::init(config);
 
-    let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
-    let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);
-    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up);
+    let nss = Output::new(p.PA15, Level::High, Speed::Low);
+    let reset = Output::new(p.PC0, Level::High, Speed::Low);
+    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up, Irqs);
 
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);
-    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
+    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, Irqs, spi_config);
     let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx127x::Config {

--- a/examples/stm32l0/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_receive.rs
@@ -5,10 +5,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
-use embassy_stm32::spi;
+use embassy_stm32::exti::{self, ExtiInput};
+use embassy_stm32::gpio::{Level, Output, Pull, Speed};
 use embassy_stm32::time::khz;
+use embassy_stm32::{bind_interrupts, dma, peripherals, spi};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
@@ -16,6 +16,11 @@ use lora_phy::sx127x::{Sx1276, Sx127x};
 use lora_phy::{mod_params::*, sx127x};
 use lora_phy::{LoRa, RxMode};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    EXTI4_15 => exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI4_15>;
+    DMA1_CHANNEL2_3 => dma::InterruptHandler<peripherals::DMA1_CH2>, dma::InterruptHandler<peripherals::DMA1_CH3>;
+});
 
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
 
@@ -26,13 +31,13 @@ async fn main(_spawner: Spawner) {
     config.rcc.sys = embassy_stm32::rcc::Sysclk::HSI;
     let p = embassy_stm32::init(config);
 
-    let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
-    let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);
-    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up);
+    let nss = Output::new(p.PA15, Level::High, Speed::Low);
+    let reset = Output::new(p.PC0, Level::High, Speed::Low);
+    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up, Irqs);
 
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);
-    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
+    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, Irqs, spi_config);
     let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx127x::Config {

--- a/examples/stm32l0/src/bin/lora_p2p_send.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_send.rs
@@ -5,10 +5,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
-use embassy_stm32::spi;
+use embassy_stm32::exti::{self, ExtiInput};
+use embassy_stm32::gpio::{Level, Output, Pull, Speed};
 use embassy_stm32::time::khz;
+use embassy_stm32::{bind_interrupts, dma, peripherals, spi};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use lora_phy::iv::GenericSx127xInterfaceVariant;
@@ -16,6 +16,11 @@ use lora_phy::sx127x::{Sx1276, Sx127x};
 use lora_phy::LoRa;
 use lora_phy::{mod_params::*, sx127x};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    EXTI4_15 => exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI4_15>;
+    DMA1_CHANNEL2_3 => dma::InterruptHandler<peripherals::DMA1_CH2>, dma::InterruptHandler<peripherals::DMA1_CH3>;
+});
 
 const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriately for the region
 
@@ -26,13 +31,13 @@ async fn main(_spawner: Spawner) {
     config.rcc.sys = embassy_stm32::rcc::Sysclk::HSI;
     let p = embassy_stm32::init(config);
 
-    let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
-    let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);
-    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up);
+    let nss = Output::new(p.PA15, Level::High, Speed::Low);
+    let reset = Output::new(p.PC0, Level::High, Speed::Low);
+    let irq = ExtiInput::new(p.PB4, p.EXTI4, Pull::Up, Irqs);
 
     let mut spi_config = spi::Config::default();
     spi_config.frequency = khz(200);
-    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
+    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, Irqs, spi_config);
     let spi = ExclusiveDevice::new(spi, nss, Delay).unwrap();
 
     let config = sx127x::Config {

--- a/examples/stm32wba/Cargo.toml
+++ b/examples/stm32wba/Cargo.toml
@@ -7,15 +7,15 @@ publish = false
 
 [dependencies]
 # STM32WBA65RI with LR1110 external radio
-embassy-stm32 = { version = "0.5.0", features = [
+embassy-stm32 = { version = "0.6.0", features = [
     "defmt",
     "stm32wba65ri",
     "time-driver-any",
     "memory-x",
     "exti",
 ] }
-embassy-executor = { version = "0.9.0", features = [
-    "arch-cortex-m",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-cortex-m",
     "executor-thread",
     "defmt",
 ] }
@@ -24,7 +24,7 @@ embassy-time = { version = "0.5.0", features = [
     "defmt-timestamp-uptime",
     "tick-hz-32_768",
 ] }
-embassy-sync = { version = "0.7.2", features = ["defmt"] }
+embassy-sync = { version = "0.8.0", features = ["defmt"] }
 embassy-futures = { version = "0.1.2" }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio", "defmt-03"] }

--- a/examples/stm32wba/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wba/src/bin/lora_p2p_receive.rs
@@ -27,16 +27,18 @@ use embassy_stm32::time::Hertz;
 use embassy_stm32::{Config, bind_interrupts};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
+use lora_phy::LoRa;
 use lora_phy::iv::GenericLr1110InterfaceVariant;
 use lora_phy::lr1110::{self as lr1110_module, PaSelection, TcxoCtrlVoltage};
 use lora_phy::mod_params::{Bandwidth, CodingRate, RxMode, SpreadingFactor};
-use lora_phy::LoRa;
 use {defmt_rtt as _, panic_probe as _};
 
 // Bind EXTI interrupts for PB13 (BUSY) and PB14 (DIO1)
 bind_interrupts!(struct Irqs {
     EXTI13 => embassy_stm32::exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI13>;
     EXTI14 => embassy_stm32::exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI14>;
+    GPDMA1_CHANNEL0 => embassy_stm32::dma::InterruptHandler<embassy_stm32::peripherals::GPDMA1_CH0>;
+    GPDMA1_CHANNEL1 => embassy_stm32::dma::InterruptHandler<embassy_stm32::peripherals::GPDMA1_CH1>;
 });
 
 const RF_FREQUENCY: u32 = 915_000_000;
@@ -80,6 +82,7 @@ async fn main(_spawner: Spawner) {
         p.PA9,  // MISO
         p.GPDMA1_CH0,
         p.GPDMA1_CH1,
+        Irqs,
         spi_config,
     );
 

--- a/examples/stm32wba/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wba/src/bin/lora_p2p_send.rs
@@ -27,16 +27,18 @@ use embassy_stm32::time::Hertz;
 use embassy_stm32::{Config, bind_interrupts};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
+use lora_phy::LoRa;
 use lora_phy::iv::GenericLr1110InterfaceVariant;
 use lora_phy::lr1110::{self as lr1110_module, PaSelection, TcxoCtrlVoltage};
 use lora_phy::mod_params::{Bandwidth, CodingRate, SpreadingFactor};
-use lora_phy::LoRa;
 use {defmt_rtt as _, panic_probe as _};
 
 // Bind EXTI interrupts for PB13 (BUSY) and PB14 (DIO1)
 bind_interrupts!(struct Irqs {
     EXTI13 => embassy_stm32::exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI13>;
     EXTI14 => embassy_stm32::exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI14>;
+    GPDMA1_CHANNEL0 => embassy_stm32::dma::InterruptHandler<embassy_stm32::peripherals::GPDMA1_CH0>;
+    GPDMA1_CHANNEL1 => embassy_stm32::dma::InterruptHandler<embassy_stm32::peripherals::GPDMA1_CH1>;
 });
 
 const RF_FREQUENCY: u32 = 915_000_000;
@@ -82,6 +84,7 @@ async fn main(_spawner: Spawner) {
         p.PA9,  // MISO
         p.GPDMA1_CH0,
         p.GPDMA1_CH1,
+        Irqs,
         spi_config,
     );
 

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Change stm32wle5jc to your chip name, if necessary. Also update .cargo/config.toml
-embassy-stm32 = { version = "0.2.0", features = [
+embassy-stm32 = { version = "0.6.0", features = [
     "defmt",
     "stm32wle5jc",
     "time-driver-any",
@@ -15,16 +15,16 @@ embassy-stm32 = { version = "0.2.0", features = [
     "exti",
     "chrono",
 ] }
-embassy-executor = { version = "0.7.0", features = [
-    "arch-cortex-m",
+embassy-executor = { version = "0.10.0", features = [
+    "platform-cortex-m",
     "executor-thread",
     "defmt",
 ] }
-embassy-time = { version = "0.4.0", features = [
+embassy-time = { version = "0.5.0", features = [
     "defmt",
     "defmt-timestamp-uptime",
 ] }
-embassy-sync = { version = "0.6", features = ["defmt"] }
+embassy-sync = { version = "0.8", features = ["defmt"] }
 embassy-futures = { version = "0", features = ["defmt"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio", "defmt-03"] }

--- a/examples/stm32wl/src/bin/lora_lorawan.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan.rs
@@ -8,11 +8,11 @@ mod iv;
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_stm32::gpio::{Level, Output, Pin, Speed};
+use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::rng::{self, Rng};
 use embassy_stm32::spi::Spi;
 use embassy_stm32::time::Hertz;
-use embassy_stm32::{bind_interrupts, peripherals};
+use embassy_stm32::{bind_interrupts, dma, peripherals};
 use embassy_time::Delay;
 use lora_phy::lorawan_radio::LorawanRadio;
 use lora_phy::sx126x::{self, Stm32wl, Sx126x, TcxoCtrlVoltage};
@@ -40,6 +40,8 @@ const DEFAULT_APPKEY: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 bind_interrupts!(struct Irqs{
     SUBGHZ_RADIO => InterruptHandler;
     RNG => rng::InterruptHandler<peripherals::RNG>;
+    DMA1_CHANNEL1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+    DMA1_CHANNEL2 => dma::InterruptHandler<peripherals::DMA1_CH2>;
 });
 
 #[embassy_executor::main]
@@ -64,11 +66,11 @@ async fn main(_spawner: Spawner) {
     }
     let p = embassy_stm32::init(config);
 
-    let ctrl1 = Output::new(p.PC4.degrade(), Level::Low, Speed::High);
-    let ctrl2 = Output::new(p.PC5.degrade(), Level::Low, Speed::High);
-    let ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
+    let ctrl1 = Output::new(p.PC4, Level::Low, Speed::High);
+    let ctrl2 = Output::new(p.PC5, Level::Low, Speed::High);
+    let ctrl3 = Output::new(p.PC3, Level::High, Speed::High);
 
-    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, Irqs);
     let spi = SubghzSpiDevice(spi);
     let use_high_power_pa = true;
     let config = sx126x::Config {

--- a/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan_class_c.rs
@@ -10,13 +10,13 @@ use defmt::info;
 
 use embassy_executor::Spawner;
 use embassy_futures::select::{select, Either};
-use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::gpio::{Level, Output, Pin, Pull, Speed};
+use embassy_stm32::exti::{self, ExtiInput};
+use embassy_stm32::gpio::{Level, Output, Pull, Speed};
 use embassy_stm32::mode::Async;
 use embassy_stm32::rng::{self, Rng};
-use embassy_stm32::spi::Spi;
+use embassy_stm32::spi::{mode::Master, Spi};
 use embassy_stm32::time::Hertz;
-use embassy_stm32::{bind_interrupts, peripherals};
+use embassy_stm32::{bind_interrupts, dma, peripherals};
 use embassy_sync::{
     blocking_mutex::raw::ThreadModeRawMutex,
     channel::{Channel, Receiver, Sender},
@@ -51,6 +51,9 @@ const DEFAULT_APPKEY: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 bind_interrupts!(struct Irqs{
     SUBGHZ_RADIO => InterruptHandler;
     RNG => rng::InterruptHandler<peripherals::RNG>;
+    DMA1_CHANNEL1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+    DMA1_CHANNEL2 => dma::InterruptHandler<peripherals::DMA1_CH2>;
+    EXTI0 => exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI0>;
 });
 
 static CHANNEL: Channel<ThreadModeRawMutex, ButtonState, 3> = Channel::new();
@@ -77,11 +80,11 @@ async fn main(spawner: Spawner) {
     }
     let p = embassy_stm32::init(config);
 
-    let ctrl1 = Output::new(p.PC4.degrade(), Level::Low, Speed::High);
-    let ctrl2 = Output::new(p.PC5.degrade(), Level::Low, Speed::High);
-    let ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
+    let ctrl1 = Output::new(p.PC4, Level::Low, Speed::High);
+    let ctrl2 = Output::new(p.PC5, Level::Low, Speed::High);
+    let ctrl3 = Output::new(p.PC3, Level::High, Speed::High);
 
-    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, Irqs);
     let spi = SubghzSpiDevice(spi);
     let use_high_power_pa = true;
     let config = sx126x::Config {
@@ -93,14 +96,14 @@ async fn main(spawner: Spawner) {
     let iv = Stm32wlInterfaceVariant::new(Irqs, use_high_power_pa, Some(ctrl1), Some(ctrl2), Some(ctrl3)).unwrap();
     let lora = LoRa::new(Sx126x::new(spi, iv, config), false, Delay).await.unwrap();
 
-    let _lora_task = spawner.spawn(lora_task(lora, Rng::new(p.RNG, Irqs), CHANNEL.receiver()));
+    spawner.spawn(lora_task(lora, Rng::new(p.RNG, Irqs), CHANNEL.receiver()).unwrap());
 
-    let button = ExtiInput::new(p.PA0, p.EXTI0, Pull::Up);
-    let _button_task = spawner.spawn(button_task(button, CHANNEL.sender()));
+    let button = ExtiInput::new(p.PA0, p.EXTI0, Pull::Up, Irqs);
+    spawner.spawn(button_task(button, CHANNEL.sender()).unwrap());
 }
 
 type Stm32wlLoRa<'d> =
-    LoRa<Sx126x<iv::SubghzSpiDevice<Spi<'d, Async>>, Stm32wlInterfaceVariant<Output<'d>>, Stm32wl>, Delay>;
+    LoRa<Sx126x<iv::SubghzSpiDevice<Spi<'d, Async, Master>>, Stm32wlInterfaceVariant<Output<'d>>, Stm32wl>, Delay>;
 
 #[embassy_executor::task]
 async fn lora_task(
@@ -182,7 +185,7 @@ enum ButtonState {
 }
 
 #[embassy_executor::task]
-async fn button_task(mut button: ExtiInput<'static>, tx: Sender<'static, ThreadModeRawMutex, ButtonState, 3>) {
+async fn button_task(mut button: ExtiInput<'static, Async>, tx: Sender<'static, ThreadModeRawMutex, ButtonState, 3>) {
     info!("Press the USER button...");
     loop {
         button.wait_for_falling_edge().await;

--- a/examples/stm32wl/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_receive.rs
@@ -8,10 +8,10 @@ mod iv;
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_stm32::bind_interrupts;
-use embassy_stm32::gpio::{Level, Output, Pin, Speed};
+use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::spi::Spi;
 use embassy_stm32::time::Hertz;
+use embassy_stm32::{bind_interrupts, dma, peripherals};
 use embassy_time::{Delay, Timer};
 use lora_phy::sx126x::{Stm32wl, Sx126x, TcxoCtrlVoltage};
 use lora_phy::{mod_params::*, sx126x};
@@ -24,6 +24,8 @@ const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriatel
 
 bind_interrupts!(struct Irqs{
     SUBGHZ_RADIO => InterruptHandler;
+    DMA1_CHANNEL1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+    DMA1_CHANNEL2 => dma::InterruptHandler<peripherals::DMA1_CH2>;
 });
 
 #[embassy_executor::main]
@@ -48,11 +50,11 @@ async fn main(_spawner: Spawner) {
     }
     let p = embassy_stm32::init(config);
 
-    let ctrl1 = Output::new(p.PC4.degrade(), Level::Low, Speed::High);
-    let ctrl2 = Output::new(p.PC5.degrade(), Level::Low, Speed::High);
-    let ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
+    let ctrl1 = Output::new(p.PC4, Level::Low, Speed::High);
+    let ctrl2 = Output::new(p.PC5, Level::Low, Speed::High);
+    let ctrl3 = Output::new(p.PC3, Level::High, Speed::High);
 
-    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, Irqs);
     let spi = SubghzSpiDevice(spi);
     let use_high_power_pa = true;
     let config = sx126x::Config {

--- a/examples/stm32wl/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_send.rs
@@ -8,10 +8,10 @@ mod iv;
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_stm32::bind_interrupts;
-use embassy_stm32::gpio::{Level, Output, Pin, Speed};
+use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::spi::Spi;
 use embassy_stm32::time::Hertz;
+use embassy_stm32::{bind_interrupts, dma, peripherals};
 use embassy_time::Delay;
 use lora_phy::sx126x::{Stm32wl, Sx126x, TcxoCtrlVoltage};
 use lora_phy::LoRa;
@@ -24,6 +24,8 @@ const LORA_FREQUENCY_IN_HZ: u32 = 903_900_000; // warning: set this appropriatel
 
 bind_interrupts!(struct Irqs{
     SUBGHZ_RADIO => InterruptHandler;
+    DMA1_CHANNEL1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+    DMA1_CHANNEL2 => dma::InterruptHandler<peripherals::DMA1_CH2>;
 });
 
 #[embassy_executor::main]
@@ -48,11 +50,11 @@ async fn main(_spawner: Spawner) {
     }
     let p = embassy_stm32::init(config);
 
-    let ctrl1 = Output::new(p.PC4.degrade(), Level::Low, Speed::High);
-    let ctrl2 = Output::new(p.PC5.degrade(), Level::Low, Speed::High);
-    let ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
+    let ctrl1 = Output::new(p.PC4, Level::Low, Speed::High);
+    let ctrl2 = Output::new(p.PC5, Level::Low, Speed::High);
+    let ctrl3 = Output::new(p.PC3, Level::High, Speed::High);
 
-    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, Irqs);
     let spi = SubghzSpiDevice(spi);
     let use_high_power_pa = true;
     let config = sx126x::Config {

--- a/examples/stm32wle5cx/Cargo.toml
+++ b/examples/stm32wle5cx/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Change stm32wle5cc to your chip name, if necessary. Also update .cargo/config.toml
-embassy-stm32 = { version = "0.5.0", features = [
+embassy-stm32 = { version = "0.6.0", features = [
   "defmt",
   "stm32wle5cc",
   "time-driver-any",
@@ -15,8 +15,8 @@ embassy-stm32 = { version = "0.5.0", features = [
   "exti",
   "chrono",
 ] }
-embassy-executor = { version = "0.9.1", features = [
-  "arch-cortex-m",
+embassy-executor = { version = "0.10.0", features = [
+  "platform-cortex-m",
   "executor-thread",
   "defmt",
 ] }
@@ -24,7 +24,7 @@ embassy-time = { version = "0.5.0", features = [
   "defmt",
   "defmt-timestamp-uptime",
 ] }
-embassy-sync = { version = "0.7.2", features = ["defmt"] }
+embassy-sync = { version = "0.8.0", features = ["defmt"] }
 embassy-futures = { version = "0", features = ["defmt"] }
 
 lora-phy = { path = "../../lora-phy", features = ["lorawan-radio", "defmt-03"] }

--- a/examples/stm32wle5cx/src/bin/lora_lorawan.rs
+++ b/examples/stm32wle5cx/src/bin/lora_lorawan.rs
@@ -12,7 +12,7 @@ use embassy_stm32::gpio::{Level, Output, Pin, Speed};
 use embassy_stm32::rng::{self, Rng};
 use embassy_stm32::spi::Spi;
 use embassy_stm32::time::Hertz;
-use embassy_stm32::{bind_interrupts, peripherals};
+use embassy_stm32::{bind_interrupts, dma, peripherals};
 use embassy_time::Delay;
 use lora_phy::LoRa;
 use lora_phy::lorawan_radio::LorawanRadio;
@@ -40,6 +40,8 @@ const DEFAULT_APPKEY: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 bind_interrupts!(struct Irqs{
     SUBGHZ_RADIO => InterruptHandler;
     RNG => rng::InterruptHandler<peripherals::RNG>;
+    DMA1_CHANNEL1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+    DMA1_CHANNEL2 => dma::InterruptHandler<peripherals::DMA1_CH2>;
 });
 
 #[embassy_executor::main]
@@ -59,7 +61,7 @@ async fn main(_spawner: Spawner) {
     let tx_pin = Output::new(p.PC13, Level::Low, Speed::VeryHigh);
     let rx_pin = Output::new(p.PB8, Level::Low, Speed::VeryHigh);
 
-    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, Irqs);
     let spi = SubghzSpiDevice(spi);
     let use_high_power_pa = true;
     let config = sx126x::Config {

--- a/examples/stm32wle5cx/src/bin/lora_lorawan_class_c.rs
+++ b/examples/stm32wle5cx/src/bin/lora_lorawan_class_c.rs
@@ -15,7 +15,7 @@ use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::mode::Async;
 use embassy_stm32::rng::{self, Rng};
 use embassy_stm32::spi::{Spi, mode::Master};
-use embassy_stm32::{bind_interrupts, peripherals};
+use embassy_stm32::{bind_interrupts, dma, peripherals};
 use embassy_sync::{
     blocking_mutex::raw::ThreadModeRawMutex,
     channel::{Channel, Receiver, Sender},
@@ -49,6 +49,8 @@ const DEFAULT_APPKEY: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 bind_interrupts!(struct Irqs{
     SUBGHZ_RADIO => InterruptHandler;
     RNG => rng::InterruptHandler<peripherals::RNG>;
+    DMA1_CHANNEL1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+    DMA1_CHANNEL2 => dma::InterruptHandler<peripherals::DMA1_CH2>;
 });
 
 static CHANNEL: Channel<ThreadModeRawMutex, ButtonState, 3> = Channel::new();
@@ -70,7 +72,7 @@ async fn main(spawner: Spawner) {
     let tx_pin = Output::new(p.PC13, Level::Low, Speed::VeryHigh);
     let rx_pin = Output::new(p.PB8, Level::Low, Speed::VeryHigh);
 
-    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, Irqs);
     let spi = SubghzSpiDevice(spi);
     let use_high_power_pa = true;
     let config = sx126x::Config {
@@ -81,7 +83,7 @@ async fn main(spawner: Spawner) {
     };
     let iv = Stm32wlInterfaceVariant::new(Irqs, use_high_power_pa, Some(rx_pin), Some(tx_pin), None).unwrap();
     let lora = LoRa::new(Sx126x::new(spi, iv, config), true, Delay).await.unwrap();
-    let _lora_task = spawner.spawn(lora_task(lora, Rng::new(p.RNG, Irqs), CHANNEL.receiver()));
+    spawner.spawn(lora_task(lora, Rng::new(p.RNG, Irqs), CHANNEL.receiver()).unwrap());
 
     // let _button_task = spawner.spawn(button_task(button, CHANNEL.sender()));
 }
@@ -166,7 +168,7 @@ enum ButtonState {
 }
 
 #[embassy_executor::task]
-async fn button_task(mut button: ExtiInput<'static>, tx: Sender<'static, ThreadModeRawMutex, ButtonState, 3>) {
+async fn button_task(mut button: ExtiInput<'static, Async>, tx: Sender<'static, ThreadModeRawMutex, ButtonState, 3>) {
     info!("Press the USER button...");
     loop {
         button.wait_for_falling_edge().await;

--- a/examples/stm32wle5cx/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wle5cx/src/bin/lora_p2p_receive.rs
@@ -9,8 +9,9 @@ mod iv;
 use defmt::{error, info};
 use embassy_executor::Spawner;
 use embassy_stm32::{
-    Config, bind_interrupts,
+    Config, bind_interrupts, dma,
     gpio::{Level, Output, Speed},
+    peripherals,
     rcc::{MSIRange, Sysclk, mux},
     spi::Spi,
 };
@@ -26,6 +27,8 @@ const LORA_FREQUENCY_IN_HZ: u32 = 868_000_000; // warning: set this appropriatel
 
 bind_interrupts!(struct Irqs{
     SUBGHZ_RADIO => InterruptHandler;
+    DMA1_CHANNEL1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+    DMA1_CHANNEL2 => dma::InterruptHandler<peripherals::DMA1_CH2>;
 });
 
 #[embassy_executor::main]
@@ -43,7 +46,7 @@ async fn main(_spawner: Spawner) {
     let tx_pin = Output::new(p.PC13, Level::Low, Speed::VeryHigh);
     let rx_pin = Output::new(p.PB8, Level::Low, Speed::VeryHigh);
 
-    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, Irqs);
     let spi = SubghzSpiDevice(spi);
     let use_high_power_pa = true;
     let config = sx126x::Config {

--- a/examples/stm32wle5cx/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wle5cx/src/bin/lora_p2p_send.rs
@@ -8,9 +8,9 @@ mod iv;
 
 use defmt::{error, info};
 use embassy_executor::Spawner;
-use embassy_stm32::bind_interrupts;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::spi::Spi;
+use embassy_stm32::{bind_interrupts, dma, peripherals};
 use embassy_time::{Delay, Timer};
 use lora_phy::LoRa;
 use lora_phy::sx126x::{Stm32wl, Sx126x};
@@ -23,6 +23,8 @@ const LORA_FREQUENCY_IN_HZ: u32 = 868_000_000; // warning: set this appropriatel
 
 bind_interrupts!(struct Irqs{
     SUBGHZ_RADIO => InterruptHandler;
+    DMA1_CHANNEL1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+    DMA1_CHANNEL2 => dma::InterruptHandler<peripherals::DMA1_CH2>;
 });
 
 #[embassy_executor::main]
@@ -41,7 +43,7 @@ async fn main(_spawner: Spawner) {
     let tx_pin = Output::new(p.PC13, Level::Low, Speed::VeryHigh);
     let rx_pin = Output::new(p.PB8, Level::Low, Speed::VeryHigh);
 
-    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, Irqs);
     let spi = SubghzSpiDevice(spi);
     let use_high_power_pa = true;
     let config = sx126x::Config {


### PR DESCRIPTION
Moves all six examples onto the current embassy release set. The embassy crates are version locked to each other, so this cluster has to move as one:

- embassy-executor 0.7 / 0.9 -> 0.10 (the arch-cortex-m feature is now platform-cortex-m)
- embassy-time 0.4 -> 0.5
- embassy-sync 0.6 / 0.7 -> 0.8
- embassy-stm32 0.2 / 0.5 -> 0.6 (stm32l0, stm32wl, stm32wba, stm32wle5cx)
- embassy-nrf 0.3 -> 0.11 (nrf52840)
- embassy-rp 0.3 -> 0.10 (rp)

lorawan-device already allows embassy-time ">=0.3, <0.6" so no library changes are needed.

Code changes the new APIs required:

- SPI and ExtiInput constructors now take an interrupt binding, so the bind_interrupts! blocks gained DMA (and where relevant EXTI) handlers and the constructors take Irqs.
- Pin::degrade() is gone; constructors type erase pins themselves.
- stm32wl class_c: Spi gained a CommunicationMode generic and ExtiInput a mode generic; task functions returning SpawnToken are now spawned as spawner.spawn(task(...).unwrap()).
- nrf52840: Rng is now generic over mode (Rng<'static, Async>); embassy-nrf 0.11 still implements rand_core 0.6 so the rand usage is unchanged.
- rp multicore: unwrap moved inside spawn per the new SpawnToken signature.

Verified with cargo build --release in all six example crates, and checked with cargo tree that each resolves to exactly one version of embassy-executor, embassy-time, embassy-sync and embassy-time-driver. The esp32 examples are untouched (not built in CI, and they pin their own set).