### PR TITLE
Add Adaptive Data Rate

### DIFF
--- a/lorawan-device/CHANGELOG.md
+++ b/lorawan-device/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Deprecate NewSKey in favor of more commonly used NwkSKey
 - Rename the defmt feature to defmt-03
 - Add `class-c` feature flag
+- Enable Adaptive Data Rate (ADR) by default: uplink FCtrl ADR bit, ADRACKReq
+  after `ADR_ACK_LIMIT` missed downlinks, and data-rate backoff after
+  `ADR_ACK_DELAY`. Controllable via `Device::set_adr` / `get_adr`.
 
 ## [v0.12.1]
 

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -301,6 +301,28 @@ where
         self.mac.configuration.data_rate = datarate;
     }
 
+    /// Whether Adaptive Data Rate (ADR) is enabled.
+    ///
+    /// When enabled, uplinks set the FCtrl ADR bit so the network may adjust
+    /// data rate and TX power via LinkADRReq. ADRACKReq / DR backoff also run
+    /// when connectivity is lost.
+    pub fn get_adr(&self) -> bool {
+        self.mac.configuration.adr_enabled
+    }
+
+    /// Enable or disable Adaptive Data Rate (ADR).
+    ///
+    /// ADR is enabled by default. Disable it for mobile devices or when the
+    /// application manages data rate itself.
+    pub fn set_adr(&mut self, enabled: bool) {
+        self.mac.configuration.adr_enabled = enabled;
+        if !enabled {
+            if let Some(session) = self.mac.get_session_mut() {
+                session.adr_ack_cnt = 0;
+            }
+        }
+    }
+
     /// Join the LoRaWAN network asynchronously. The returned future completes when
     /// the LoRaWAN network has been joined successfully, or an error has occurred.
     ///

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -316,10 +316,8 @@ where
     /// application manages data rate itself.
     pub fn set_adr(&mut self, enabled: bool) {
         self.mac.configuration.adr_enabled = enabled;
-        if !enabled {
-            if let Some(session) = self.mac.get_session_mut() {
-                session.adr_ack_cnt = 0;
-            }
+        if !enabled && let Some(session) = self.mac.get_session_mut() {
+            session.adr_ack_cnt = 0;
         }
     }
 

--- a/lorawan-device/src/mac/certification.rs
+++ b/lorawan-device/src/mac/certification.rs
@@ -98,6 +98,8 @@ impl Certification {
         &mut self,
         mut state: &mut mac::State,
         buf: &mut RadioBuffer<N>,
+        configuration: &mac::Configuration,
+        region: &crate::region::Configuration,
     ) -> mac::Result<mac::FcntUp> {
         let send_data = mac::SendData {
             fport: CERTIFICATION_PORT,
@@ -105,7 +107,9 @@ impl Certification {
             confirmed: false,
         };
         match &mut state {
-            mac::State::Joined(session) => Ok(session.prepare_buffer::<N>(&send_data, buf)),
+            mac::State::Joined(session) => {
+                Ok(session.prepare_buffer::<N>(&send_data, buf, configuration, region))
+            }
             mac::State::Otaa(_) => Err(mac::Error::NotJoined),
             mac::State::Unjoined => Err(mac::Error::NotJoined),
         }

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -83,6 +83,9 @@ pub struct Configuration {
     pub(crate) rx1_dr_offset: u8,
     pub(crate) rx2_data_rate: Option<DR>,
     pub(crate) rx2_frequency: Option<u32>,
+    /// When true, uplinks set the FCtrl ADR bit so the network may manage
+    /// data rate and TX power via LinkADRReq.
+    pub(crate) adr_enabled: bool,
 }
 
 pub(crate) struct Mac {
@@ -140,6 +143,7 @@ impl Mac {
                 rx2_data_rate: None,
                 rx2_frequency: None,
                 tx_power: None,
+                adr_enabled: true,
             },
             #[cfg(feature = "certification")]
             certification: certification::Certification::new(),
@@ -184,7 +188,9 @@ impl Mac {
         send_data: &SendData<'_>,
     ) -> Result<(radio::TxConfig, RxWindows, FcntUp)> {
         let fcnt = match &mut self.state {
-            State::Joined(session) => Ok(session.prepare_buffer::<N>(send_data, buf)),
+            State::Joined(session) => {
+                Ok(session.prepare_buffer::<N>(send_data, buf, &self.configuration, &self.region))
+            }
             State::Otaa(_) => Err(Error::NotJoined),
             State::Unjoined => Err(Error::NotJoined),
         }?;
@@ -215,16 +221,18 @@ impl Mac {
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
     ) -> Result<(radio::TxConfig, FcntUp)> {
-        self.multicast.setup_send::<N>(&mut self.state, buf).map(|fcnt_up| {
-            // No RX windows follow this uplink; the caller re-arms the RXC window.
-            let (mut tx_config, _) =
-                self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Data);
-            tx_config.adjust_power(
-                self.configuration.tx_power.unwrap_or(self.board_eirp.max_power),
-                self.board_eirp.antenna_gain,
-            );
-            (tx_config, fcnt_up)
-        })
+        self.multicast.setup_send::<N>(&mut self.state, buf, &self.configuration, &self.region).map(
+            |fcnt_up| {
+                // No RX windows follow this uplink; the caller re-arms the RXC window.
+                let (mut tx_config, _) =
+                    self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Data);
+                tx_config.adjust_power(
+                    self.configuration.tx_power.unwrap_or(self.board_eirp.max_power),
+                    self.board_eirp.antenna_gain,
+                );
+                (tx_config, fcnt_up)
+            },
+        )
     }
 
     #[cfg(feature = "certification")]
@@ -233,13 +241,15 @@ impl Mac {
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
     ) -> Result<(radio::TxConfig, FcntUp)> {
-        self.certification.setup_send::<N>(&mut self.state, buf).map(|fcnt_up| {
-            // No RX windows follow this uplink; the caller completes with rx2_complete().
-            let (mut tx_config, _) =
-                self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Data);
-            tx_config.adjust_power(self.board_eirp.max_power, self.board_eirp.antenna_gain);
-            (tx_config, fcnt_up)
-        })
+        self.certification
+            .setup_send::<N>(&mut self.state, buf, &self.configuration, &self.region)
+            .map(|fcnt_up| {
+                // No RX windows follow this uplink; the caller completes with rx2_complete().
+                let (mut tx_config, _) =
+                    self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Data);
+                tx_config.adjust_power(self.board_eirp.max_power, self.board_eirp.antenna_gain);
+                (tx_config, fcnt_up)
+            })
     }
 
     pub(crate) fn get_rx_delay(&self, frame: &Frame, window: &Window) -> u32 {
@@ -328,7 +338,7 @@ impl Mac {
 
     pub(crate) fn rx2_complete(&mut self) -> Response {
         match &mut self.state {
-            State::Joined(session) => session.rx2_complete(),
+            State::Joined(session) => session.rx2_complete(&mut self.configuration, &self.region),
             State::Otaa(otaa) => otaa.rx2_complete(),
             State::Unjoined => Response::NoUpdate,
         }
@@ -344,6 +354,14 @@ impl Mac {
 
     pub(crate) fn get_session(&self) -> Option<&Session> {
         match &self.state {
+            State::Joined(session) => Some(session),
+            State::Otaa(_) => None,
+            State::Unjoined => None,
+        }
+    }
+
+    pub(crate) fn get_session_mut(&mut self) -> Option<&mut Session> {
+        match &mut self.state {
             State::Joined(session) => Some(session),
             State::Otaa(_) => None,
             State::Unjoined => None,

--- a/lorawan-device/src/mac/multicast.rs
+++ b/lorawan-device/src/mac/multicast.rs
@@ -207,6 +207,8 @@ impl Multicast {
         &mut self,
         mut state: &mut mac::State,
         buf: &mut RadioBuffer<N>,
+        configuration: &mac::Configuration,
+        region: &crate::region::Configuration,
     ) -> mac::Result<mac::FcntUp> {
         let send_data = mac::SendData {
             fport: self.remote_setup_port,
@@ -215,7 +217,7 @@ impl Multicast {
         };
         match &mut state {
             mac::State::Joined(session) => {
-                let response = session.prepare_buffer::<N>(&send_data, buf);
+                let response = session.prepare_buffer::<N>(&send_data, buf, configuration, region);
                 self.pending_uplinks.clear();
                 Ok(response)
             }

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::radio::RadioBuffer;
 use crate::region::constants::{ADR_ACK_DELAY, ADR_ACK_LIMIT, MAX_FCNT_GAP};
-use crate::{region, AppSKey, Downlink, NwkSKey};
+use crate::{AppSKey, Downlink, NwkSKey, region};
 use core::num::NonZeroU8;
 use heapless::Vec;
 use lorawan::creator::{DataFrame, Payload};
@@ -287,10 +287,10 @@ impl Session {
             // step down the data rate to try to regain connectivity.
             if self.adr_ack_cnt >= (ADR_ACK_LIMIT + ADR_ACK_DELAY) as u32 {
                 let past_limit = self.adr_ack_cnt - ADR_ACK_LIMIT as u32;
-                if past_limit.is_multiple_of(ADR_ACK_DELAY as u32) {
-                    if let Some(dr) = next_lower_datarate(region, configuration.data_rate) {
-                        configuration.data_rate = dr;
-                    }
+                if past_limit.is_multiple_of(ADR_ACK_DELAY as u32)
+                    && let Some(dr) = next_lower_datarate(region, configuration.data_rate)
+                {
+                    configuration.data_rate = dr;
                 }
             }
         }
@@ -587,11 +587,82 @@ fn next_fcnt_down(last: Option<u32>, wire: u16) -> Option<u32> {
 mod tests {
     use super::next_fcnt_down;
     use super::{SendData, Session};
+    use crate::mac::Mac;
     use crate::radio::RadioBuffer;
+    use crate::region;
     use crate::{AppSKey, NwkSKey};
     use lorawan::default_crypto::DefaultCrypto;
     use lorawan::maccommandcreator::LinkADRAnsCreator;
-    use lorawan::parser::{DecryptedDataPayload, DevAddr, FrmPayload};
+    use lorawan::parser::{DecryptedDataPayload, DevAddr, EncryptedDataPayload, FrmPayload};
+    use lorawan::types::DR;
+
+    fn uplink_fctrl(session: &mut Session, mac: &Mac) -> lorawan::parser::FCtrl {
+        let mut tx: RadioBuffer<256> = RadioBuffer::new();
+        session.prepare_buffer::<256>(
+            &SendData { data: &[], fport: 1, confirmed: false },
+            &mut tx,
+            &mac.configuration,
+            &mac.region,
+        );
+        EncryptedDataPayload::parse(tx.as_mut_for_read()).unwrap().fhdr().fctrl()
+    }
+
+    fn eu868_mac() -> Mac {
+        Mac::new(region::Configuration::new(region::Region::EU868), 14, 0)
+    }
+
+    fn session() -> Session {
+        Session::new(NwkSKey::from([2; 16]), AppSKey::from([1; 16]), DevAddr::from_value(1))
+    }
+
+    #[test]
+    fn adr_bits_follow_configuration_and_ack_limit() {
+        let mut mac = eu868_mac();
+        mac.configuration.data_rate = DR::_5;
+        let mut session = session();
+
+        let fctrl = uplink_fctrl(&mut session, &mac);
+        assert!(fctrl.adr());
+        assert!(!fctrl.adr_ack_req());
+
+        session.adr_ack_cnt = super::ADR_ACK_LIMIT as u32;
+        let fctrl = uplink_fctrl(&mut session, &mac);
+        assert!(fctrl.adr());
+        assert!(fctrl.adr_ack_req());
+
+        mac.configuration.adr_enabled = false;
+        let fctrl = uplink_fctrl(&mut session, &mac);
+        assert!(!fctrl.adr());
+        assert!(!fctrl.adr_ack_req());
+    }
+
+    #[test]
+    fn adr_backoff_starts_after_ack_limit_and_delay() {
+        let mut mac = eu868_mac();
+        mac.configuration.data_rate = DR::_5;
+        let mut session = session();
+        session.adr_ack_cnt = (super::ADR_ACK_LIMIT + super::ADR_ACK_DELAY - 1) as u32;
+
+        session.rx2_complete(&mut mac.configuration, &mac.region);
+        assert_eq!(mac.configuration.data_rate, DR::_4);
+
+        for _ in 0..super::ADR_ACK_DELAY {
+            session.rx2_complete(&mut mac.configuration, &mac.region);
+        }
+        assert_eq!(mac.configuration.data_rate, DR::_3);
+    }
+
+    #[test]
+    fn adr_ack_req_stops_at_lowest_supported_datarate() {
+        let mut mac = eu868_mac();
+        mac.configuration.data_rate = DR::_0;
+        let mut session = session();
+        session.adr_ack_cnt = super::ADR_ACK_LIMIT as u32;
+
+        let fctrl = uplink_fctrl(&mut session, &mac);
+        assert!(fctrl.adr());
+        assert!(!fctrl.adr_ack_req());
+    }
 
     /// FPort 0 sends the queued MAC commands as the FRMPayload (encrypted
     /// with the NwkSKey), with FOpts left empty.
@@ -607,7 +678,7 @@ mod tests {
         session.uplink.add_mac_command(cmd);
 
         let mut tx: RadioBuffer<256> = RadioBuffer::new();
-        let mac = super::Mac::new(region::Configuration::new(region::Region::EU868), 14, 0);
+        let mac = Mac::new(region::Configuration::new(region::Region::EU868), 14, 0);
         session.prepare_buffer::<256>(
             &SendData { data: &[], fport: 0, confirmed: false },
             &mut tx,

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -4,8 +4,8 @@ use super::{
     uplink,
 };
 use crate::radio::RadioBuffer;
-use crate::region::constants::MAX_FCNT_GAP;
-use crate::{AppSKey, Downlink, NwkSKey, region};
+use crate::region::constants::{ADR_ACK_DELAY, ADR_ACK_LIMIT, MAX_FCNT_GAP};
+use crate::{region, AppSKey, Downlink, NwkSKey};
 use core::num::NonZeroU8;
 use heapless::Vec;
 use lorawan::creator::{DataFrame, Payload};
@@ -42,10 +42,8 @@ pub struct Session {
     /// downlink of the session. Only the low 16 bits of the counter are on the
     /// wire; the high 16 bits kept here are used to rebuild the full value.
     fcnt_down: Option<u32>,
-    // TODO: ADR handling
-    #[cfg(feature = "certification")]
-    /// Whether to force ADR bit for subsequent frames
-    pub override_adr: bool,
+    /// Uplinks since the last accepted downlink; used for ADRACKReq / ADR backoff.
+    pub(crate) adr_ack_cnt: u32,
     #[cfg(feature = "certification")]
     /// Whether to override confirmation bit for sent frames
     pub override_confirmed: Option<bool>,
@@ -89,10 +87,9 @@ impl Session {
             confirmed: false,
             fcnt_down: None,
             fcnt_up: 0,
+            adr_ack_cnt: 0,
             uplink: uplink::Uplink::default(),
 
-            #[cfg(feature = "certification")]
-            override_adr: false,
             #[cfg(feature = "certification")]
             override_confirmed: None,
             #[cfg(feature = "certification")]
@@ -150,7 +147,7 @@ impl Session {
                 let payload_len = encrypted_data.as_bytes().len();
                 if payload_len > max_payload_len as usize + MHDR_LEN + MIC_LEN {
                     info!("Dropping oversized payload.");
-                    return self.rx2_complete();
+                    return self.rx2_complete(configuration, region);
                 }
             }
 
@@ -180,6 +177,8 @@ impl Session {
             let app_crypto = DefaultCrypto::new(self.appskey.inner());
             if encrypted_data.validate_mic(&nwk_crypto, fcnt) {
                 self.fcnt_down = Some(fcnt);
+                // Any accepted downlink confirms connectivity for ADR.
+                self.adr_ack_cnt = 0;
                 // We can safely unwrap here because we already validated the MIC
                 let decrypted = DecryptedDataPayload::decrypt_in_place(
                     bytes,
@@ -225,7 +224,7 @@ impl Session {
                             use crate::mac::certification::Response::*;
                             match certification.handle_message(data, fcnt as u16) {
                                 AdrBitChange(adr) => {
-                                    self.override_adr = adr;
+                                    configuration.adr_enabled = adr;
                                 }
                                 DutJoinReq => {
                                     return Response::DeviceHandler(DeviceEvent::ResetMac);
@@ -269,7 +268,11 @@ impl Session {
         Response::NoUpdate
     }
 
-    pub(crate) fn rx2_complete(&mut self) -> Response {
+    pub(crate) fn rx2_complete(
+        &mut self,
+        configuration: &mut super::Configuration,
+        region: &region::Configuration,
+    ) -> Response {
         // Until we handle NbTrans, there is no case where we should not increment FCntUp.
         if self.fcnt_up == 0xFFFF_FFFF {
             // if the FCnt is used up, the session has expired
@@ -277,6 +280,21 @@ impl Session {
         } else {
             self.fcnt_up += 1;
         }
+
+        if configuration.adr_enabled {
+            self.adr_ack_cnt = self.adr_ack_cnt.saturating_add(1);
+            // After ADR_ACK_LIMIT + N*ADR_ACK_DELAY uplinks without a downlink,
+            // step down the data rate to try to regain connectivity.
+            if self.adr_ack_cnt >= (ADR_ACK_LIMIT + ADR_ACK_DELAY) as u32 {
+                let past_limit = self.adr_ack_cnt - ADR_ACK_LIMIT as u32;
+                if past_limit.is_multiple_of(ADR_ACK_DELAY as u32) {
+                    if let Some(dr) = next_lower_datarate(region, configuration.data_rate) {
+                        configuration.data_rate = dr;
+                    }
+                }
+            }
+        }
+
         if self.confirmed {
             Response::NoAck
         } else {
@@ -288,6 +306,8 @@ impl Session {
         &mut self,
         data: &SendData<'_>,
         tx_buffer: &mut RadioBuffer<N>,
+        configuration: &super::Configuration,
+        region: &region::Configuration,
     ) -> FcntUp {
         tx_buffer.clear();
         let fcnt = self.fcnt_up;
@@ -298,16 +318,12 @@ impl Session {
             self.uplink.clear_downlink_confirmation();
         }
 
-        let adr = {
-            #[cfg(feature = "certification")]
-            {
-                self.override_adr
-            }
-            #[cfg(not(feature = "certification"))]
-            {
-                false
-            }
-        };
+        let adr = configuration.adr_enabled;
+        // ADRACKReq asks the network for a downlink so ADR can keep working.
+        // It is not set when already at the lowest usable data rate.
+        let adr_ack_req = adr
+            && self.adr_ack_cnt >= ADR_ACK_LIMIT as u32
+            && next_lower_datarate(region, configuration.data_rate).is_some();
 
         self.confirmed = data.confirmed;
         #[cfg(feature = "certification")]
@@ -336,7 +352,7 @@ impl Session {
             },
             dev_addr: self.devaddr,
             adr,
-            adr_ack_req: false,
+            adr_ack_req,
             ack,
             f_pending: false,
             fcnt,
@@ -521,6 +537,20 @@ impl Session {
     }
 }
 
+/// Next lower region-supported data rate, if any.
+fn next_lower_datarate(region: &region::Configuration, current: DR) -> Option<DR> {
+    let current = current as u8;
+    if current == 0 {
+        return None;
+    }
+    for candidate in (0..current).rev() {
+        if region.get_datarate(candidate).is_some() {
+            return Some(DR::from(candidate));
+        }
+    }
+    None
+}
+
 /// Rebuild the full 32-bit downlink frame counter from the 16-bit value carried
 /// on the wire and decide whether the frame is fresh.
 ///
@@ -577,7 +607,13 @@ mod tests {
         session.uplink.add_mac_command(cmd);
 
         let mut tx: RadioBuffer<256> = RadioBuffer::new();
-        session.prepare_buffer::<256>(&SendData { data: &[], fport: 0, confirmed: false }, &mut tx);
+        let mac = super::Mac::new(region::Configuration::new(region::Region::EU868), 14, 0);
+        session.prepare_buffer::<256>(
+            &SendData { data: &[], fport: 0, confirmed: false },
+            &mut tx,
+            &mac.configuration,
+            &mac.region,
+        );
 
         let bytes = tx.as_mut_for_read();
         let nwk_crypto = DefaultCrypto::new(nwkskey.inner());

--- a/lorawan-device/src/nb_device/mod.rs
+++ b/lorawan-device/src/nb_device/mod.rs
@@ -73,10 +73,8 @@ where
     /// Enable or disable Adaptive Data Rate (ADR). Enabled by default.
     pub fn set_adr(&mut self, enabled: bool) {
         self.shared.mac.configuration.adr_enabled = enabled;
-        if !enabled {
-            if let Some(session) = self.shared.mac.get_session_mut() {
-                session.adr_ack_cnt = 0;
-            }
+        if !enabled && let Some(session) = self.shared.mac.get_session_mut() {
+            session.adr_ack_cnt = 0;
         }
     }
 

--- a/lorawan-device/src/nb_device/mod.rs
+++ b/lorawan-device/src/nb_device/mod.rs
@@ -65,6 +65,21 @@ where
         self.shared.mac.configuration.data_rate = datarate
     }
 
+    /// Whether Adaptive Data Rate (ADR) is enabled.
+    pub fn get_adr(&self) -> bool {
+        self.shared.mac.configuration.adr_enabled
+    }
+
+    /// Enable or disable Adaptive Data Rate (ADR). Enabled by default.
+    pub fn set_adr(&mut self, enabled: bool) {
+        self.shared.mac.configuration.adr_enabled = enabled;
+        if !enabled {
+            if let Some(session) = self.shared.mac.get_session_mut() {
+                session.adr_ack_cnt = 0;
+            }
+        }
+    }
+
     pub fn ready_to_send_data(&self) -> bool {
         matches!(&self.state, State::Idle(_)) && self.shared.mac.is_joined()
     }


### PR DESCRIPTION
Adds initial Adaptive Data Rate support.

ADR is enabled by default and can be controlled through Device::set_adr / get_adr. Uplinks set ADR and ADRACKReq as appropriate, accepted downlinks reset the acknowledgement counter, and the data rate backs off after ADR_ACK_LIMIT + ADR_ACK_DELAY missed downlinks.

This is an incremental implementation and does not yet support NbTrans, so it is not the complete LoRaWAN 1.0.4 ADR behavior.