### PR TITLE
lorawan-encoding: fix TXParamSetupReq dwell time bit handling and validate DutyCycleReq max duty cycle

### DIFF
--- a/lorawan-encoding/src/maccommandcreator.rs
+++ b/lorawan-encoding/src/maccommandcreator.rs
@@ -8,6 +8,7 @@ pub enum Error {
     InvalidTxPower,
     MarginOutOfRange,
     DelayOutOfRange,
+    MaxDutyCycleOutOfRange,
     MaxEirpOutOfRange,
     NanoSecondsOutOfRange,
     BufferTooShort,
@@ -207,7 +208,11 @@ impl DutyCycleReqCreator {
     /// * max_duty_cycle - the value used to determine the aggregated duty cycle
     ///   using the formula `1 / (2 ** max_duty_cycle)`.
     pub fn set_max_duty_cycle(&mut self, max_duty_cycle: u8) -> Result<&mut Self, Error> {
-        self.data[1] = max_duty_cycle;
+        if max_duty_cycle > 0x0f {
+            return Err(Error::MaxDutyCycleOutOfRange);
+        }
+        self.data[1] &= 0xf0;
+        self.data[1] |= max_duty_cycle;
 
         Ok(self)
     }
@@ -501,14 +506,27 @@ pub use crate::maccommands::RXTimingSetupAnsCreator;
 pub use crate::maccommands::TXParamSetupReqCreator;
 
 impl TXParamSetupReqCreator {
-    pub fn set_downlink_dwell_time(&mut self) -> &mut Self {
-        self.data[1] &= 0xfe;
-        self.data[1] |= (1 << 5) as u8;
+    /// Sets the DownlinkDwellTime bit of the TXParamSetupReq to the provided value.
+    ///
+    /// # Argument
+    ///
+    /// * dwell_time - true when the downlink dwell time limit is 400 ms, false when
+    ///   there is no limit.
+    pub fn set_downlink_dwell_time(&mut self, dwell_time: bool) -> &mut Self {
+        self.data[1] &= !(1 << 5);
+        self.data[1] |= (dwell_time as u8) << 5;
         self
     }
-    pub fn set_uplink_dwell_time(&mut self) -> &mut Self {
-        self.data[1] &= 0xfe;
-        self.data[1] |= (1 << 4) as u8;
+
+    /// Sets the UplinkDwellTime bit of the TXParamSetupReq to the provided value.
+    ///
+    /// # Argument
+    ///
+    /// * dwell_time - true when the uplink dwell time limit is 400 ms, false when
+    ///   there is no limit.
+    pub fn set_uplink_dwell_time(&mut self, dwell_time: bool) -> &mut Self {
+        self.data[1] &= !(1 << 4);
+        self.data[1] |= (dwell_time as u8) << 4;
         self
     }
     pub fn set_max_eirp(&mut self, max_eirp: u8) -> Result<&mut Self, Error> {

--- a/lorawan-encoding/tests/maccommandcreator.rs
+++ b/lorawan-encoding/tests/maccommandcreator.rs
@@ -58,6 +58,13 @@ fn test_duty_cycle_req_creator() {
 }
 
 #[test]
+fn test_duty_cycle_req_creator_bad_max_duty_cycle() {
+    // MaxDutyCycle is a 4 bit field; bits 7:4 are RFU
+    let mut creator = DutyCycleReqCreator::new();
+    assert!(creator.set_max_duty_cycle(0x10).is_err());
+}
+
+#[test]
 fn test_duty_cycle_ans_creator() {
     let creator = DutyCycleAnsCreator::new();
     let res = creator.build();
@@ -148,11 +155,34 @@ fn test_rx_timing_setup_req_creator_bad_delay() {
 #[test]
 fn test_tx_param_setup_req_creator() {
     let mut creator = TXParamSetupReqCreator::new();
-    creator.set_downlink_dwell_time();
-    creator.set_uplink_dwell_time().set_uplink_dwell_time();
+    creator.set_downlink_dwell_time(true);
+    creator.set_uplink_dwell_time(true).set_uplink_dwell_time(true);
     creator.set_max_eirp(3).unwrap();
     let res = creator.build();
     assert_eq!(res, [TXParamSetupReqPayload::cid(), 0b110011]);
+}
+
+#[test]
+fn test_tx_param_setup_req_creator_dwell_time_preserves_max_eirp() {
+    // setting the dwell time bits must not touch the MaxEIRP field, in any call order
+    let mut creator = TXParamSetupReqCreator::new();
+    creator.set_max_eirp(3).unwrap();
+    creator.set_downlink_dwell_time(true);
+    creator.set_uplink_dwell_time(true);
+    let res = creator.build();
+    assert_eq!(res, [TXParamSetupReqPayload::cid(), 0b110011]);
+}
+
+#[test]
+fn test_tx_param_setup_req_creator_clear_dwell_time() {
+    let mut creator = TXParamSetupReqCreator::new();
+    creator.set_downlink_dwell_time(true);
+    creator.set_uplink_dwell_time(true);
+    creator.set_max_eirp(5).unwrap();
+    creator.set_downlink_dwell_time(false);
+    creator.set_uplink_dwell_time(false);
+    let res = creator.build();
+    assert_eq!(res, [TXParamSetupReqPayload::cid(), 0b000101]);
 }
 
 #[test]


### PR DESCRIPTION
Two fixes in the MAC command creators:

**TXParamSetupReqCreator dwell time setters wrote the wrong bits.** Both setters cleared bit 0 (the low bit of the MaxEIRP field) instead of their own bit before setting it. Calling them after `set_max_eirp` corrupted the EIRP value, and once set, neither dwell bit could be cleared. The existing test only passed because it happened to call `set_max_eirp` last, which repaired the damage.

The setters now take a `bool` and mask only their own bit, matching the layout in TS001 (EIRP_DwellTime: bit 5 DownlinkDwellTime, bit 4 UplinkDwellTime, bits 3:0 MaxEIRP) and the parser side, which already reads bits 5 and 4. This is a signature change: `set_downlink_dwell_time()` becomes `set_downlink_dwell_time(bool)`, same for uplink. That matches the style of the other bool setters (`set_channel_mask_ack` etc.) and makes the bits clearable.

**DutyCycleReqCreator::set_max_duty_cycle accepted any byte.** It documents returning a `Result` and MaxDutyCycle is a 4 bit field (bits 7:4 are RFU), but the old code wrote the full byte unchecked. It now rejects values above 0x0f with a new `MaxDutyCycleOutOfRange` error variant.

New tests cover call order independence, clearing the dwell bits, and the out of range rejection. The first and last of those fail against the previous code.