### PR TITLE
phy: sx127x: optionally watch DIO1 for RxTimeout

### DIFF
--- a/lora-phy/CHANGELOG.md
+++ b/lora-phy/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- sx127x: Add `GenericSx127xInterfaceVariant::new_with_secondary_irq` to watch DIO1 (RxTimeout), fixing LoRaWAN RX-window hangs on single-IRQ boards
 - Bump MSRV to 1.75
 - Add documentation for crate features
 - Various documentation fixes (link rot, update docstrings to reflect reality)

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -15,6 +15,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
+embassy-futures = "0.1"
 lora-modulation = { path = "../lora-modulation", version = ">=0.1.2" }
 lorawan-device = { path = "../lorawan-device", default-features = false, version = "0.12", optional = true }
 num-traits = { version = "0.2", default-features = false }

--- a/lora-phy/src/iv.rs
+++ b/lora-phy/src/iv.rs
@@ -1,3 +1,4 @@
+use embassy_futures::select::{select, Either};
 use embedded_hal::digital::OutputPin;
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::digital::Wait;
@@ -6,15 +7,22 @@ use crate::mod_params::RadioError;
 use crate::mod_params::RadioError::*;
 use crate::mod_traits::InterfaceVariant;
 
-/// Base for the InterfaceVariant implementation for the Sx127x for
-/// LoRa P2P operations.
+/// Base for the InterfaceVariant implementation for the Sx127x.
 ///
-/// Note: This `InterfaceVariant` is not compatible with
-/// [`lorawan_device::async_device::Device`] due to its reliance on `RxTimeout`
-/// IRQ which is exposed on secondary IRQ pin.
+/// The sx127x reports events on up to two DIO lines: DIO0 carries
+/// RxDone/TxDone/CadDone, while RxTimeout is only ever routed to DIO1. LoRa
+/// P2P and CAD only need DIO0, so [`new`](Self::new) takes a single IRQ pin.
+///
+/// [`lorawan_device::async_device::Device`], however, relies on RxTimeout to
+/// close an empty receive window: with only DIO0 wired, an RX window that
+/// hears nothing never wakes the driver and the join/receive hangs forever.
+/// For LoRaWAN, construct with
+/// [`new_with_secondary_irq`](Self::new_with_secondary_irq) so `await_irq`
+/// also watches DIO1.
 pub struct GenericSx127xInterfaceVariant<CTRL, WAIT> {
     reset: CTRL,
     irq: WAIT,
+    irq_secondary: Option<WAIT>,
     rf_switch_rx: Option<CTRL>,
     rf_switch_tx: Option<CTRL>,
 }
@@ -24,16 +32,37 @@ where
     CTRL: OutputPin,
     WAIT: Wait,
 {
-    /// Create an InterfaceVariant instance for sx127x chips for LoRa P2P operations.
+    /// Create an InterfaceVariant watching a single IRQ pin (DIO0).
+    ///
+    /// Enough for LoRa P2P and CAD. Not enough for LoRaWAN receive windows,
+    /// which need RxTimeout on DIO1; use
+    /// [`new_with_secondary_irq`](Self::new_with_secondary_irq) there.
     pub fn new(
         reset: CTRL,
         irq: WAIT,
         rf_switch_rx: Option<CTRL>,
         rf_switch_tx: Option<CTRL>,
     ) -> Result<Self, RadioError> {
+        Self::new_with_secondary_irq(reset, irq, None, rf_switch_rx, rf_switch_tx)
+    }
+
+    /// Create an InterfaceVariant watching DIO0 and, when supplied, DIO1.
+    ///
+    /// Pass the DIO1 pin as `irq_secondary` for LoRaWAN: the sx127x routes
+    /// RxTimeout only to DIO1, so without it an empty receive window never
+    /// completes. `await_irq` then wakes on whichever line fires and the
+    /// driver reads RegIrqFlags to tell the events apart.
+    pub fn new_with_secondary_irq(
+        reset: CTRL,
+        irq: WAIT,
+        irq_secondary: Option<WAIT>,
+        rf_switch_rx: Option<CTRL>,
+        rf_switch_tx: Option<CTRL>,
+    ) -> Result<Self, RadioError> {
         Ok(Self {
             reset,
             irq,
+            irq_secondary,
             rf_switch_rx,
             rf_switch_tx,
         })
@@ -57,7 +86,18 @@ where
         Ok(())
     }
     async fn await_irq(&mut self) -> Result<(), RadioError> {
-        self.irq.wait_for_high().await.map_err(|_| Irq)
+        // Destructure so DIO0 and the optional DIO1 are borrowed as disjoint
+        // fields; both futures must be live at once.
+        let Self { irq, irq_secondary, .. } = self;
+        match irq_secondary {
+            None => irq.wait_for_high().await.map_err(|_| Irq)?,
+            // Wake on either line. `select` polls DIO0 first, so a coincident
+            // RxDone is reported ahead of RxTimeout.
+            Some(dio1) => match select(irq.wait_for_high(), dio1.wait_for_high()).await {
+                Either::First(r) | Either::Second(r) => r.map_err(|_| Irq)?,
+            },
+        }
+        Ok(())
     }
 
     async fn enable_rf_switch_rx(&mut self) -> Result<(), RadioError> {


### PR DESCRIPTION
## Problem

`GenericSx127xInterfaceVariant` watches a single IRQ pin (DIO0), which carries RxDone/TxDone/CadDone. The sx127x routes **RxTimeout only to DIO1**, and `lorawan_device::async_device::Device` needs it to close an empty receive window. With DIO0 alone, an RX window that hears nothing never wakes the driver, so an OTAA join (or any receive) that gets no downlink hangs forever instead of moving on to the next window/attempt.

The struct doc already conceded this ("not compatible with `async_device::Device` due to its reliance on `RxTimeout` ... on secondary IRQ pin"), so single-DIO boards had no working generic LoRaWAN variant.

## Fix

Add `new_with_secondary_irq(reset, irq, irq_secondary, rf_switch_rx, rf_switch_tx)`. When a DIO1 pin is supplied, `await_irq` wakes on whichever of DIO0/DIO1 fires (via `embassy_futures::select`, DIO0 polled first so a coincident RxDone is reported ahead of RxTimeout); the driver then reads `RegIrqFlags` to tell the events apart, exactly as before. `new()` is unchanged (secondary = `None`) and keeps its single-pin behavior for LoRa P2P and CAD.

This pulls in `embassy-futures` as a dependency, already used across the `examples/` in this repo.

## Testing

Hardware-validated on a B-L072Z-LRWAN1 (STM32L072CZ + SX1276, single-DIO wiring, US915) against a real gateway and network-server fixture. Full OTAA suite 5/5: join, DLSettings RX1/RX2 downlink reception, and, the load-bearing cases, two negative scenarios where the server never sends a JoinAccept. Those only terminate because RxTimeout on DIO1 closes each empty window; on the old single-DIO variant they hang. Reverting to `new()` reproduces the hang.

## Compatibility

Additive, non-breaking: existing `new()` callers are untouched.
