### PR TITLE
lorawan-device: fix LinkADRReq ChMaskCntl=5 handling for fixed channel plans

### DIFF
--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -123,17 +123,19 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
                 channel_mask.set_bank(base_index + 1, ch_mask.get_index(1));
             }
             5 => {
-                let ch_mask: u16 =
-                    ch_mask.get_index(0) as u16 | ((ch_mask.get_index(1) as u16) << 8);
-                channel_mask.set_bank(0, ((ch_mask & 0b1) * 0xFF) as u8);
-                channel_mask.set_bank(1, ((ch_mask & 0b10) * 0xFF) as u8);
-                channel_mask.set_bank(2, ((ch_mask & 0b100) * 0xFF) as u8);
-                channel_mask.set_bank(3, ((ch_mask & 0b1000) * 0xFF) as u8);
-                channel_mask.set_bank(4, ((ch_mask & 0b10000) * 0xFF) as u8);
-                channel_mask.set_bank(5, ((ch_mask & 0b100000) * 0xFF) as u8);
-                channel_mask.set_bank(6, ((ch_mask & 0b1000000) * 0xFF) as u8);
-                channel_mask.set_bank(7, ((ch_mask & 0b10000000) * 0xFF) as u8);
-                channel_mask.set_bank(8, ((ch_mask & 0b100000000) * 0xFF) as u8);
+                // Each of the 8 LSBs controls a bank of 8 125 kHz channels plus the
+                // paired 500 kHz channel: bit i -> channels [8i, 8i+7] and 64+i.
+                // The 8 MSBs are RFU. (RP002 2.5.5, Table 19)
+                let blocks = ch_mask.get_index(0);
+                for i in 0..8 {
+                    let bank = if blocks & (1 << i) != 0 {
+                        0xFF
+                    } else {
+                        0x00
+                    };
+                    channel_mask.set_bank(i, bank);
+                }
+                channel_mask.set_bank(8, blocks);
             }
             6 => {
                 self.set_125k_channels(channel_mask, true, ch_mask);

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -699,6 +699,51 @@ mod tests {
 
     #[test]
     #[cfg(feature = "region-us915")]
+    fn test_us915_chmaskcntl5_single_block() {
+        // ChMaskCntl=5: each of the 8 LSBs controls a bank of 8 125 kHz channels
+        // plus the paired 500 kHz channel: bit i -> channels [8i, 8i+7] and 64+i
+        // (RP002 2.5.5, Table 19)
+        let r = Configuration::new(Region::US915);
+        let mut mask = ChannelMask::<9>::default();
+        r.channel_mask_update(&mut mask, 5, ChannelMask::<2>::new(&[0b0000_0010, 0x00]).unwrap())
+            .unwrap();
+        for ch in 0..72 {
+            let expected = (8..=15).contains(&ch) || ch == 65;
+            assert_eq!(mask.is_enabled(ch).unwrap(), expected, "channel {ch}");
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "region-us915")]
+    fn test_us915_chmaskcntl5_multiple_blocks() {
+        let r = Configuration::new(Region::US915);
+        let mut mask = ChannelMask::<9>::default();
+        r.channel_mask_update(&mut mask, 5, ChannelMask::<2>::new(&[0b1000_0001, 0x00]).unwrap())
+            .unwrap();
+        for ch in 0..72 {
+            let expected = (0..=7).contains(&ch) || (56..=63).contains(&ch) || ch == 64 || ch == 71;
+            assert_eq!(mask.is_enabled(ch).unwrap(), expected, "channel {ch}");
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "region-us915")]
+    fn test_us915_chmaskcntl5_rfu_msbs_ignored() {
+        // the 8 MSBs of the ChMask are RFU and must not affect the result
+        let r = Configuration::new(Region::US915);
+        let mut with_rfu = ChannelMask::<9>::default();
+        let mut without_rfu = ChannelMask::<9>::default();
+        r.channel_mask_update(&mut with_rfu, 5, ChannelMask::<2>::new(&[0x05, 0xFF]).unwrap())
+            .unwrap();
+        r.channel_mask_update(&mut without_rfu, 5, ChannelMask::<2>::new(&[0x05, 0x00]).unwrap())
+            .unwrap();
+        for ch in 0..72 {
+            assert_eq!(with_rfu.is_enabled(ch).unwrap(), without_rfu.is_enabled(ch).unwrap());
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "region-us915")]
     fn test_fixed_us915_frequency_range() {
         let r = Configuration::new(Region::US915);
         assert!(r.frequency_valid(902_000_000));


### PR DESCRIPTION
Two bugs in the ChMaskCntl=5 arm of `channel_mask_update` for US915/AU915:

**Bank values were truncated.** Each bank was computed as `(ch_mask & bit) * 0xFF` cast to u8, which only yields 0xFF for bit 0. Bank 1 got 0xFE, bank 2 got 0xFC, and so on down to bank 8 getting 0x00. So enabling a channel block via ChMaskCntl=5 silently dropped some of its channels (for block 1, channel 8; for block 2, channels 16 and 17; etc).

**The 500 kHz channels were driven off an RFU bit.** RP002 section 2.5.5 (Table 19) says each set LSB i enables the bank of 8 125 kHz channels [8i, 8i+7] plus the paired 500 kHz channel 64+i, and the 8 MSBs of the ChMask are RFU. The old code instead set all of channels 64-71 from ChMask bit 8. Bank 8 now mirrors the low ChMask byte, so bit i drives channel 64+i.

ChMaskCntl=5 matters in practice because it is the single-command path a network server uses to move a device from 64 channel operation to one subband (the note in RP002 2.5.5 calls this out).

Three regression tests added: single block, multiple blocks, and RFU MSBs ignored. The first two fail against the previous code.