### PR TITLE
increase rx window by a bit, fix missing downlinks on lr1110 with faster data rates

### DIFF
--- a/lora-modulation/CHANGELOG.md
+++ b/lora-modulation/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## Unreleased
 
+- `delay_in_symbols` now rounds up so a millisecond budget is never converted to too few symbols
 - Rename defmt feature to defmt-03
 
 ## [v0.1.5]

--- a/lora-modulation/src/lib.rs
+++ b/lora-modulation/src/lib.rs
@@ -130,7 +130,9 @@ impl BaseBandModulationParams {
     }
 
     pub const fn delay_in_symbols(&self, delay_in_ms: u32) -> u16 {
-        (delay_in_ms * 1000 / self.t_sym_us) as u16
+        // Round up so callers never underestimate the symbol count for a time budget.
+        let delay_us = delay_in_ms.saturating_mul(1000);
+        ((delay_us + self.t_sym_us - 1) / self.t_sym_us) as u16
     }
 
     pub const fn symbols_to_ms(&self, symbols: u32) -> u32 {

--- a/lora-phy/CHANGELOG.md
+++ b/lora-phy/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- lorawan-radio: Keep a minimum late-arrival margin on single-RX symbol timeouts so higher datarates (SF10/SF9/…) still catch Class A downlinks when the gateway schedules slightly late (SF12’s long symbols previously masked this).
 - Bump MSRV to 1.75
 - Add documentation for crate features
 - Various documentation fixes (link rot, update docstrings to reflect reality)

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -169,7 +169,13 @@ impl RxMode {
                 // Since both sx126x and sx127x have a preamble-based timeout, we translate
                 // the additional millisecond delay into symbols and add it to the amount of preamble symbols.
                 const PREAMBLE_SYMBOLS: u16 = 13; // 12.25
-                let num_symbols = PREAMBLE_SYMBOLS + bb.delay_in_symbols(ms);
+
+                // add a fixed margin to the timeout to account for the late arrival of the packet in fast modulation modes
+                const MIN_LATE_MARGIN_MS: u32 = 250;
+                let timeout_ms = ms
+                    .saturating_add(bb.symbols_to_ms(PREAMBLE_SYMBOLS as u32))
+                    .saturating_add(MIN_LATE_MARGIN_MS);
+                let num_symbols = bb.delay_in_symbols(timeout_ms).max(PREAMBLE_SYMBOLS);
                 RxMode::Single(num_symbols)
             }
         }


### PR DESCRIPTION
fixes #473 

I don't know why this problem only appears on lr1110, as far as I can see loramac-node does something similar (albeit more complex)