### PR TITLE
Move to Rust edition 2024 and adopt embassy toolchain conventions

### DIFF
--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "lora-nrf52840-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "lora-rp-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "lora-stm32l0-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "lora-stm32wl-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"

--- a/lora-modulation/CHANGELOG.md
+++ b/lora-modulation/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## Unreleased
 
+- Move to Rust edition 2024 (requires Rust 1.85+)
 - Rename defmt feature to defmt-03
 
 ## [v0.1.5]

--- a/lora-modulation/Cargo.toml
+++ b/lora-modulation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lora-modulation"
 version = "0.1.5"
-edition = "2021"
+edition = "2024"
 authors = ["Louis Thiery <thiery.louis@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/lora-phy/CHANGELOG.md
+++ b/lora-phy/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Move to Rust edition 2024 (requires Rust 1.85+)
 - sx127x: Add `GenericSx127xInterfaceVariant::new_with_secondary_irq` to watch DIO1 (RxTimeout), fixing LoRaWAN RX-window hangs on single-IRQ boards
 - Bump MSRV to 1.75
 - Add documentation for crate features

--- a/lora-phy/Cargo.toml
+++ b/lora-phy/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "lora-phy"
 version = "3.0.2-alpha"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/lora-phy"
 categories = ["embedded", "no-std", "asynchronous"]
 keywords = ["lora", "radio", "embedded-hal-async", "iot", "semtech"]
 description = "A LoRa physical layer implementation enabling utilization of a range of MCU/LoRa board combinations within embedded frameworks supporting embedded-hal-async."
-rust-version = "1.75"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/lora-phy/src/iv.rs
+++ b/lora-phy/src/iv.rs
@@ -1,4 +1,4 @@
-use embassy_futures::select::{select, Either};
+use embassy_futures::select::{Either, select};
 use embedded_hal::digital::OutputPin;
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::digital::Wait;

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -6,8 +6,8 @@ use super::{DelayNs, LoRa, RxMode};
 
 use lora_modulation::BaseBandModulationParams;
 use lorawan_device::async_device::{
-    radio::{PhyRxTx, RxConfig, RxMode as LorawanRxMode, RxQuality, RxStatus, TxConfig},
     Timings,
+    radio::{PhyRxTx, RxConfig, RxMode as LorawanRxMode, RxQuality, RxStatus, TxConfig},
 };
 
 const DEFAULT_RX_WINDOW_LEAD_TIME: u32 = 50;

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -12,39 +12,38 @@ use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::*;
 pub use radio_kind_params::TcxoCtrlVoltage;
 pub use radio_kind_params::{
-    LrFhssBandwidth, LrFhssCodingRate, LrFhssGrid, LrFhssModulationType, LrFhssParams, LrFhssV1Params,
-    LR_FHSS_DEFAULT_SYNC_WORD, LR_FHSS_SYNC_WORD_BYTES,
+    LR_FHSS_DEFAULT_SYNC_WORD, LR_FHSS_SYNC_WORD_BYTES, LrFhssBandwidth, LrFhssCodingRate, LrFhssGrid,
+    LrFhssModulationType, LrFhssParams, LrFhssV1Params,
 };
 // System types
 pub use radio_kind_params::{
-    ChipMode, ChipType, CommandStatus, ResetStatus, Stat1, Stat2, SystemStatus, Version, LR11XX_SYSTEM_JOIN_EUI_LENGTH,
-    LR11XX_SYSTEM_UID_LENGTH,
+    ChipMode, ChipType, CommandStatus, LR11XX_SYSTEM_JOIN_EUI_LENGTH, LR11XX_SYSTEM_UID_LENGTH, ResetStatus, Stat1,
+    Stat2, SystemStatus, Version,
 };
 // IrqMask for direct use
 pub use radio_kind_params::IrqMask;
 // Bootloader types
 pub use radio_kind_params::{
-    BootloaderChipEui, BootloaderCommandStatus, BootloaderJoinEui, BootloaderOpCode, BootloaderPin, BootloaderStat1,
-    BootloaderStat2, BootloaderStatus, BootloaderVersion, BOOTLOADER_CHIP_EUI_LENGTH,
-    BOOTLOADER_FLASH_BLOCK_SIZE_BYTES, BOOTLOADER_FLASH_BLOCK_SIZE_WORDS, BOOTLOADER_JOIN_EUI_LENGTH,
-    BOOTLOADER_PIN_LENGTH, BOOTLOADER_VERSION_LENGTH,
+    BOOTLOADER_CHIP_EUI_LENGTH, BOOTLOADER_FLASH_BLOCK_SIZE_BYTES, BOOTLOADER_FLASH_BLOCK_SIZE_WORDS,
+    BOOTLOADER_JOIN_EUI_LENGTH, BOOTLOADER_PIN_LENGTH, BOOTLOADER_VERSION_LENGTH, BootloaderChipEui,
+    BootloaderCommandStatus, BootloaderJoinEui, BootloaderOpCode, BootloaderPin, BootloaderStat1, BootloaderStat2,
+    BootloaderStatus, BootloaderVersion,
 };
 // RegMem (Register/Memory) types
-pub use radio_kind_params::{RegMemOpCode, REGMEM_BUFFER_SIZE_MAX, REGMEM_MAX_READ_WRITE_WORDS};
+pub use radio_kind_params::{REGMEM_BUFFER_SIZE_MAX, REGMEM_MAX_READ_WRITE_WORDS, RegMemOpCode};
 // GFSK types
 pub use radio_kind_params::{
-    GfskAddressFiltering, GfskBandwidth, GfskCrcType, GfskDcFree, GfskHeaderType, GfskModulationParams,
-    GfskPacketParams, GfskPreambleDetector, GfskPulseShape, GfskStats, GFSK_DEFAULT_SYNC_WORD,
-    GFSK_SYNC_WORD_MAX_LENGTH,
+    GFSK_DEFAULT_SYNC_WORD, GFSK_SYNC_WORD_MAX_LENGTH, GfskAddressFiltering, GfskBandwidth, GfskCrcType, GfskDcFree,
+    GfskHeaderType, GfskModulationParams, GfskPacketParams, GfskPreambleDetector, GfskPulseShape, GfskStats,
 };
 // Radio Statistics types
 pub use radio_kind_params::{LoRaStats, RadioStats};
 // Radio Timings helpers
 use radio_kind_params::*;
 pub use radio_kind_params::{
+    RX_DONE_IRQ_PROCESSING_TIME_IN_US, TX_DONE_IRQ_PROCESSING_TIME_IN_US,
     delay_between_last_bit_sent_and_rx_done_in_us, delay_between_last_bit_sent_and_tx_done_in_us,
-    lora_rx_input_delay_in_us, lora_symbol_time_in_us, RX_DONE_IRQ_PROCESSING_TIME_IN_US,
-    TX_DONE_IRQ_PROCESSING_TIME_IN_US,
+    lora_rx_input_delay_in_us, lora_symbol_time_in_us,
 };
 
 use crate::lr1110_interface::Lr1110SpiInterface;
@@ -2005,12 +2004,11 @@ where
                 // Duty cycles above 0x04 are not allowed below 400 MHz per the
                 // LR1110 User Manual. With the vendor table only the +15 dBm
                 // entry (duty 0x07) trips this.
-                if entry.pa_duty_cycle > 0x04 {
-                    if let Some(m_p) = mdltn_params {
-                        if m_p.frequency_in_hz < 400_000_000 {
-                            return Err(RadioError::InvalidOutputPowerForFrequency);
-                        }
-                    }
+                if entry.pa_duty_cycle > 0x04
+                    && let Some(m_p) = mdltn_params
+                    && m_p.frequency_in_hz < 400_000_000
+                {
+                    return Err(RadioError::InvalidOutputPowerForFrequency);
                 }
 
                 // LP PA always runs from the internal regulator.

--- a/lora-phy/src/lr1110/test/mod.rs
+++ b/lora-phy/src/lr1110/test/mod.rs
@@ -6,7 +6,7 @@
 //! byte plus data — so transactions are compared exactly.
 mod fixtures;
 use fixtures::{
-    get_lr1110, get_lr1110_boosted, get_lr1110_dcdc_tcxo, get_lr1110_hf, get_lr1110_lp, Delayer, TestFixture,
+    Delayer, TestFixture, get_lr1110, get_lr1110_boosted, get_lr1110_dcdc_tcxo, get_lr1110_hf, get_lr1110_lp,
 };
 
 use crate::mod_params::{RadioMode, RxMode};
@@ -844,8 +844,8 @@ async fn test_lr_fhss_init() {
 #[tokio::test]
 async fn test_lr_fhss_build_frame() {
     use crate::lr1110::{
-        LrFhssBandwidth, LrFhssCodingRate, LrFhssGrid, LrFhssModulationType, LrFhssParams, LrFhssV1Params,
-        LR_FHSS_DEFAULT_SYNC_WORD,
+        LR_FHSS_DEFAULT_SYNC_WORD, LrFhssBandwidth, LrFhssCodingRate, LrFhssGrid, LrFhssModulationType, LrFhssParams,
+        LrFhssV1Params,
     };
     let payload = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
 

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -422,12 +422,11 @@ where
             DeviceSel::LowPowerPA => {
                 // For SX1261 the +15 dBm row is only valid above 400 MHz
                 // (below, paDutyCycle must not exceed 0x04)
-                if output_power >= 15 {
-                    if let Some(m_p) = mdltn_params {
-                        if m_p.frequency_in_hz < 400_000_000 {
-                            return Err(RadioError::InvalidOutputPowerForFrequency);
-                        }
-                    }
+                if output_power >= 15
+                    && let Some(m_p) = mdltn_params
+                    && m_p.frequency_in_hz < 400_000_000
+                {
+                    return Err(RadioError::InvalidOutputPowerForFrequency);
                 }
             }
             DeviceSel::HighPowerPA => {

--- a/lora-phy/src/sx126x/test/emulator.rs
+++ b/lora-phy/src/sx126x/test/emulator.rs
@@ -4,7 +4,7 @@
 use crate::mod_params::RadioError;
 use crate::mod_traits::InterfaceVariant;
 use crate::sx126x::radio_kind_params::{IrqMask, OpCode};
-use crate::sx126x::{Config, Sx1261, Sx126x};
+use crate::sx126x::{Config, Sx126x, Sx1261};
 use crate::test_fixtures::SpiError;
 use embedded_hal::spi::Operation;
 use embedded_hal_async::delay::DelayNs;
@@ -249,7 +249,7 @@ impl SpiDevice<u8> for FakeSpi {
         let mut response = if cmd.is_empty() {
             vec![]
         } else {
-            self.0 .0.lock().unwrap().execute(cmd[0], &cmd[1..])
+            self.0.0.lock().unwrap().execute(cmd[0], &cmd[1..])
         };
         let mut cursor = response.drain(..);
         for op in operations.iter_mut() {

--- a/lora-phy/src/sx126x/test/fixtures.rs
+++ b/lora-phy/src/sx126x/test/fixtures.rs
@@ -1,4 +1,4 @@
-use crate::sx126x::{Config, Sx1261, Sx1262, Sx126x};
+use crate::sx126x::{Config, Sx126x, Sx1261, Sx1262};
 pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
 use embedded_hal::spi::Operation;
 use embedded_hal_async::spi::SpiDevice;

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -3,18 +3,18 @@
 //! state machine against an emulated chip.
 mod emulator;
 mod fixtures;
-use emulator::{get_emulated_sx1261, Chip, FakeIv, FakeSpi, Mode};
-use fixtures::{get_sx1262, get_sx126x, Delayer, TestFixture};
+use emulator::{Chip, FakeIv, FakeSpi, Mode, get_emulated_sx1261};
+use fixtures::{Delayer, TestFixture, get_sx126x, get_sx1262};
 
+use crate::LoRa;
 use crate::mod_params::{RadioMode, RxMode};
 use crate::mod_traits::RadioKind;
-use crate::sx126x::{Sx1261, Sx126x};
-use crate::LoRa;
+use crate::sx126x::{Sx126x, Sx1261};
 use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 use smtc_modem_cores::sx126x::{
-    sx126x_cad_exit_modes_e, sx126x_cad_params_t, sx126x_cad_symbs_e, sx126x_lora_bw_e, sx126x_lora_cr_e,
-    sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t, sx126x_pa_cfg_params_t,
-    sx126x_pkt_params_lora_t, sx126x_pkt_types_e, sx126x_ramp_time_e, sx126x_standby_cfgs_e, Context, SleepCfg,
+    Context, SleepCfg, sx126x_cad_exit_modes_e, sx126x_cad_params_t, sx126x_cad_symbs_e, sx126x_lora_bw_e,
+    sx126x_lora_cr_e, sx126x_lora_pkt_len_modes_e, sx126x_lora_sf_e, sx126x_mod_params_lora_t, sx126x_pa_cfg_params_t,
+    sx126x_pkt_params_lora_t, sx126x_pkt_types_e, sx126x_ramp_time_e, sx126x_standby_cfgs_e,
 };
 
 fn reference() -> Context<TestFixture> {

--- a/lora-phy/src/sx127x/sx1272.rs
+++ b/lora-phy/src/sx127x/sx1272.rs
@@ -1,7 +1,7 @@
 use crate::mod_params::{ModulationParams, PacketParams, RadioError};
 use crate::mod_traits::InterfaceVariant;
-use crate::sx127x::radio_kind_params::{coding_rate_value, spreading_factor_value, RampTime, Register, Sx127xVariant};
-use crate::sx127x::{Sx127x, SX1272_RSSI_OFFSET};
+use crate::sx127x::radio_kind_params::{RampTime, Register, Sx127xVariant, coding_rate_value, spreading_factor_value};
+use crate::sx127x::{SX1272_RSSI_OFFSET, Sx127x};
 use embedded_hal_async::spi::SpiDevice;
 use lora_modulation::Bandwidth;
 

--- a/lora-phy/src/sx127x/sx1276.rs
+++ b/lora-phy/src/sx127x/sx1276.rs
@@ -1,10 +1,10 @@
 use crate::mod_params::{ModulationParams, PacketParams, RadioError};
 use crate::mod_traits::InterfaceVariant;
 use crate::sx127x::radio_kind_params::{
-    coding_rate_denominator_value, spreading_factor_value, OcpTrim, PaConfig, PaDac, RampTime, Register, Sx127xVariant,
+    OcpTrim, PaConfig, PaDac, RampTime, Register, Sx127xVariant, coding_rate_denominator_value, spreading_factor_value,
 };
 use crate::sx127x::{
-    pll_step_to_freq, Sx127x, SX1276_RF_MID_BAND_THRESH, SX1276_RSSI_OFFSET_HF, SX1276_RSSI_OFFSET_LF,
+    SX1276_RF_MID_BAND_THRESH, SX1276_RSSI_OFFSET_HF, SX1276_RSSI_OFFSET_LF, Sx127x, pll_step_to_freq,
 };
 use embedded_hal_async::spi::SpiDevice;
 use lora_modulation::Bandwidth;

--- a/lora-phy/src/sx127x/test/emulator.rs
+++ b/lora-phy/src/sx127x/test/emulator.rs
@@ -15,7 +15,7 @@
 use super::fixtures::RESET_VALUES;
 use crate::mod_params::RadioError;
 use crate::mod_traits::InterfaceVariant;
-use crate::sx127x::{Config, Sx1276, Sx127x};
+use crate::sx127x::{Config, Sx127x, Sx1276};
 use crate::test_fixtures::SpiError;
 use embedded_hal::spi::Operation;
 use embedded_hal_async::delay::DelayNs;
@@ -144,10 +144,10 @@ impl ChipModel {
             let op_mode = (self.reg(REG_OP_MODE) & !0x07) | 0x01;
             self.regs.insert(REG_OP_MODE, op_mode);
             self.raise_irq(IRQ_TX_DONE);
-        } else if self.mode() == Mode::Rx {
-            if let Some(rx) = self.pending_rx.take() {
-                self.deliver_rx(rx);
-            }
+        } else if self.mode() == Mode::Rx
+            && let Some(rx) = self.pending_rx.take()
+        {
+            self.deliver_rx(rx);
         }
     }
 

--- a/lora-phy/src/sx127x/test/fixtures.rs
+++ b/lora-phy/src/sx127x/test/fixtures.rs
@@ -1,4 +1,4 @@
-use crate::sx127x::{Config, Sx1276, Sx127x};
+use crate::sx127x::{Config, Sx127x, Sx1276};
 pub use crate::test_fixtures::{Delayer, DummyVariant, SpiError};
 use embedded_hal::spi::Operation;
 use embedded_hal_async::spi::SpiDevice;

--- a/lora-phy/src/sx127x/test/mod.rs
+++ b/lora-phy/src/sx127x/test/mod.rs
@@ -12,15 +12,15 @@
 //! at all — noted per test.
 mod emulator;
 mod fixtures;
-use emulator::{get_emulated_sx1276, Chip, Mode};
-use fixtures::{get_sx1276, get_sx1276_boost, Delayer, TestFixture};
+use emulator::{Chip, Mode, get_emulated_sx1276};
+use fixtures::{Delayer, TestFixture, get_sx1276, get_sx1276_boost};
 
+use crate::LoRa;
 use crate::mod_params::{RadioMode, RxMode};
 use crate::mod_traits::RadioKind;
 use crate::sx127x::radio_kind_params::Register;
-use crate::LoRa;
 use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
-use smtc_modem_cores::sx127x::{sx127x_radio_id_e, Context};
+use smtc_modem_cores::sx127x::{Context, sx127x_radio_id_e};
 use smtc_modem_cores::sys;
 
 /// SX1276 reference with the LoRa packet engine selected. Selecting LoRa is

--- a/lorawan-device/CHANGELOG.md
+++ b/lorawan-device/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## Unreleased
 
+- Move to Rust edition 2024 (requires Rust 1.85+)
 - Deprecate NewSKey in favor of more commonly used NwkSKey
 - Rename the defmt feature to defmt-03
 - Add `class-c` feature flag

--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -5,8 +5,7 @@ authors = [
     "Louis Thiery <thiery.louis@gmail.com>",
     "Ulf Lilleengen <lulf@redhat.com>",
 ]
-edition = "2021"
-rust-version = "1.75"
+edition = "2024"
 categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT"
 readme = "README.md"

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -2,9 +2,9 @@
 //! allowing for asynchronous radio implementations. Requires the `async` feature.
 use super::mac::{self, FcntDown, Frame, Mac, Window};
 pub use super::{
+    Downlink, JoinMode,
     mac::{NetworkCredentials, SendData, Session},
     region::{self, Region},
-    Downlink, JoinMode,
 };
 use heapless::Vec;
 use rand_core::RngCore;
@@ -402,7 +402,7 @@ where
         duration: u32,
     ) -> Result<Option<mac::Response>, Error<R::PhyError>> {
         use self::radio::RxQuality;
-        use futures::{future::select, future::Either, pin_mut};
+        use futures::{future::Either, future::select, pin_mut};
 
         if !self.class_c {
             self.radio.low_power().await.map_err(Error::Radio)?;

--- a/lorawan-device/src/async_device/test/certification/mod.rs
+++ b/lorawan-device/src/async_device/test/certification/mod.rs
@@ -3,7 +3,7 @@
 use super::util;
 use crate::async_device::SendResponse;
 use crate::radio::RfConfig;
-use crate::test_util::{get_crypto, get_dev_addr, Uplink};
+use crate::test_util::{Uplink, get_crypto, get_dev_addr};
 use core::num::NonZeroU8;
 use lorawan::creator::{DataFrame, Payload};
 use lorawan::parser::{self, DataFrameType, DecryptedDataPayload, PhyPayload};

--- a/lorawan-device/src/async_device/test/certification/oversized_payload_eu868.rs
+++ b/lorawan-device/src/async_device/test/certification/oversized_payload_eu868.rs
@@ -60,7 +60,11 @@ async fn oversized_payload_sf12_bw_125_eu868() {
     });
 
     fn oversized_payload(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
-        build_packet(buf, "07020101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101", 2)
+        build_packet(
+            buf,
+            "07020101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101",
+            2,
+        )
     }
     timer.fire_most_recent().await;
     radio.handle_rxtx(oversized_payload).await;

--- a/lorawan-device/src/async_device/test/class_c.rs
+++ b/lorawan-device/src/async_device/test/class_c.rs
@@ -1,7 +1,7 @@
 use super::util;
 use crate::async_device::{ListenResponse, SendResponse};
 use crate::radio::RfConfig;
-use crate::test_util::{get_crypto, get_dev_addr, Uplink};
+use crate::test_util::{Uplink, get_crypto, get_dev_addr};
 use core::num::NonZeroU8;
 use lorawan::creator::{DataFrame, Payload};
 use lorawan::parser::DataFrameType;

--- a/lorawan-device/src/async_device/test/maccommands.rs
+++ b/lorawan-device/src/async_device/test/maccommands.rs
@@ -1,7 +1,7 @@
 use super::util;
 use crate::async_device::SendResponse;
 use crate::radio::RfConfig;
-use crate::test_util::{get_crypto, Uplink};
+use crate::test_util::{Uplink, get_crypto};
 
 use lorawan::creator::{DataFrame, Payload};
 use lorawan::maccommands::parse_uplink_mac_commands;

--- a/lorawan-device/src/async_device/test/multicast.rs
+++ b/lorawan-device/src/async_device/test/multicast.rs
@@ -114,7 +114,7 @@ async fn test_multicast_remote_setup() {
     match response {
         Ok(ListenResponse::Multicast(MulticastResponse::NewSession { group_id })) => {
             assert_eq!(group_id, 1); // Group ID from the setup request
-                                     // Verify the session was created correctly
+            // Verify the session was created correctly
             let mc_addr = McAddr::from_wire_bytes([52, 110, 29, 60]);
             let (fetched_group_id, stored_session) =
                 device.mac.multicast.matching_session(mc_addr).unwrap();

--- a/lorawan-device/src/async_device/test/radio.rs
+++ b/lorawan-device/src/async_device/test/radio.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::async_device::radio::{PhyRxTx, RxConfig, RxStatus};
 use std::sync::Arc;
 use tokio::{
-    sync::{mpsc, Mutex},
+    sync::{Mutex, mpsc},
     time,
 };
 impl TestRadio {

--- a/lorawan-device/src/async_device/test/timer.rs
+++ b/lorawan-device/src/async_device/test/timer.rs
@@ -1,6 +1,6 @@
 use crate::async_device::radio::Timer;
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{Mutex, mpsc};
 
 impl TestTimer {
     pub fn new() -> (TimerChannel, Self) {

--- a/lorawan-device/src/async_device/test/util.rs
+++ b/lorawan-device/src/async_device/test/util.rs
@@ -2,9 +2,9 @@ use crate::radio::RfConfig;
 use lorawan::creator::DataFrame;
 use lorawan::parser::{self, DataFrameType, DecryptedDataPayload, PhyPayload};
 
-use super::{get_dev_addr, get_key, radio::*, region, timer::*, Device};
+use super::{Device, get_dev_addr, get_key, radio::*, region, timer::*};
 use crate::mac::Session;
-pub(crate) use crate::test_util::{get_crypto, handle_data_uplink_with_link_adr_req, Uplink};
+pub(crate) use crate::test_util::{Uplink, get_crypto, handle_data_uplink_with_link_adr_req};
 use crate::{AppSKey, NwkSKey};
 
 fn default_session() -> Session {

--- a/lorawan-device/src/mac/certification.rs
+++ b/lorawan-device/src/mac/certification.rs
@@ -105,7 +105,7 @@ impl Certification {
             confirmed: false,
         };
         match &mut state {
-            mac::State::Joined(ref mut session) => Ok(session.prepare_buffer::<N>(&send_data, buf)),
+            mac::State::Joined(session) => Ok(session.prepare_buffer::<N>(&send_data, buf)),
             mac::State::Otaa(_) => Err(mac::Error::NotJoined),
             mac::State::Unjoined => Err(mac::Error::NotJoined),
         }

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -3,8 +3,9 @@
 //! decrypting from send and receive buffers.
 
 use crate::{
+    AppSKey, Downlink, NwkSKey,
     radio::{self, RadioBuffer, RfConfig, RxConfig, RxMode},
-    region, AppSKey, Downlink, NwkSKey,
+    region,
 };
 use heapless::Vec;
 use lora_modulation::BaseBandModulationParams;
@@ -183,7 +184,7 @@ impl Mac {
         send_data: &SendData<'_>,
     ) -> Result<(radio::TxConfig, RxWindows, FcntUp)> {
         let fcnt = match &mut self.state {
-            State::Joined(ref mut session) => Ok(session.prepare_buffer::<N>(send_data, buf)),
+            State::Joined(session) => Ok(session.prepare_buffer::<N>(send_data, buf)),
             State::Otaa(_) => Err(Error::NotJoined),
             State::Unjoined => Err(Error::NotJoined),
         }?;
@@ -198,7 +199,7 @@ impl Mac {
 
     pub(crate) fn add_uplink<M: SerializableMacCommand>(&mut self, cmd: M) -> Result<()> {
         let _fcnt = match &mut self.state {
-            State::Joined(ref mut session) => {
+            State::Joined(session) => {
                 session.uplink.add_mac_command(cmd);
                 Ok(())
             }
@@ -268,7 +269,7 @@ impl Mac {
         rf_config: &RfConfig,
     ) -> Response {
         match &mut self.state {
-            State::Joined(ref mut session) => session.handle_rx::<N, D>(
+            State::Joined(session) => session.handle_rx::<N, D>(
                 &mut self.region,
                 &mut self.configuration,
                 #[cfg(feature = "certification")]
@@ -281,7 +282,7 @@ impl Mac {
                 snr,
                 false,
             ),
-            State::Otaa(ref mut otaa) => {
+            State::Otaa(otaa) => {
                 if let Some(session) =
                     otaa.handle_rx::<N>(&mut self.region, &mut self.configuration, buf)
                 {
@@ -307,7 +308,7 @@ impl Mac {
         rf_config: &RfConfig,
     ) -> Result<Response> {
         match &mut self.state {
-            State::Joined(ref mut session) => Ok(session.handle_rx::<N, D>(
+            State::Joined(session) => Ok(session.handle_rx::<N, D>(
                 &mut self.region,
                 &mut self.configuration,
                 #[cfg(feature = "certification")]

--- a/lorawan-device/src/mac/multicast.rs
+++ b/lorawan-device/src/mac/multicast.rs
@@ -1,6 +1,6 @@
+use crate::Downlink;
 use crate::mac::FcntDown;
 use crate::radio::RadioBuffer;
-use crate::Downlink;
 use crate::{async_device, mac};
 use core::fmt::Debug;
 use core::ops::RangeInclusive;
@@ -214,7 +214,7 @@ impl Multicast {
             confirmed: false,
         };
         match &mut state {
-            mac::State::Joined(ref mut session) => {
+            mac::State::Joined(session) => {
                 let response = session.prepare_buffer::<N>(&send_data, buf);
                 self.pending_uplinks.clear();
                 Ok(response)
@@ -229,10 +229,10 @@ impl Multicast {
         multicast_addr: McAddr,
     ) -> Option<(u8, &mut Session)> {
         self.sessions.iter_mut().enumerate().find_map(|(group_id, s)| {
-            if let Some(s) = s {
-                if s.multicast_addr() == multicast_addr {
-                    return Some((group_id as u8, s));
-                }
+            if let Some(s) = s
+                && s.multicast_addr() == multicast_addr
+            {
+                return Some((group_id as u8, s));
             }
             None
         })

--- a/lorawan-device/src/mac/otaa.rs
+++ b/lorawan-device/src/mac/otaa.rs
@@ -1,4 +1,4 @@
-use super::{del_to_delay_ms, session::Session, Response};
+use super::{Response, del_to_delay_ms, session::Session};
 use crate::radio::RadioBuffer;
 use crate::region::Configuration;
 use crate::{AppEui, AppKey, DevEui};

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -1,10 +1,11 @@
 use super::{
+    FcntUp, Response, SendData,
     otaa::{DevNonce, NetworkCredentials},
-    uplink, FcntUp, Response, SendData,
+    uplink,
 };
 use crate::radio::RadioBuffer;
 use crate::region::constants::MAX_FCNT_GAP;
-use crate::{region, AppSKey, Downlink, NwkSKey};
+use crate::{AppSKey, Downlink, NwkSKey, region};
 use core::num::NonZeroU8;
 use heapless::Vec;
 use lorawan::creator::{DataFrame, Payload};
@@ -13,7 +14,7 @@ use lorawan::maccommandcreator::{
     RXParamSetupAnsCreator, RXTimingSetupAnsCreator,
 };
 use lorawan::maccommands::DownlinkMacCommand;
-use lorawan::maccommands::{parse_downlink_mac_commands, MacCommands};
+use lorawan::maccommands::{MacCommands, parse_downlink_mac_commands};
 use lorawan::parser::{
     DataFrameType, DecryptedDataPayload, DecryptedJoinAcceptPayload, DevAddr, EncryptedDataPayload,
     FrmPayload,
@@ -160,16 +161,16 @@ impl Session {
             }
 
             #[cfg(feature = "certification")]
-            if let Some(port) = encrypted_data.f_port() {
-                if port > 0 {
-                    self.rx_app_cnt += 1;
-                }
+            if let Some(port) = encrypted_data.f_port()
+                && port > 0
+            {
+                self.rx_app_cnt += 1;
             }
             #[cfg(feature = "multicast")]
-            if let Some(port) = encrypted_data.f_port() {
-                if multicast.is_in_range(port) {
-                    return multicast.handle_rx(dl, bytes).into();
-                }
+            if let Some(port) = encrypted_data.f_port()
+                && multicast.is_in_range(port)
+            {
+                return multicast.handle_rx(dl, bytes).into();
             }
             let confirmed = encrypted_data.is_confirmed();
             let Some(fcnt) = next_fcnt_down(self.fcnt_down, encrypted_data.fhdr().fcnt()) else {
@@ -227,10 +228,10 @@ impl Session {
                                     self.override_adr = adr;
                                 }
                                 DutJoinReq => {
-                                    return Response::DeviceHandler(DeviceEvent::ResetMac)
+                                    return Response::DeviceHandler(DeviceEvent::ResetMac);
                                 }
                                 DutResetReq => {
-                                    return Response::DeviceHandler(DeviceEvent::ResetDevice)
+                                    return Response::DeviceHandler(DeviceEvent::ResetDevice);
                                 }
                                 LinkCheckReq => {
                                     return Response::LinkCheckReq;
@@ -244,7 +245,7 @@ impl Session {
                                 TxPeriodicityChange(periodicity) => {
                                     return Response::DeviceHandler(
                                         DeviceEvent::TxPeriodicityChange { periodicity },
-                                    )
+                                    );
                                 }
                                 UplinkPrepared => return Response::UplinkPrepared,
                                 NoUpdate => return Response::NoUpdate,
@@ -436,13 +437,11 @@ impl Session {
                     };
 
                     let cm_ack = region.channel_mask_validate(&channel_mask, dr);
-                    if cm_ack {
-                        if let (Some(dr), Some(pw)) = (dr, pw) {
-                            // TODO: handle nbtrans
-                            configuration.data_rate = dr;
-                            configuration.tx_power = pw;
-                            region.channel_mask_set(channel_mask.clone());
-                        }
+                    if cm_ack && let (Some(dr), Some(pw)) = (dr, pw) {
+                        // TODO: handle nbtrans
+                        configuration.data_rate = dr;
+                        configuration.tx_power = pw;
+                        region.channel_mask_set(channel_mask.clone());
                     }
                     // Add matching number of LinkADRAns responses
                     for _ in 0..num_adrreq {
@@ -493,12 +492,11 @@ impl Session {
                             }
                         }
                     };
-                    if freq_ack {
-                        if let (Some(rx2_dr), Some(rx1_dr_offset)) = (rx2_dr, rx1_dr_offset) {
-                            configuration.rx2_data_rate = rx2_dr;
-                            configuration.rx2_frequency = Some(freq);
-                            configuration.rx1_dr_offset = rx1_dr_offset;
-                        }
+                    if freq_ack && let (Some(rx2_dr), Some(rx1_dr_offset)) = (rx2_dr, rx1_dr_offset)
+                    {
+                        configuration.rx2_data_rate = rx2_dr;
+                        configuration.rx2_frequency = Some(freq);
+                        configuration.rx1_dr_offset = rx1_dr_offset;
                     }
 
                     let mut cmd = RXParamSetupAnsCreator::new();

--- a/lorawan-device/src/mac/uplink/mod.rs
+++ b/lorawan-device/src/mac/uplink/mod.rs
@@ -68,8 +68,8 @@ impl defmt::Format for Uplink {
 #[cfg(test)]
 mod test {
     use super::*;
-    use lorawan::maccommands::parse_uplink_mac_commands;
     use lorawan::maccommands::LinkADRAnsCreator;
+    use lorawan::maccommands::parse_uplink_mac_commands;
     #[test]
     fn two_link_adr_ans() {
         let mut uplink = Uplink::default();

--- a/lorawan-device/src/nb_device/state.rs
+++ b/lorawan-device/src/nb_device/state.rs
@@ -40,8 +40,9 @@ else(Ready)║ ╚═════════════╝   ║              
  */
 use super::super::*;
 use super::{
+    Event, RadioBuffer, Response, Timings,
     mac::{Frame, Mac, RxWindows, Window},
-    radio, Event, RadioBuffer, Response, Timings,
+    radio,
 };
 
 #[derive(Copy, Clone)]

--- a/lorawan-device/src/nb_device/test/util.rs
+++ b/lorawan-device/src/nb_device/test/util.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::radio::{RfConfig, RxQuality};
 
 use crate::nb_device::{
-    radio::{Event, PhyRxTx, Response},
     Device, Timings,
+    radio::{Event, PhyRxTx, Response},
 };
 use crate::test_util::*;
 use region::{Configuration, Region};

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -222,15 +222,15 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
             Frame::Data => {
                 let mut channel = self.get_random_in_range(rng);
                 loop {
-                    if self.channel_mask.is_enabled(channel).unwrap() {
-                        if let Some(ch) = self.channels[channel] {
-                            return TxChannel {
-                                datarate: R::datarates()[datarate as usize].clone().unwrap(),
-                                dr: datarate,
-                                frequency: ch.ul_frequency(),
-                                rx1_frequency: ch.rx1_frequency(),
-                            };
-                        }
+                    if self.channel_mask.is_enabled(channel).unwrap()
+                        && let Some(ch) = self.channels[channel]
+                    {
+                        return TxChannel {
+                            datarate: R::datarates()[datarate as usize].clone().unwrap(),
+                            dr: datarate,
+                            frequency: ch.ul_frequency(),
+                            rx1_frequency: ch.rx1_frequency(),
+                        };
                     }
                     channel = self.get_random_in_range(rng)
                 }
@@ -268,20 +268,18 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
         }
         if self.channel_mask.is_enabled(index as usize).is_ok()
             && self.channel_mask.is_enabled(index as usize).unwrap()
+            && let Some(mut channel) = self.channels[index as usize]
+            && channel.frequency != 0
         {
-            if let Some(mut channel) = self.channels[index as usize] {
-                if channel.frequency != 0 {
-                    channel.dl_frequency = if freq == channel.frequency {
-                        // Reset downlink frequency
-                        None
-                    } else {
-                        // Update downlink frequency
-                        Some(freq)
-                    };
-                    self.channels[index as usize] = Some(channel);
-                    return (freq_valid, true);
-                }
-            }
+            channel.dl_frequency = if freq == channel.frequency {
+                // Reset downlink frequency
+                None
+            } else {
+                // Update downlink frequency
+                Some(freq)
+            };
+            self.channels[index as usize] = Some(channel);
+            return (freq_valid, true);
         }
         (freq_valid, false)
     }

--- a/lorawan-device/src/region/fixed_channel_plans/au915/datarates.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/au915/datarates.rs
@@ -1,4 +1,4 @@
-use super::{Bandwidth, Datarate, SpreadingFactor, NUM_DATARATES};
+use super::{Bandwidth, Datarate, NUM_DATARATES, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES as usize] = [
     // DR0

--- a/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
@@ -215,9 +215,9 @@ mod test {
     use super::*;
     use crate::mac::Response;
     use crate::{
-        mac::{Mac, SendData},
-        test_util::{get_key, handle_join_request, Uplink},
         AppEui, AppKey, DevEui, NetworkCredentials,
+        mac::{Mac, SendData},
+        test_util::{Uplink, get_key, handle_join_request},
     };
     use heapless::Vec;
 

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -152,18 +152,17 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
     }
 
     fn channel_mask_validate(&self, channel_mask: &ChannelMask<9>, dr: Option<DR>) -> bool {
-        if let Some(dr) = dr {
-            if let Some(dr) = &F::datarates()[dr as usize] {
-                return match dr.bandwidth {
-                    Bandwidth::_500KHz => (64..=71).any(|i| channel_mask.is_enabled(i).unwrap()),
-                    Bandwidth::_125KHz => {
-                        // Check that at least two channels are enabled
-                        (0..64).filter(|&i| channel_mask.is_enabled(i).unwrap()).take(2).count()
-                            == 2
-                    }
-                    _ => true,
-                };
-            }
+        if let Some(dr) = dr
+            && let Some(dr) = &F::datarates()[dr as usize]
+        {
+            return match dr.bandwidth {
+                Bandwidth::_500KHz => (64..=71).any(|i| channel_mask.is_enabled(i).unwrap()),
+                Bandwidth::_125KHz => {
+                    // Check that at least two channels are enabled
+                    (0..64).filter(|&i| channel_mask.is_enabled(i).unwrap()).take(2).count() == 2
+                }
+                _ => true,
+            };
         }
         false
     }

--- a/lorawan-device/src/region/fixed_channel_plans/us915/datarates.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/us915/datarates.rs
@@ -1,4 +1,4 @@
-use super::{Bandwidth, Datarate, SpreadingFactor, NUM_DATARATES};
+use super::{Bandwidth, Datarate, NUM_DATARATES, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; NUM_DATARATES as usize] = [
     // DR0

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -53,10 +53,10 @@ pub(crate) use dynamic_channel_plans::IN865;
 
 #[cfg(any(feature = "region-us915", feature = "region-au915"))]
 mod fixed_channel_plans;
-#[cfg(any(feature = "region-us915", feature = "region-au915"))]
-pub use fixed_channel_plans::Subband;
 #[cfg(feature = "region-au915")]
 pub use fixed_channel_plans::AU915;
+#[cfg(any(feature = "region-us915", feature = "region-au915"))]
+pub use fixed_channel_plans::Subband;
 #[cfg(feature = "region-us915")]
 pub use fixed_channel_plans::US915;
 

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -3,8 +3,8 @@ use core::num::NonZeroU8;
 use lorawan::creator::{DataFrame, JoinAccept, Payload};
 use lorawan::default_crypto::{DefaultCrypto, DefaultNetworkCrypto};
 use lorawan::maccommandcreator::LinkADRReqCreator;
-use lorawan::maccommands::parse_uplink_mac_commands;
 use lorawan::maccommands::UplinkMacCommand;
+use lorawan::maccommands::parse_uplink_mac_commands;
 use lorawan::parser::{
     self, DataFrameType, DecryptedDataPayload, DecryptedJoinAcceptPayload, DevAddr, JoinNonce,
     NetId, PhyPayload,

--- a/lorawan-encoding/CHANGELOG.md
+++ b/lorawan-encoding/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## Unreleased
 
+- Move to Rust edition 2024 (requires Rust 1.85+)
 - Rewrite parser and creator as borrowed views, replacing the `T: AsRef<[u8]>`
   generic-over-storage design ([#465](https://github.com/lora-rs/lora-rs/pull/465)).
   Behavior changes from the previous API:

--- a/lorawan-encoding/Cargo.toml
+++ b/lorawan-encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lorawan"
 version = "0.9.1"
-edition = "2021"
+edition = "2024"
 authors = ["Ivaylo Petrov <ivajloip@gmail.com>"]
 description = "Crate lorawan provides structures and tools for reading and writing LoRaWAN messages from and to a slice of bytes."
 repository = "https://github.com/lora-rs/lora-rs"

--- a/lorawan-encoding/benches/lorawan.rs
+++ b/lorawan-encoding/benches/lorawan.rs
@@ -6,17 +6,17 @@
 //
 // author: Ivaylo Petrov <ivajloip@gmail.com>
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use lorawan::default_crypto::DefaultCrypto;
-use lorawan::maccommands::parse_downlink_mac_commands;
 use lorawan::maccommands::DownlinkMacCommand;
+use lorawan::maccommands::parse_downlink_mac_commands;
 use std::alloc::System;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 extern crate std;
 
 use lorawan::keys::*;
-use lorawan::parser::{parse, DecryptedDataPayload, FrmPayload, PhyPayload};
+use lorawan::parser::{DecryptedDataPayload, FrmPayload, PhyPayload, parse};
 
 #[global_allocator]
 static GLOBAL: trallocator::Trallocator<System> = trallocator::Trallocator::new(System);

--- a/lorawan-encoding/size-compare/Cargo.toml
+++ b/lorawan-encoding/size-compare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "size-compare"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/lorawan-encoding/size-compare/src/lib.rs
+++ b/lorawan-encoding/size-compare/src/lib.rs
@@ -85,13 +85,13 @@ mod new {
 }
 
 #[cfg(any(feature = "new1", feature = "new3"))]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn work_slice_new(ptr: *mut u8, len: usize) -> u32 {
     new::work(core::slice::from_raw_parts_mut(ptr, len))
 }
 
 #[cfg(feature = "new3")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn work_array_new(ptr: *const u8) -> u32 {
     let mut data = [0u8; 33];
     core::ptr::copy_nonoverlapping(ptr, data.as_mut_ptr(), 33);
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn work_array_new(ptr: *const u8) -> u32 {
 }
 
 #[cfg(feature = "new3")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn work_wrapper_new(ptr: *const u8) -> u32 {
     let mut data = [0u8; 33];
     core::ptr::copy_nonoverlapping(ptr, data.as_mut_ptr(), 33);

--- a/lorawan-encoding/src/default_crypto.rs
+++ b/lorawan-encoding/src/default_crypto.rs
@@ -4,8 +4,8 @@ use aes::cipher::{
     BlockCipherDecrypt as BlockDecrypt, BlockCipherEncrypt as BlockEncrypt, KeyInit,
 };
 use aes::{Aes128, Aes128Enc};
-use cmac::digest::InnerInit;
 use cmac::Cmac as RustCmac;
+use cmac::digest::InnerInit;
 
 /// Default software implementation of the device-side [`Crypto`] primitives.
 ///

--- a/lorawan-encoding/src/maccommandcreator.rs
+++ b/lorawan-encoding/src/maccommandcreator.rs
@@ -1,4 +1,4 @@
-use super::maccommands::{mac_commands_len, SerializableMacCommand};
+use super::maccommands::{SerializableMacCommand, mac_commands_len};
 use crate::types::{ChannelMask, DLSettings, DataRateRange, Frequency, Redundancy};
 
 #[derive(Debug, PartialEq)]

--- a/lorawan-encoding/src/multicast/group_setup.rs
+++ b/lorawan-encoding/src/multicast/group_setup.rs
@@ -1,4 +1,4 @@
-use crate::keys::{Crypto, McAppSKey, McKey, McNetSKey, NetworkCrypto, AES128};
+use crate::keys::{AES128, Crypto, McAppSKey, McKey, McNetSKey, NetworkCrypto};
 use crate::multicast::McGroupSetupReqCreator;
 use crate::{
     multicast::{McGroupSetupAnsCreator, McGroupSetupAnsPayload, McGroupSetupReqPayload},
@@ -189,8 +189,8 @@ mod tests {
     use super::*;
     use crate::default_crypto::{DefaultCrypto, DefaultNetworkCrypto};
     use crate::keys::McKEKey;
-    use crate::multicast::parse_downlink_multicast_commands;
     use crate::multicast::DownlinkRemoteSetup;
+    use crate::multicast::parse_downlink_multicast_commands;
 
     #[test]
     fn roundtrip() {

--- a/lorawan-encoding/src/multicast/group_status.rs
+++ b/lorawan-encoding/src/multicast/group_status.rs
@@ -1,6 +1,6 @@
 use crate::maccommands::Error;
 use crate::multicast::{
-    McGroupStatusAnsPayload, McGroupStatusReqCreator, McGroupStatusReqPayload, MAX_GROUPS,
+    MAX_GROUPS, McGroupStatusAnsPayload, McGroupStatusReqCreator, McGroupStatusReqPayload,
 };
 use crate::parser::McAddr;
 
@@ -161,8 +161,8 @@ impl McGroupStatusReqPayload<'_> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::multicast::{parse_downlink_multicast_commands, parse_uplink_multicast_commands};
     use crate::multicast::{DownlinkRemoteSetup, UplinkRemoteSetup};
+    use crate::multicast::{parse_downlink_multicast_commands, parse_uplink_multicast_commands};
     #[test]
     fn roundtrip_one_group() {
         let mut creator = McGroupStatusAnsCreator::new();

--- a/lorawan-encoding/src/parser.rs
+++ b/lorawan-encoding/src/parser.rs
@@ -73,7 +73,7 @@
 //! assert_eq!(bytes.len(), 18);
 //! ```
 
-use crate::keys::{AppSKey, Crypto, NwkSKey, AES128, MIC};
+use crate::keys::{AES128, AppSKey, Crypto, MIC, NwkSKey};
 use crate::packet_length::phy::join::{
     JOIN_ACCEPT_LEN, JOIN_ACCEPT_WITH_CFLIST_LEN, JOIN_REQUEST_LEN,
 };

--- a/lorawan-encoding/tests/certification.rs
+++ b/lorawan-encoding/tests/certification.rs
@@ -1,5 +1,5 @@
-use lorawan::certification::parse_downlink_dut_commands;
 use lorawan::certification::DownlinkDUTCommand::*;
+use lorawan::certification::parse_downlink_dut_commands;
 use lorawan::certification::*;
 use lorawan::maccommands::ParseError as Error;
 

--- a/lorawan-encoding/tests/lorawan.rs
+++ b/lorawan-encoding/tests/lorawan.rs
@@ -2,7 +2,7 @@
 
 use lorawan::creator::{DataFrame, JoinAccept, JoinRequest, Payload};
 use lorawan::default_crypto::{DefaultCrypto, DefaultNetworkCrypto};
-use lorawan::keys::{AppKey, AppSKey, NwkSKey, AES128, MIC};
+use lorawan::keys::{AES128, AppKey, AppSKey, MIC, NwkSKey};
 use lorawan::parser::*;
 
 use core::str::FromStr;
@@ -491,10 +491,10 @@ fn join_accept_decryption_and_derived_keys() {
 // ---------------------------------------------------------------------------
 
 mod mac_commands {
-    use lorawan::maccommands::{
-        parse_downlink_mac_commands, parse_uplink_mac_commands, ParseError as MacError,
-    };
     use lorawan::maccommands::{DownlinkMacCommand, UplinkMacCommand};
+    use lorawan::maccommands::{
+        ParseError as MacError, parse_downlink_mac_commands, parse_uplink_mac_commands,
+    };
 
     #[test]
     fn parses_valid_uplink_stream() {
@@ -813,8 +813,8 @@ mod euis {
 mod certification {
     use lorawan::certification::*;
     use lorawan::certification::{
-        parse_downlink_dut_commands, parse_uplink_dut_commands, DownlinkDUTCommand,
-        UplinkDUTCommand,
+        DownlinkDUTCommand, UplinkDUTCommand, parse_downlink_dut_commands,
+        parse_uplink_dut_commands,
     };
     use lorawan::maccommands::ParseError as MacError;
 
@@ -888,8 +888,8 @@ mod multicast {
     use lorawan::keys::{McKEKey, McKey};
     use lorawan::maccommands::ParseError as MacError;
     use lorawan::multicast::{
-        parse_downlink_multicast_commands, parse_uplink_multicast_commands, DownlinkRemoteSetup,
-        UplinkRemoteSetup,
+        DownlinkRemoteSetup, UplinkRemoteSetup, parse_downlink_multicast_commands,
+        parse_uplink_multicast_commands,
     };
     use lorawan::multicast::{McGroupSetupReqCreator, McGroupStatusAnsCreator};
     use lorawan::parser::McAddr;

--- a/lorawan-encoding/tests/maccommands.rs
+++ b/lorawan-encoding/tests/maccommands.rs
@@ -1,7 +1,7 @@
 use lorawan::maccommandcreator::*;
 use lorawan::maccommands::*;
 use lorawan::maccommands::{parse_downlink_mac_commands, parse_uplink_mac_commands};
-use lorawan::types::{DLSettings, DataRateRange, Frequency, Redundancy, DR};
+use lorawan::types::{DLSettings, DR, DataRateRange, Frequency, Redundancy};
 
 macro_rules! test_helper {
     ( $cmd:ident, $data:ident, $name:ident, $type:ident, $size:expr, $( ( $method:ident, $val:expr ) ,)*) => {{

--- a/lorawan-macros/Cargo.toml
+++ b/lorawan-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lorawan-macros"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 description = "A collection of macros to generate common code for LoRaWAN mac command parsers."
 repository = "https://github.com/lora-rs/lora-rs"

--- a/lorawan-macros/src/lib.rs
+++ b/lorawan-macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Ident, Span};
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput, Fields, Meta, PathArguments};
+use syn::{Data, DeriveInput, Fields, Meta, PathArguments, parse_macro_input};
 
 struct Payload {
     name: Ident,
@@ -209,33 +209,33 @@ pub fn derive_command_handler(input: proc_macro::TokenStream) -> proc_macro::Tok
             });
 
             // Add fixed-length methods if len is specified
-            if let Some(ref len) = len_opt {
-                if let Some(lt) = lt {
-                    payload_struct_impls.push(quote! {
-                        impl<#lt> #t<#lt> {
-                            /// Creates a new instance of the MAC command if there is enough data.
-                            pub fn new(data: &#lt [u8]) -> Result<#t<#lt>, Error> {
-                                if data.len() != Self::max_len() {
-                                    Err(Error::BufferTooShort)
-                                } else {
-                                    Ok(#t(data))
-                                }
+            if let Some(len) = len_opt
+                && let Some(lt) = lt
+            {
+                payload_struct_impls.push(quote! {
+                    impl<#lt> #t<#lt> {
+                        /// Creates a new instance of the MAC command if there is enough data.
+                        pub fn new(data: &#lt [u8]) -> Result<#t<#lt>, Error> {
+                            if data.len() != Self::max_len() {
+                                Err(Error::BufferTooShort)
+                            } else {
+                                Ok(#t(data))
                             }
-
-                            /// Maximum length of payload without the CID.
-                            pub const fn max_len() -> usize {
-                                #len
-                            }
-
-                            /// Actual length of payload without the CID.
-                            #[allow(clippy::len_without_is_empty)]
-                            pub fn len(&self) -> usize {
-                                Self::max_len()
-                            }
-
                         }
-                    });
-                }
+
+                        /// Maximum length of payload without the CID.
+                        pub const fn max_len() -> usize {
+                            #len
+                        }
+
+                        /// Actual length of payload without the CID.
+                        #[allow(clippy::len_without_is_empty)]
+                        pub fn len(&self) -> usize {
+                            Self::max_len()
+                        }
+
+                    }
+                });
             }
 
             // Only build Creator structs for fixed-length commands

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,8 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "stable"
-components = [ "clippy", "rust-src", "rustfmt", "llvm-tools" ]
+channel = "1.97"
+components = [ "clippy", "rust-src", "rustfmt", "llvm-tools", "rust-analyzer" ]
 targets = [
     "thumbv6m-none-eabi",
     "thumbv7em-none-eabi",


### PR DESCRIPTION
Bumps the whole workspace (and the CI-built examples) to edition 2024, following the conventions used by the embassy project:

- `edition = "2024"` on every crate
- no per-crate `rust-version` fields: the pinned toolchain defines the supported compiler, so the two stale `rust-version = "1.75"` entries (lora-phy, lorawan-device) are dropped
- `rust-toolchain.toml` pins a concrete stable (`1.97`, same as embassy today) instead of the moving `stable` channel, and gains the `rust-analyzer` component

Code changes are the mechanical edition-2024 fallout:

- remove `ref`/`ref mut` binding modifiers that the new match ergonomics reject in implicitly-borrowing patterns
- `#[no_mangle]` becomes `#[unsafe(no_mangle)]` in size-compare
- collapse nested `if`s into let-chains where clippy (with let-chains now stable) flags them, since CI runs clippy with `-Dclippy::all`
- rustfmt import reordering from the 2024 style edition

The esp32 examples stay on edition 2021: they build with the separate `esp` toolchain channel and are not covered by CI, so I could not verify a bump there.

Verified locally on 1.97.1: `cargo build --all --all-features`, `cargo test --all-features` (all suites green), `cargo clippy --tests --all-features` (clean), `cargo fmt --check`, plus release builds of the nrf52840, rp, stm32l0 and stm32wl examples. The two pre-existing dead-code warnings in the example builds (`add_uplink`, `LinkCheckReq`) are unchanged from main.