### PR TITLE
lorawan: compute datarate-aware receive windows

### DIFF
--- a/lora-modulation/CHANGELOG.md
+++ b/lora-modulation/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## Unreleased
 
 - Move to Rust edition 2024 (requires Rust 1.85+)
+- Add overflow-safe `delay_in_symbols_ceil` and expose `symbol_duration_us`
 - Rename defmt feature to defmt-03
 
 ## [v0.1.5]

--- a/lora-modulation/src/lib.rs
+++ b/lora-modulation/src/lib.rs
@@ -129,10 +129,6 @@ impl BaseBandModulationParams {
         Self { sf, bw, cr, ldro, t_sym_us }
     }
 
-    pub const fn delay_in_symbols(&self, delay_in_ms: u32) -> u16 {
-        (delay_in_ms * 1000 / self.t_sym_us) as u16
-    }
-
     /// Convert a millisecond duration to symbols, rounding up so the resulting
     /// symbol count never represents less than the requested duration.
     pub const fn delay_in_symbols_ceil(&self, delay_in_ms: u32) -> u16 {

--- a/lora-modulation/src/lib.rs
+++ b/lora-modulation/src/lib.rs
@@ -133,6 +133,23 @@ impl BaseBandModulationParams {
         (delay_in_ms * 1000 / self.t_sym_us) as u16
     }
 
+    /// Convert a millisecond duration to symbols, rounding up so the resulting
+    /// symbol count never represents less than the requested duration.
+    pub const fn delay_in_symbols_ceil(&self, delay_in_ms: u32) -> u16 {
+        let delay_us = delay_in_ms as u64 * 1_000;
+        let symbols = delay_us.div_ceil(self.t_sym_us as u64);
+        if symbols > u16::MAX as u64 {
+            u16::MAX
+        } else {
+            symbols as u16
+        }
+    }
+
+    /// Duration of one symbol in microseconds.
+    pub const fn symbol_duration_us(&self) -> u32 {
+        self.t_sym_us
+    }
+
     pub const fn symbols_to_ms(&self, symbols: u32) -> u32 {
         (self.t_sym_us * symbols) / 1_000
     }
@@ -223,6 +240,13 @@ mod tests {
         assert_eq!(1152, SF5BW500.time_on_air_us(None, true, 0));
         assert_eq!(6656, SF7BW250.time_on_air_us(None, true, 0));
         assert_eq!(13312, SF7BW125.time_on_air_us(None, true, 0));
+    }
+
+    #[test]
+    fn delay_in_symbols_ceil_never_shortens_the_delay() {
+        assert_eq!(1, SF7BW125.delay_in_symbols_ceil(1));
+        assert_eq!(2, SF7BW125.delay_in_symbols_ceil(2));
+        assert_eq!(u16::MAX, SF5BW500.delay_in_symbols_ceil(u32::MAX));
     }
 
     #[test]

--- a/lora-phy/CHANGELOG.md
+++ b/lora-phy/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - Move to Rust edition 2024 (requires Rust 1.85+)
+- lorawan-radio: Compute datarate-aware RX window offsets and symbol timeouts using LoRaMac-node's configurable system-error model
 - sx127x: Add `GenericSx127xInterfaceVariant::new_with_secondary_irq` to watch DIO1 (RxTimeout), fixing LoRaWAN RX-window hangs on single-IRQ boards
 - Bump MSRV to 1.75
 - Add documentation for crate features

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -62,7 +62,8 @@ where
         self.system_max_rx_error_ms = error_ms;
     }
 
-    /// Set the minimum preamble-detection timeout.
+    /// Set the minimum preamble-detection timeout, in symbols. Values below 5
+    /// are raised to 5.
     pub fn set_min_rx_symbols(&mut self, symbols: u16) {
         self.min_rx_symbols = symbols.max(5);
     }
@@ -184,11 +185,9 @@ where
         self.lora.sleep(false).await.map_err(|e| e.into())
     }
     async fn low_power_retain(&mut self) -> Result<(), Self::PhyError> {
-        // Warm sleep between the transmit and its receive windows on chips that
-        // retain their configuration, so the next setup is a warm start
-        // (hundreds of us) instead of a cold re-init (tens of ms). Chips without
-        // a retention sleep must re-initialize after every sleep, so they take
-        // the normal cold sleep here.
+        // Warm sleep on chips that retain their configuration, so the next
+        // setup is a warm start instead of a full cold re-init. Chips without
+        // a retention sleep take the normal cold sleep.
         self.lora.sleep(RK::SUPPORTS_WARM_START).await.map_err(|e| e.into())
     }
 }
@@ -234,8 +233,8 @@ impl RxMode {
 /// there would close the window before a latest-edge packet inside the
 /// configured error bound arrives, so fall back to the wall-clock RX timer,
 /// which covers the same span and stops on preamble detection just like the
-/// symbol timeout. Chips without that timer keep the clamped symbol timeout;
-/// their windows shorten by the clamped amount at the late edge.
+/// symbol timeout. Chips without that timer keep the clamped symbol timeout
+/// and lose the excess from the late edge of the window.
 fn select_single_rx_mode(
     timeout_symbols: u16,
     symbol_duration_us: u32,
@@ -275,8 +274,7 @@ fn compute_rx_window_timing(
     // device clock runs fast, and keep the window open for `lead + 2 * error`
     // so it still spans the nominal time when setup is fast. This keeps the
     // timeout data-rate-aware (it scales with the symbol duration) without
-    // assuming the setup latency equals the lead time, which is what made the
-    // narrower windows close before the nominal time on radios with fast setup.
+    // assuming the setup latency equals the lead time.
     let offset_us = -((lead_us + error_us) as i64);
 
     // Spanning the nominal time is not enough on its own: a packet arriving at
@@ -364,8 +362,8 @@ mod tests {
     #[test]
     fn under_cap_window_keeps_symbol_timeout() {
         // At or below the ceiling nothing changes: EU868's fastest window
-        // (SF7/BW250 = 143+6 symbols) stays symbol-closed.
-        assert_eq!(select_single_rx_mode(149, 512, 248, true), RxMode::Single(149));
+        // (SF7/BW250 with defaults = 137 span + 6 margin) stays symbol-closed.
+        assert_eq!(select_single_rx_mode(143, 512, 248, true), RxMode::Single(143));
         assert_eq!(select_single_rx_mode(248, 256, 248, true), RxMode::Single(248));
     }
 

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -186,7 +186,7 @@ where
     async fn low_power(&mut self) -> Result<(), Self::PhyError> {
         self.lora.sleep(false).await.map_err(|e| e.into())
     }
-    async fn low_power_retain(&mut self) -> Result<(), Self::PhyError> {
+    async fn warm_sleep(&mut self) -> Result<(), Self::PhyError> {
         // Warm sleep on chips that retain their configuration, so the next
         // setup is a warm start instead of a full cold re-init. Chips without
         // a retention sleep take the normal cold sleep.

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -270,17 +270,13 @@ fn compute_rx_window_timing(
     let lead_us = wake_up_time_ms as u64 * 1_000;
     let buffer_us = window_buffer_ms as u64 * 1_000;
 
-    // The radio is configured after the offset sleep, and the setup transaction
-    // itself takes up to `wake_up_time_ms` (the lead time budget). We do not
-    // know where in [0, lead] it actually lands, so the window has to cover the
-    // nominal time for the whole range. Open `lead + error` early so the radio
-    // is listening before the nominal window even when setup is slow and the
-    // device clock runs fast, and keep the window open for `buffer + 2 * error`.
-    // The buffer defaults to the lead time, preserving that coverage while
-    // allowing applications to explicitly widen the receive window. This
-    // keeps the timeout data-rate-aware (it scales with the symbol duration)
-    // without assuming the setup latency equals the lead time.
+    // Start setup early enough to cover the radio wake-up time and the maximum
+    // clock or scheduling error.
     let offset_us = -((lead_us + error_us) as i64);
+
+    // Keep the window open for the configured buffer plus the maximum error on
+    // both sides of the nominal receive time.
+    let span_us = buffer_us + 2 * error_us;
 
     // Spanning the nominal time is not enough on its own: a packet arriving at
     // the late edge of the clock-error bound begins its preamble exactly as a
@@ -288,7 +284,6 @@ fn compute_rx_window_timing(
     // for the radio to detect. Extend the timeout by `min_symbols` so even the
     // latest packet has that much preamble in-window before the single-RX
     // timeout expires.
-    let span_us = buffer_us + 2 * error_us;
     let timeout_symbols = (span_us.div_ceil(symbol_us) + min_symbols).min(u16::MAX as u64) as u16;
 
     RxWindowTiming {

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -229,14 +229,11 @@ impl RxMode {
 
 /// Choose how the chip should close a receive window `timeout_symbols` long.
 ///
-/// At fast data rates the window span can exceed what the chip's symbol
-/// counter can express (SF7/BW500 with the default lead and error wants 280+
-/// symbols against the sx126x/lr11xx ceiling of 248). Letting the driver clamp
-/// there would close the window before a latest-edge packet inside the
-/// configured error bound arrives, so fall back to the wall-clock RX timer,
-/// which covers the same span and stops on preamble detection just like the
-/// symbol timeout. Chips without that timer keep the clamped symbol timeout
-/// and lose the excess from the late edge of the window.
+/// Uses the symbol timeout when it fits, otherwise falls back to the
+/// wall-clock timeout when supported.
+///
+/// If neither timeout can represent the requested window, clamps it to
+/// `max_symbols` and logs a warning.
 fn select_single_rx_mode(
     timeout_symbols: u16,
     symbol_duration_us: u32,

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -68,6 +68,7 @@ where
         self.min_rx_symbols = symbols.max(5);
     }
 
+    /// Set the receive-window timeout margin, in milliseconds.
     pub fn set_rx_window_buffer(&mut self, buffer: u32) {
         self.rx_window_buffer = buffer;
     }
@@ -93,6 +94,7 @@ where
             self.min_rx_symbols,
             self.system_max_rx_error_ms,
             self.rx_window_lead_time,
+            self.rx_window_buffer,
         )
     }
 }
@@ -260,21 +262,24 @@ fn compute_rx_window_timing(
     min_rx_symbols: u16,
     system_max_rx_error_ms: u32,
     wake_up_time_ms: u32,
+    window_buffer_ms: u32,
 ) -> RxWindowTiming {
     let symbol_us = symbol_duration_us as u64;
     let min_symbols = min_rx_symbols.max(5) as u64;
     let error_us = system_max_rx_error_ms as u64 * 1_000;
     let lead_us = wake_up_time_ms as u64 * 1_000;
+    let buffer_us = window_buffer_ms as u64 * 1_000;
 
     // The radio is configured after the offset sleep, and the setup transaction
     // itself takes up to `wake_up_time_ms` (the lead time budget). We do not
     // know where in [0, lead] it actually lands, so the window has to cover the
     // nominal time for the whole range. Open `lead + error` early so the radio
     // is listening before the nominal window even when setup is slow and the
-    // device clock runs fast, and keep the window open for `lead + 2 * error`
-    // so it still spans the nominal time when setup is fast. This keeps the
-    // timeout data-rate-aware (it scales with the symbol duration) without
-    // assuming the setup latency equals the lead time.
+    // device clock runs fast, and keep the window open for `buffer + 2 * error`.
+    // The buffer defaults to the lead time, preserving that coverage while
+    // allowing applications to explicitly widen the receive window. This
+    // keeps the timeout data-rate-aware (it scales with the symbol duration)
+    // without assuming the setup latency equals the lead time.
     let offset_us = -((lead_us + error_us) as i64);
 
     // Spanning the nominal time is not enough on its own: a packet arriving at
@@ -283,7 +288,7 @@ fn compute_rx_window_timing(
     // for the radio to detect. Extend the timeout by `min_symbols` so even the
     // latest packet has that much preamble in-window before the single-RX
     // timeout expires.
-    let span_us = lead_us + 2 * error_us;
+    let span_us = buffer_us + 2 * error_us;
     let timeout_symbols = (span_us.div_ceil(symbol_us) + min_symbols).min(u16::MAX as u64) as u16;
 
     RxWindowTiming {
@@ -307,7 +312,7 @@ mod tests {
 
         // SF7/BW125: 1.024 ms per symbol. 70 ms span -> 69 symbols, +6 margin.
         assert_eq!(
-            compute_rx_window_timing(1_024, 6, 10, 50),
+            compute_rx_window_timing(1_024, 6, 10, 50, 50),
             RxWindowTiming {
                 offset_ms: -60,
                 timeout_symbols: 75
@@ -316,7 +321,7 @@ mod tests {
 
         // SF12/BW125: 32.768 ms per symbol. 3 symbols cover the span, +6 margin.
         assert_eq!(
-            compute_rx_window_timing(32_768, 6, 10, 50),
+            compute_rx_window_timing(32_768, 6, 10, 50, 50),
             RxWindowTiming {
                 offset_ms: -60,
                 timeout_symbols: 9
@@ -327,14 +332,14 @@ mod tests {
     #[test]
     fn window_timeout_supports_faster_bandwidths() {
         assert_eq!(
-            compute_rx_window_timing(512, 6, 10, 50),
+            compute_rx_window_timing(512, 6, 10, 50, 50),
             RxWindowTiming {
                 offset_ms: -60,
                 timeout_symbols: 143
             }
         );
         assert_eq!(
-            compute_rx_window_timing(256, 6, 10, 50),
+            compute_rx_window_timing(256, 6, 10, 50, 50),
             RxWindowTiming {
                 offset_ms: -60,
                 timeout_symbols: 280
@@ -349,12 +354,12 @@ mod tests {
         // (280 * 256 us = 71.68 ms, rounded up) instead of clamping to
         // 248 * 256 us = 63.5 ms, which would close before a latest-edge
         // packet inside the error bound arrives.
-        let timing = compute_rx_window_timing(256, 6, 10, 50);
+        let timing = compute_rx_window_timing(256, 6, 10, 50, 50);
         assert_eq!(timing.timeout_symbols, 280);
         assert_eq!(select_single_rx_mode(280, 256, 248, true), RxMode::SingleMs(72));
 
         // lr11xx min_rx_symbols default of 13: 287 symbols, same fallback.
-        let timing = compute_rx_window_timing(256, 13, 10, 50);
+        let timing = compute_rx_window_timing(256, 13, 10, 50, 50);
         assert_eq!(timing.timeout_symbols, 287);
         assert_eq!(select_single_rx_mode(287, 256, 248, true), RxMode::SingleMs(74));
     }
@@ -380,10 +385,21 @@ mod tests {
         // error 50 ms, lead 50 ms: open 100 ms early, span 150 ms -> 147
         // symbols, +6 margin.
         assert_eq!(
-            compute_rx_window_timing(1_024, 6, 50, 50),
+            compute_rx_window_timing(1_024, 6, 50, 50, 50),
             RxWindowTiming {
                 offset_ms: -100,
                 timeout_symbols: 153
+            }
+        );
+    }
+
+    #[test]
+    fn window_buffer_expands_timeout_without_changing_offset() {
+        assert_eq!(
+            compute_rx_window_timing(1_000, 6, 10, 50, 100),
+            RxWindowTiming {
+                offset_ms: -60,
+                timeout_symbols: 126
             }
         );
     }

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -275,12 +275,8 @@ fn compute_rx_window_timing(
     // both sides of the nominal receive time.
     let span_us = buffer_us + 2 * error_us;
 
-    // Spanning the nominal time is not enough on its own: a packet arriving at
-    // the late edge of the clock-error bound begins its preamble exactly as a
-    // span-only timeout would fire, leaving no preamble symbols in the window
-    // for the radio to detect. Extend the timeout by `min_symbols` so even the
-    // latest packet has that much preamble in-window before the single-RX
-    // timeout expires.
+    // Add enough preamble margin to detect a packet arriving at the latest
+    // expected time.
     let timeout_symbols = (span_us.div_ceil(symbol_us) + min_symbols).min(u16::MAX as u64) as u16;
 
     RxWindowTiming {

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -243,8 +243,14 @@ fn compute_rx_window_timing(
     // narrower windows close before the nominal time on radios with fast setup.
     let offset_us = -((lead_us + error_us) as i64);
 
+    // Spanning the nominal time is not enough on its own: a packet arriving at
+    // the late edge of the clock-error bound begins its preamble exactly as a
+    // span-only timeout would fire, leaving no preamble symbols in the window
+    // for the radio to detect. Extend the timeout by `min_symbols` so even the
+    // latest packet has that much preamble in-window before the single-RX
+    // timeout expires.
     let span_us = lead_us + 2 * error_us;
-    let timeout_symbols = span_us.div_ceil(symbol_us).max(min_symbols).min(u16::MAX as u64) as u16;
+    let timeout_symbols = (span_us.div_ceil(symbol_us) + min_symbols).min(u16::MAX as u64) as u16;
 
     RxWindowTiming {
         // Truncation toward zero on a negative value matches ceil(offset_us /
@@ -262,23 +268,24 @@ mod tests {
     fn window_timeout_scales_with_symbol_duration() {
         // The offset is set by the lead time and clock error (open lead + error
         // = 60 ms early), not the data rate. The timeout, in symbols, grows as
-        // the symbols get shorter so the window spans the same wall-clock time.
+        // the symbols get shorter so the window spans the same wall-clock time,
+        // plus min_symbols of preamble margin for a latest-edge arrival.
 
-        // SF7/BW125: 1.024 ms per symbol. 70 ms span -> 69 symbols.
+        // SF7/BW125: 1.024 ms per symbol. 70 ms span -> 69 symbols, +6 margin.
         assert_eq!(
             compute_rx_window_timing(1_024, 6, 10, 50),
             RxWindowTiming {
                 offset_ms: -60,
-                timeout_symbols: 69
+                timeout_symbols: 75
             }
         );
 
-        // SF12/BW125: 32.768 ms per symbol. The six-symbol minimum dominates.
+        // SF12/BW125: 32.768 ms per symbol. 3 symbols cover the span, +6 margin.
         assert_eq!(
             compute_rx_window_timing(32_768, 6, 10, 50),
             RxWindowTiming {
                 offset_ms: -60,
-                timeout_symbols: 6
+                timeout_symbols: 9
             }
         );
     }
@@ -289,26 +296,27 @@ mod tests {
             compute_rx_window_timing(512, 6, 10, 50),
             RxWindowTiming {
                 offset_ms: -60,
-                timeout_symbols: 137
+                timeout_symbols: 143
             }
         );
         assert_eq!(
             compute_rx_window_timing(256, 6, 10, 50),
             RxWindowTiming {
                 offset_ms: -60,
-                timeout_symbols: 274
+                timeout_symbols: 280
             }
         );
     }
 
     #[test]
     fn larger_system_error_expands_and_shifts_window_earlier() {
-        // error 50 ms, lead 50 ms: open 100 ms early, span 150 ms.
+        // error 50 ms, lead 50 ms: open 100 ms early, span 150 ms -> 147
+        // symbols, +6 margin.
         assert_eq!(
             compute_rx_window_timing(1_024, 6, 50, 50),
             RxWindowTiming {
                 offset_ms: -100,
-                timeout_symbols: 147
+                timeout_symbols: 153
             }
         );
     }

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -145,7 +145,13 @@ where
     }
 
     async fn setup_rx_window(&mut self, config: RxConfig, timing: RxWindowTiming) -> Result<(), Self::PhyError> {
-        self.setup_rx_mode(config, RxMode::Single(timing.timeout_symbols)).await
+        let mode = select_single_rx_mode(
+            timing.timeout_symbols,
+            config.rf.bb.symbol_duration_us(),
+            RK::MAX_SINGLE_RX_SYMBOLS,
+            RK::SUPPORTS_TIMED_SINGLE_RX,
+        );
+        self.setup_rx_mode(config, mode).await
     }
 
     async fn rx_single(&mut self, buf: &mut [u8]) -> Result<RxStatus, Self::PhyError> {
@@ -217,6 +223,36 @@ impl RxMode {
                 RxMode::Single(PREAMBLE_SYMBOLS.saturating_add(bb.delay_in_symbols_ceil(ms)))
             }
         }
+    }
+}
+
+/// Choose how the chip should close a receive window `timeout_symbols` long.
+///
+/// At fast data rates the window span can exceed what the chip's symbol
+/// counter can express (SF7/BW500 with the default lead and error wants 280+
+/// symbols against the sx126x/lr11xx ceiling of 248). Letting the driver clamp
+/// there would close the window before a latest-edge packet inside the
+/// configured error bound arrives, so fall back to the wall-clock RX timer,
+/// which covers the same span and stops on preamble detection just like the
+/// symbol timeout. Chips without that timer keep the clamped symbol timeout;
+/// their windows shorten by the clamped amount at the late edge.
+fn select_single_rx_mode(
+    timeout_symbols: u16,
+    symbol_duration_us: u32,
+    max_symbols: u16,
+    timed_single_rx: bool,
+) -> RxMode {
+    if timeout_symbols <= max_symbols {
+        RxMode::Single(timeout_symbols)
+    } else if timed_single_rx {
+        let ms = (timeout_symbols as u64 * symbol_duration_us as u64).div_ceil(1_000) as u32;
+        RxMode::SingleMs(ms)
+    } else {
+        warn!(
+            "rx window of {} symbols exceeds the chip's {}-symbol timeout ceiling; clamping shortens the late edge",
+            timeout_symbols, max_symbols
+        );
+        RxMode::Single(max_symbols)
     }
 }
 
@@ -306,6 +342,39 @@ mod tests {
                 timeout_symbols: 280
             }
         );
+    }
+
+    #[test]
+    fn over_cap_window_falls_back_to_wall_clock_close() {
+        // SF7/BW500 (256 us symbols), defaults: 280 symbols > the sx126x/lr11xx
+        // 248-symbol ceiling. The wall-clock close covers the full span
+        // (280 * 256 us = 71.68 ms, rounded up) instead of clamping to
+        // 248 * 256 us = 63.5 ms, which would close before a latest-edge
+        // packet inside the error bound arrives.
+        let timing = compute_rx_window_timing(256, 6, 10, 50);
+        assert_eq!(timing.timeout_symbols, 280);
+        assert_eq!(select_single_rx_mode(280, 256, 248, true), RxMode::SingleMs(72));
+
+        // lr11xx min_rx_symbols default of 13: 287 symbols, same fallback.
+        let timing = compute_rx_window_timing(256, 13, 10, 50);
+        assert_eq!(timing.timeout_symbols, 287);
+        assert_eq!(select_single_rx_mode(287, 256, 248, true), RxMode::SingleMs(74));
+    }
+
+    #[test]
+    fn under_cap_window_keeps_symbol_timeout() {
+        // At or below the ceiling nothing changes: EU868's fastest window
+        // (SF7/BW250 = 143+6 symbols) stays symbol-closed.
+        assert_eq!(select_single_rx_mode(149, 512, 248, true), RxMode::Single(149));
+        assert_eq!(select_single_rx_mode(248, 256, 248, true), RxMode::Single(248));
+    }
+
+    #[test]
+    fn over_cap_window_clamps_without_wall_clock_timer() {
+        // A chip with no wall-clock RX timer (sx127x) clamps to its ceiling;
+        // only reachable there with an extreme configured error (its ceiling
+        // is 1023 symbols).
+        assert_eq!(select_single_rx_mode(1030, 1_024, 1023, false), RxMode::Single(1023));
     }
 
     #[test]

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -10,7 +10,6 @@ use lorawan_device::async_device::{
 };
 
 const DEFAULT_RX_WINDOW_LEAD_TIME: u32 = 50;
-const DEFAULT_MIN_RX_SYMBOLS: u16 = 6;
 const DEFAULT_SYSTEM_MAX_RX_ERROR_MS: u32 = 10;
 
 /// LoRaWAN radio implementation.
@@ -41,7 +40,7 @@ where
             rx_pkt_params: None,
             rx_window_lead_time: DEFAULT_RX_WINDOW_LEAD_TIME,
             rx_window_buffer: DEFAULT_RX_WINDOW_LEAD_TIME,
-            min_rx_symbols: DEFAULT_MIN_RX_SYMBOLS,
+            min_rx_symbols: RK::DEFAULT_MIN_RX_SYMBOLS,
             system_max_rx_error_ms: DEFAULT_SYSTEM_MAX_RX_ERROR_MS,
         }
     }
@@ -222,20 +221,26 @@ fn compute_rx_window_timing(
     let symbol_us = symbol_duration_us as u64;
     let min_symbols = min_rx_symbols.max(5) as u64;
     let error_us = system_max_rx_error_ms as u64 * 1_000;
+    let lead_us = wake_up_time_ms as u64 * 1_000;
 
-    // LoRaMac-node's RegionCommonComputeRxWindowParameters equations. The
-    // factor of two covers the same maximum timing error before and after the
-    // nominal window time.
-    let numerator = (2 * min_symbols - 8) * symbol_us + 2 * error_us;
-    let timeout_symbols = numerator.div_ceil(symbol_us).max(min_symbols);
-    let timeout_symbols = timeout_symbols.min(u16::MAX as u64) as u16;
+    // The radio is configured after the offset sleep, and the setup transaction
+    // itself takes up to `wake_up_time_ms` (the lead time budget). We do not
+    // know where in [0, lead] it actually lands, so the window has to cover the
+    // nominal time for the whole range. Open `lead + error` early so the radio
+    // is listening before the nominal window even when setup is slow and the
+    // device clock runs fast, and keep the window open for `lead + 2 * error`
+    // so it still spans the nominal time when setup is fast. This keeps the
+    // timeout data-rate-aware (it scales with the symbol duration) without
+    // assuming the setup latency equals the lead time, which is what made the
+    // narrower windows close before the nominal time on radios with fast setup.
+    let offset_us = -((lead_us + error_us) as i64);
 
-    let half_window_us = (timeout_symbols as u64 * symbol_us).div_ceil(2);
-    let offset_us = 4_i64 * symbol_us as i64 - half_window_us as i64 - wake_up_time_ms as i64 * 1_000;
+    let span_us = lead_us + 2 * error_us;
+    let timeout_symbols = span_us.div_ceil(symbol_us).max(min_symbols).min(u16::MAX as u64) as u16;
 
     RxWindowTiming {
-        // Integer division truncates negative values toward zero, which is
-        // equivalent to ceil(offset_us / 1000), as used by LoRaMac-node.
+        // Truncation toward zero on a negative value matches ceil(offset_us /
+        // 1000): the window opens no later than the microsecond-exact offset.
         offset_ms: (offset_us / 1_000).clamp(i32::MIN as i64, i32::MAX as i64) as i32,
         timeout_symbols,
     }
@@ -246,13 +251,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn loramac_default_window_timing_scales_with_symbol_duration() {
-        // SF7/BW125: 1.024 ms per symbol.
+    fn window_timeout_scales_with_symbol_duration() {
+        // The offset is set by the lead time and clock error (open lead + error
+        // = 60 ms early), not the data rate. The timeout, in symbols, grows as
+        // the symbols get shorter so the window spans the same wall-clock time.
+
+        // SF7/BW125: 1.024 ms per symbol. 70 ms span -> 69 symbols.
         assert_eq!(
             compute_rx_window_timing(1_024, 6, 10, 50),
             RxWindowTiming {
-                offset_ms: -58,
-                timeout_symbols: 24
+                offset_ms: -60,
+                timeout_symbols: 69
             }
         );
 
@@ -260,37 +269,38 @@ mod tests {
         assert_eq!(
             compute_rx_window_timing(32_768, 6, 10, 50),
             RxWindowTiming {
-                offset_ms: -17,
+                offset_ms: -60,
                 timeout_symbols: 6
             }
         );
     }
 
     #[test]
-    fn loramac_window_timing_supports_faster_bandwidths() {
+    fn window_timeout_supports_faster_bandwidths() {
         assert_eq!(
             compute_rx_window_timing(512, 6, 10, 50),
             RxWindowTiming {
-                offset_ms: -59,
-                timeout_symbols: 44
+                offset_ms: -60,
+                timeout_symbols: 137
             }
         );
         assert_eq!(
             compute_rx_window_timing(256, 6, 10, 50),
             RxWindowTiming {
-                offset_ms: -59,
-                timeout_symbols: 83
+                offset_ms: -60,
+                timeout_symbols: 274
             }
         );
     }
 
     #[test]
-    fn larger_system_error_expands_and_recenters_window() {
+    fn larger_system_error_expands_and_shifts_window_earlier() {
+        // error 50 ms, lead 50 ms: open 100 ms early, span 150 ms.
         assert_eq!(
             compute_rx_window_timing(1_024, 6, 50, 50),
             RxWindowTiming {
-                offset_ms: -98,
-                timeout_symbols: 102
+                offset_ms: -100,
+                timeout_symbols: 147
             }
         );
     }

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -177,6 +177,14 @@ where
     async fn low_power(&mut self) -> Result<(), Self::PhyError> {
         self.lora.sleep(false).await.map_err(|e| e.into())
     }
+    async fn low_power_retain(&mut self) -> Result<(), Self::PhyError> {
+        // Warm sleep between the transmit and its receive windows on chips that
+        // retain their configuration, so the next setup is a warm start
+        // (hundreds of us) instead of a cold re-init (tens of ms). Chips without
+        // a retention sleep must re-initialize after every sleep, so they take
+        // the normal cold sleep here.
+        self.lora.sleep(RK::SUPPORTS_WARM_START).await.map_err(|e| e.into())
+    }
 }
 
 impl<RK, DLY, const P: u8, const G: i8> LorawanRadio<RK, DLY, P, G>

--- a/lora-phy/src/lorawan_radio.rs
+++ b/lora-phy/src/lorawan_radio.rs
@@ -4,13 +4,14 @@ use super::mod_params::{PacketParams, RadioError};
 use super::mod_traits::RadioKind;
 use super::{DelayNs, LoRa, RxMode};
 
-use lora_modulation::BaseBandModulationParams;
 use lorawan_device::async_device::{
-    Timings,
+    RxWindowTiming, Timings,
     radio::{PhyRxTx, RxConfig, RxMode as LorawanRxMode, RxQuality, RxStatus, TxConfig},
 };
 
 const DEFAULT_RX_WINDOW_LEAD_TIME: u32 = 50;
+const DEFAULT_MIN_RX_SYMBOLS: u16 = 6;
+const DEFAULT_SYSTEM_MAX_RX_ERROR_MS: u32 = 10;
 
 /// LoRaWAN radio implementation.
 ///
@@ -25,6 +26,8 @@ where
     rx_pkt_params: Option<PacketParams>,
     rx_window_lead_time: u32,
     rx_window_buffer: u32,
+    min_rx_symbols: u16,
+    system_max_rx_error_ms: u32,
 }
 
 impl<RK, DLY, const P: u8, const G: i8> From<LoRa<RK, DLY>> for LorawanRadio<RK, DLY, P, G>
@@ -38,6 +41,8 @@ where
             rx_pkt_params: None,
             rx_window_lead_time: DEFAULT_RX_WINDOW_LEAD_TIME,
             rx_window_buffer: DEFAULT_RX_WINDOW_LEAD_TIME,
+            min_rx_symbols: DEFAULT_MIN_RX_SYMBOLS,
+            system_max_rx_error_ms: DEFAULT_SYSTEM_MAX_RX_ERROR_MS,
         }
     }
 }
@@ -50,6 +55,19 @@ where
     pub fn set_rx_window_lead_time(&mut self, lt: u32) {
         self.rx_window_lead_time = lt;
     }
+
+    /// Set the maximum expected clock and scheduling error on either side of
+    /// the nominal receive-window time. The default is 10 ms, matching
+    /// LoRaMac-node.
+    pub fn set_system_max_rx_error(&mut self, error_ms: u32) {
+        self.system_max_rx_error_ms = error_ms;
+    }
+
+    /// Set the minimum preamble-detection timeout.
+    pub fn set_min_rx_symbols(&mut self, symbols: u16) {
+        self.min_rx_symbols = symbols.max(5);
+    }
+
     pub fn set_rx_window_buffer(&mut self, buffer: u32) {
         self.rx_window_buffer = buffer;
     }
@@ -62,11 +80,20 @@ where
     DLY: DelayNs,
 {
     fn get_rx_window_buffer(&self) -> u32 {
-        self.rx_window_lead_time
+        self.rx_window_buffer
     }
 
     fn get_rx_window_lead_time_ms(&self) -> u32 {
         self.rx_window_lead_time
+    }
+
+    fn get_rx_window_timing(&self, rf: &lorawan_device::async_device::radio::RfConfig) -> RxWindowTiming {
+        compute_rx_window_timing(
+            rf.bb.symbol_duration_us(),
+            self.min_rx_symbols,
+            self.system_max_rx_error_ms,
+            self.rx_window_lead_time,
+        )
     }
 }
 
@@ -114,20 +141,12 @@ where
     }
 
     async fn setup_rx(&mut self, config: RxConfig) -> Result<(), Self::PhyError> {
-        let mdltn_params = self.lora.create_modulation_params(
-            config.rf.bb.sf,
-            config.rf.bb.bw,
-            config.rf.bb.cr,
-            config.rf.frequency,
-        )?;
-        let rx_pkt_params = self
-            .lora
-            .create_rx_packet_params(8, false, 255, true, true, &mdltn_params)?;
-        self.lora
-            .prepare_for_rx(RxMode::from(config.mode, config.rf.bb), &mdltn_params, &rx_pkt_params)
-            .await?;
-        self.rx_pkt_params = Some(rx_pkt_params);
-        Ok(())
+        let mode = RxMode::from(config.mode, config.rf.bb);
+        self.setup_rx_mode(config, mode).await
+    }
+
+    async fn setup_rx_window(&mut self, config: RxConfig, timing: RxWindowTiming) -> Result<(), Self::PhyError> {
+        self.setup_rx_mode(config, RxMode::Single(timing.timeout_symbols)).await
     }
 
     async fn rx_single(&mut self, buf: &mut [u8]) -> Result<RxStatus, Self::PhyError> {
@@ -161,17 +180,118 @@ where
     }
 }
 
+impl<RK, DLY, const P: u8, const G: i8> LorawanRadio<RK, DLY, P, G>
+where
+    RK: RadioKind,
+    DLY: DelayNs,
+{
+    async fn setup_rx_mode(&mut self, config: RxConfig, mode: RxMode) -> Result<(), Error> {
+        let mdltn_params = self.lora.create_modulation_params(
+            config.rf.bb.sf,
+            config.rf.bb.bw,
+            config.rf.bb.cr,
+            config.rf.frequency,
+        )?;
+        let rx_pkt_params = self
+            .lora
+            .create_rx_packet_params(8, false, 255, true, true, &mdltn_params)?;
+        self.lora.prepare_for_rx(mode, &mdltn_params, &rx_pkt_params).await?;
+        self.rx_pkt_params = Some(rx_pkt_params);
+        Ok(())
+    }
+}
+
 impl RxMode {
-    fn from(mode: LorawanRxMode, bb: BaseBandModulationParams) -> Self {
+    fn from(mode: LorawanRxMode, bb: lora_modulation::BaseBandModulationParams) -> Self {
         match mode {
             LorawanRxMode::Continuous => RxMode::Continuous,
             LorawanRxMode::Single { ms } => {
-                // Since both sx126x and sx127x have a preamble-based timeout, we translate
-                // the additional millisecond delay into symbols and add it to the amount of preamble symbols.
-                const PREAMBLE_SYMBOLS: u16 = 13; // 12.25
-                let num_symbols = PREAMBLE_SYMBOLS + bb.delay_in_symbols(ms);
-                RxMode::Single(num_symbols)
+                const PREAMBLE_SYMBOLS: u16 = 13;
+                RxMode::Single(PREAMBLE_SYMBOLS.saturating_add(bb.delay_in_symbols_ceil(ms)))
             }
         }
+    }
+}
+
+fn compute_rx_window_timing(
+    symbol_duration_us: u32,
+    min_rx_symbols: u16,
+    system_max_rx_error_ms: u32,
+    wake_up_time_ms: u32,
+) -> RxWindowTiming {
+    let symbol_us = symbol_duration_us as u64;
+    let min_symbols = min_rx_symbols.max(5) as u64;
+    let error_us = system_max_rx_error_ms as u64 * 1_000;
+
+    // LoRaMac-node's RegionCommonComputeRxWindowParameters equations. The
+    // factor of two covers the same maximum timing error before and after the
+    // nominal window time.
+    let numerator = (2 * min_symbols - 8) * symbol_us + 2 * error_us;
+    let timeout_symbols = numerator.div_ceil(symbol_us).max(min_symbols);
+    let timeout_symbols = timeout_symbols.min(u16::MAX as u64) as u16;
+
+    let half_window_us = (timeout_symbols as u64 * symbol_us).div_ceil(2);
+    let offset_us = 4_i64 * symbol_us as i64 - half_window_us as i64 - wake_up_time_ms as i64 * 1_000;
+
+    RxWindowTiming {
+        // Integer division truncates negative values toward zero, which is
+        // equivalent to ceil(offset_us / 1000), as used by LoRaMac-node.
+        offset_ms: (offset_us / 1_000).clamp(i32::MIN as i64, i32::MAX as i64) as i32,
+        timeout_symbols,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loramac_default_window_timing_scales_with_symbol_duration() {
+        // SF7/BW125: 1.024 ms per symbol.
+        assert_eq!(
+            compute_rx_window_timing(1_024, 6, 10, 50),
+            RxWindowTiming {
+                offset_ms: -58,
+                timeout_symbols: 24
+            }
+        );
+
+        // SF12/BW125: 32.768 ms per symbol. The six-symbol minimum dominates.
+        assert_eq!(
+            compute_rx_window_timing(32_768, 6, 10, 50),
+            RxWindowTiming {
+                offset_ms: -17,
+                timeout_symbols: 6
+            }
+        );
+    }
+
+    #[test]
+    fn loramac_window_timing_supports_faster_bandwidths() {
+        assert_eq!(
+            compute_rx_window_timing(512, 6, 10, 50),
+            RxWindowTiming {
+                offset_ms: -59,
+                timeout_symbols: 44
+            }
+        );
+        assert_eq!(
+            compute_rx_window_timing(256, 6, 10, 50),
+            RxWindowTiming {
+                offset_ms: -59,
+                timeout_symbols: 83
+            }
+        );
+    }
+
+    #[test]
+    fn larger_system_error_expands_and_recenters_window() {
+        assert_eq!(
+            compute_rx_window_timing(1_024, 6, 50, 50),
+            RxWindowTiming {
+                offset_ms: -98,
+                timeout_symbols: 102
+            }
+        );
     }
 }

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -1909,14 +1909,14 @@ where
     SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
-    // The lr11xx keeps its configuration across a warm-start sleep (its
-    // set_sleep already programs the retention flag), so the stack can use the
-    // low-current retention sleep between receive windows instead of paying the
-    // full init_system (TCXO wake + CalibrateAll) on every window. The stack
-    // only warm-sleeps between a transmit and its receive windows; the idle
-    // before the next transmit stays a cold sleep, so the retention-wake High
-    // ACP workaround (needed only before a transmit) is not on this path.
-    const SUPPORTS_WARM_START: bool = true;
+    // Although set_sleep programs the retention flag, a warm-started RX window
+    // is deaf on real hardware (lr1110, EU868 join: RX1 after a warm wake hears
+    // nothing; a cold-initialized window on the same session receives fine).
+    // The warm wake path skips init_lora (packet type, sync word, RF switch
+    // config), and whatever the chip fails to retain or the driver fails to
+    // restore has not been isolated yet. Keep the cold sleep until warm start
+    // can be brought up against local hardware.
+    const SUPPORTS_WARM_START: bool = false;
 
     async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {
         // Initialize system (DC-DC, TCXO, calibration)

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -1909,13 +1909,20 @@ where
     SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
-    // Although set_sleep programs the retention flag, a warm-started RX window
-    // is deaf on real hardware (lr1110, EU868 join: RX1 after a warm wake hears
-    // nothing; a cold-initialized window on the same session receives fine).
+    // The manual describes LoRaSynchTimeout as expiring when no packet has
+    // been "detected" after SymbolNum symbols, and on this chip that appears
+    // to be a later stage than the sx126x's preamble detection: a timeout
+    // with only preamble-symbol margin expires while the preamble is still on
+    // the air. Cover the full 12.25-symbol preamble-plus-sync sequence so the
+    // timeout cannot fire before the chip has had a complete sync word to
+    // detect. Overridable at runtime with set_min_rx_symbols.
+    const DEFAULT_MIN_RX_SYMBOLS: u16 = 13;
+
     // The warm wake path skips init_lora (packet type, sync word, RF switch
-    // config), and whatever the chip fails to retain or the driver fails to
-    // restore has not been isolated yet. Keep the cold sleep until warm start
-    // can be brought up against local hardware.
+    // config) on the assumption the chip retains that configuration through a
+    // retention sleep. What actually survives a retention sleep has not been
+    // validated on hardware yet; keep the cold sleep until warm start can be
+    // brought up against local hardware.
     const SUPPORTS_WARM_START: bool = false;
 
     async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -916,24 +916,13 @@ where
         }
 
         // DIO3 acting as TCXO controller
-        if let Some(voltage) = self.config.tcxo_ctrl {
+        if self.config.tcxo_ctrl.is_some() {
             // Clear any TCXO startup errors
             let clear_opcode = SystemOpCode::ClearErrors.bytes();
             let clear_cmd = [clear_opcode[0], clear_opcode[1]];
             self.write_command(&clear_cmd).await?;
 
-            // Set TCXO mode - timeout in RTC steps (32.768 kHz)
-            let timeout = BRD_TCXO_WAKEUP_TIME * 32768 / 1000; // Convert ms to RTC steps
-            let opcode = SystemOpCode::SetTcxoMode.bytes();
-            let cmd = [
-                opcode[0],
-                opcode[1],
-                voltage.value(),
-                Self::timeout_1(timeout),
-                Self::timeout_2(timeout),
-                Self::timeout_3(timeout),
-            ];
-            self.write_command(&cmd).await?;
+            self.set_tcxo_mode().await?;
 
             // Re-run calibration now that chip knows it's running from TCXO
             let cal_opcode = SystemOpCode::Calibrate.bytes();
@@ -942,6 +931,27 @@ where
         }
 
         Ok(())
+    }
+
+    /// Configure DIO3 as the TCXO supply (no-op without `tcxo_ctrl`). The
+    /// timeout is the time the chip grants the TCXO to start before a radio
+    /// operation.
+    async fn set_tcxo_mode(&mut self) -> Result<(), RadioError> {
+        let Some(voltage) = self.config.tcxo_ctrl else {
+            return Ok(());
+        };
+        // Timeout in RTC steps (32.768 kHz)
+        let timeout = BRD_TCXO_WAKEUP_TIME * 32768 / 1000;
+        let opcode = SystemOpCode::SetTcxoMode.bytes();
+        let cmd = [
+            opcode[0],
+            opcode[1],
+            voltage.value(),
+            Self::timeout_1(timeout),
+            Self::timeout_2(timeout),
+            Self::timeout_3(timeout),
+        ];
+        self.write_command(&cmd).await
     }
 
     /// Wake up the LR1110 from sleep mode
@@ -1918,12 +1928,11 @@ where
     // detect. Overridable at runtime with set_min_rx_symbols.
     const DEFAULT_MIN_RX_SYMBOLS: u16 = 13;
 
-    // The warm wake path skips init_lora (packet type, sync word, RF switch
-    // config) on the assumption the chip retains that configuration through a
-    // retention sleep. What actually survives a retention sleep has not been
-    // validated on hardware yet; keep the cold sleep until warm start can be
-    // brought up against local hardware.
-    const SUPPORTS_WARM_START: bool = false;
+    // Retention sleep preserves the radio configuration (validated on the
+    // bench: modulation, packet params, sync word, RF-switch table and PA
+    // config all survive), EXCEPT the DIO3 TCXO-supply arming, which
+    // ensure_ready re-issues on every wake.
+    const SUPPORTS_WARM_START: bool = true;
 
     async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {
         // Initialize system (DC-DC, TCXO, calibration)
@@ -2023,7 +2032,16 @@ where
         match mode {
             // In sleep mode BUSY is held high; toggle NSS to wake the chip,
             // then wait for BUSY to go low (chip booted and ready).
-            RadioMode::Sleep => self.intf.wakeup().await,
+            RadioMode::Sleep => {
+                self.intf.wakeup().await?;
+                // The chip does not re-arm the DIO3 TCXO supply on wake, not
+                // even from a retention sleep where every other radio setting
+                // survives: the first receive after a warm wake runs on a
+                // dead reference and hears nothing (HIL-verified on firmware
+                // 0x0303 and 0x0402; TX escapes because the cold path
+                // reconfigures the TCXO in init_system).
+                self.set_tcxo_mode().await
+            }
             _ => self.intf.iv.wait_on_busy().await,
         }
     }

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -1909,6 +1909,15 @@ where
     SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
+    // The lr11xx keeps its configuration across a warm-start sleep (its
+    // set_sleep already programs the retention flag), so the stack can use the
+    // low-current retention sleep between receive windows instead of paying the
+    // full init_system (TCXO wake + CalibrateAll) on every window. The stack
+    // only warm-sleeps between a transmit and its receive windows; the idle
+    // before the next transmit stays a cold sleep, so the retention-wake High
+    // ACP workaround (needed only before a transmit) is not on this path.
+    const SUPPORTS_WARM_START: bool = true;
+
     async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {
         // Initialize system (DC-DC, TCXO, calibration)
         self.init_system().await?;

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -2040,12 +2040,7 @@ where
             // then wait for BUSY to go low (chip booted and ready).
             RadioMode::Sleep => {
                 self.intf.wakeup().await?;
-                // The chip does not re-arm the DIO3 TCXO supply on wake, not
-                // even from a retention sleep where every other radio setting
-                // survives: the first receive after a warm wake runs on a
-                // dead reference and hears nothing (HIL-verified on firmware
-                // 0x0303 and 0x0402; TX escapes because the cold path
-                // reconfigures the TCXO in init_system).
+                // tcxo is not retained to warm sleep. it must be set
                 self.set_tcxo_mode().await
             }
             _ => self.intf.iv.wait_on_busy().await,

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -1934,6 +1934,14 @@ where
     // ensure_ready re-issues on every wake.
     const SUPPORTS_WARM_START: bool = true;
 
+    const MAX_SINGLE_RX_SYMBOLS: u16 = LR1110_MAX_LORA_SYMB_NUM_TIMEOUT as u16;
+
+    // StopTimeoutOnPreamble(1) gives the SetRx tick timeout the same
+    // stop-on-preamble semantics as the symbol timeout. (Transceiver fw
+    // >= 0x0308 also has an extended 16-bit symbol timeout command, but the
+    // wall-clock close works on every fw so it needs no version gate.)
+    const SUPPORTS_TIMED_SINGLE_RX: bool = true;
+
     async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {
         // Initialize system (DC-DC, TCXO, calibration)
         self.init_system().await?;
@@ -2308,7 +2316,7 @@ where
 
         // Set symbol timeout
         let num_symbols = match rx_mode {
-            RxMode::DutyCycle(_) | RxMode::Continuous => 0,
+            RxMode::DutyCycle(_) | RxMode::Continuous | RxMode::SingleMs(_) => 0,
             RxMode::Single(n) => n,
         };
         self.set_lora_symbol_num_timeout(num_symbols).await?;
@@ -2340,11 +2348,16 @@ where
                 ];
                 self.write_command(&cmd).await
             }
-            RxMode::Single(_) | RxMode::Continuous => {
-                let timeout = if matches!(rx_mode, RxMode::Continuous) {
-                    RX_CONTINUOUS_TIMEOUT
-                } else {
-                    0
+            RxMode::Single(_) | RxMode::SingleMs(_) | RxMode::Continuous => {
+                let timeout = match rx_mode {
+                    RxMode::Continuous => RX_CONTINUOUS_TIMEOUT,
+                    // SetRx ticks are 32.768 kHz RTC steps. Round up so the
+                    // window never closes short of the requested span;
+                    // 0xffffff is the continuous sentinel, saturate below it.
+                    RxMode::SingleMs(ms) => {
+                        ((ms as u64 * 32_768).div_ceil(1_000)).min(RX_CONTINUOUS_TIMEOUT as u64 - 1) as u32
+                    }
+                    _ => 0,
                 };
 
                 // Reference driver behavior; RX duty cycle notably does NOT

--- a/lora-phy/src/lr1110/mod.rs
+++ b/lora-phy/src/lr1110/mod.rs
@@ -1919,13 +1919,11 @@ where
     SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
-    // The manual describes LoRaSynchTimeout as expiring when no packet has
-    // been "detected" after SymbolNum symbols, and on this chip that appears
-    // to be a later stage than the sx126x's preamble detection: a timeout
-    // with only preamble-symbol margin expires while the preamble is still on
-    // the air. Cover the full 12.25-symbol preamble-plus-sync sequence so the
-    // timeout cannot fire before the chip has had a complete sync word to
-    // detect. Overridable at runtime with set_min_rx_symbols.
+    // Cover the full 12.25-symbol preamble-plus-sync sequence. Bench devices
+    // at BW500 detect mid-preamble and pass with 6, but the reported EU868
+    // SF12/BW125 failures fit a detection needing ~12 symbols under LDRO, so
+    // the default stays conservative. Overridable at runtime with
+    // set_min_rx_symbols.
     const DEFAULT_MIN_RX_SYMBOLS: u16 = 13;
 
     // Retention sleep preserves the radio configuration (validated on the

--- a/lora-phy/src/lr1110/test/mod.rs
+++ b/lora-phy/src/lr1110/test/mod.rs
@@ -329,6 +329,20 @@ async fn test_do_rx_single() {
 }
 
 #[tokio::test]
+async fn test_do_rx_single_ms() {
+    // Wall-clock close: no symbol timeout, SetRx at 32.768 kHz RTC steps
+    // rounded up (72 ms -> ceil(72 * 32.768) = 2360 ticks).
+    let mut reference_radio = reference();
+    reference_radio.stop_timeout_on_preamble(true);
+    reference_radio.set_lora_sync_timeout(0);
+    reference_radio.set_rx_with_timeout_in_rtc_step(2360);
+
+    let mut radio = get_lr1110();
+    radio.do_rx(RxMode::SingleMs(72)).await.unwrap();
+    assert_eq!(radio.intf.spi, reference_radio.inner);
+}
+
+#[tokio::test]
 async fn test_do_cad() {
     let mut reference_radio = reference();
     reference_radio.set_cad_params(&sys::lr11xx_radio_cad_params_t {

--- a/lora-phy/src/mod_params.rs
+++ b/lora-phy/src/mod_params.rs
@@ -29,6 +29,7 @@ pub enum RadioError {
     TransmitTimeout,
     ReceiveTimeout,
     DutyCycleUnsupported,
+    TimedSingleRxUnsupported,
     RngUnsupported,
 }
 
@@ -42,7 +43,7 @@ pub struct PacketStatus {
 }
 
 /// The state of the radio
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum RadioMode {
     /// Sleep mode
@@ -68,7 +69,7 @@ impl From<RxMode> for RadioMode {
 }
 
 /// Listening mode for LoRaWAN packet detection/reception
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum RxMode {
     /// Single shot Rx Mode to listen until packet preamble is detected or RxTimeout occurs.
@@ -76,8 +77,15 @@ pub enum RxMode {
     /// Preamble length as symbols is configured via following registers:
     /// * sx126x: uses `SetLoRaSymbNumTimeout(0 < n < 255)` + `SetStopRxTimerOnPreamble(1)`
     /// * sx127x: uses `RegSymbTimeout (4 < n < 1023)`
-    // TODO: Single mode with time-based timeout is available on sx126x, but not sx127x
     Single(u16),
+    /// Single shot Rx mode closed by the chip's wall-clock RX timer instead of the
+    /// symbol counter, for windows longer than the symbol counter can express
+    /// (see [`RadioKind::MAX_SINGLE_RX_SYMBOLS`](crate::mod_traits::RadioKind::MAX_SINGLE_RX_SYMBOLS)).
+    /// Like [`RxMode::Single`], the timer stops on preamble detection and the radio
+    /// stays in RX until the packet completes. Not available on the sx127x, which
+    /// has no wall-clock RX timer
+    /// ([`RadioKind::SUPPORTS_TIMED_SINGLE_RX`](crate::mod_traits::RadioKind::SUPPORTS_TIMED_SINGLE_RX)).
+    SingleMs(u32),
     /// Continuous Rx mode to listen for incoming packets continuously
     Continuous,
     /// Receive in Duty Cycle mode (NB! Not supported on sx127x)
@@ -131,7 +139,7 @@ impl PacketParams {
 }
 
 /// Receive duty cycle parameters
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct DutyCycleParams {
     /// receive interval

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -35,37 +35,35 @@ pub enum IrqState {
 pub trait RadioKind {
     /// Minimum preamble-detection window, in symbols, for a single receive.
     ///
-    /// The LoRaWAN receive-window timing shrinks the programmed timeout as the
-    /// data rate rises; this floor keeps it long enough for the chip to latch
-    /// an incoming preamble. The default of 6 matches LoRaMac-node; chips
-    /// whose detection needs more headroom (sx127x, lr11xx) raise it.
-    /// Overridable at runtime via
+    /// LoRaWAN receive-window timing adds this many symbols beyond the
+    /// calculated window span, ensuring the chip has enough preamble in the
+    /// window to detect it regardless of data rate.
+    ///
+    /// Radio implementations may override the default. It can also be changed
+    /// at runtime via
     /// [`LorawanRadio::set_min_rx_symbols`](crate::lorawan_radio::LorawanRadio::set_min_rx_symbols).
     const DEFAULT_MIN_RX_SYMBOLS: u16 = 6;
 
-    /// Whether the chip can wake from sleep with its configuration retained,
-    /// skipping the full re-initialization on the next receive setup.
+    /// Whether the chip has a warm sleep that retains receive configuration.
     ///
-    /// Only chips with a real retention sleep should set this. The sx127x has
-    /// no warm start (its `set_sleep` ignores the request) and must run a fresh
-    /// `init_lora` after every sleep, so it leaves this `false`; the sx126x
-    /// keeps its configuration across a warm-start sleep and sets it `true`.
+    /// Used when possible between TX and RX1 and between RX1 and RX2. Only
+    /// chips with a real retention sleep should set this.
     const SUPPORTS_WARM_START: bool = false;
 
     /// Largest symbol count the chip's single-RX preamble timeout can express;
-    /// [`RxMode::Single`](crate::RxMode::Single) requests above it are clamped
-    /// to it by the driver. The sx126x and lr11xx symbol timeout tops out at
-    /// 248 symbols, which at fast data rates is shorter than the wall-clock
-    /// span a LoRaWAN receive window needs (SF7/BW500 with the default lead
-    /// and error wants 280+); [`LorawanRadio`](crate::lorawan_radio::LorawanRadio)
-    /// switches to [`RxMode::SingleMs`](crate::RxMode::SingleMs) above this
-    /// ceiling on chips that support it.
+    /// [`RxMode::Single`] requests above it are clamped to it by the driver.
+    ///
+    /// [`LorawanRadio`](crate::lorawan_radio::LorawanRadio) switches to
+    /// [`RxMode::SingleMs`] when the desired timeout exceeds this value and the
+    /// chip supports a timed single receive.
     const MAX_SINGLE_RX_SYMBOLS: u16 = u16::MAX;
 
     /// Whether the chip can close a single receive with its wall-clock RX
-    /// timer ([`RxMode::SingleMs`](crate::RxMode::SingleMs)). The sx126x and
-    /// lr11xx stop that timer on preamble detection, giving it the same
-    /// semantics as the symbol timeout; the sx127x has no such timer.
+    /// timer ([`RxMode::SingleMs`]).
+    ///
+    /// If the desired timeout exceeds [`RadioKind::MAX_SINGLE_RX_SYMBOLS`] and
+    /// this is `false`, the timeout is clamped to the largest supported symbol
+    /// count and a warning is logged.
     const SUPPORTS_TIMED_SINGLE_RX: bool = false;
 
     /// Initialize lora radio

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -37,9 +37,9 @@ pub trait RadioKind {
     ///
     /// The LoRaWAN receive-window timing shrinks the programmed timeout as the
     /// data rate rises; this floor keeps it long enough for the chip to latch
-    /// an incoming preamble. The default of 6 matches LoRaMac-node. The
-    /// sx127x needs a longer floor to detect the 8-symbol LoRaWAN preamble, so
-    /// it raises this. Overridable at runtime via
+    /// an incoming preamble. The default of 6 matches LoRaMac-node; chips
+    /// whose detection needs more headroom (sx127x, lr11xx) raise it.
+    /// Overridable at runtime via
     /// [`LorawanRadio::set_min_rx_symbols`](crate::lorawan_radio::LorawanRadio::set_min_rx_symbols).
     const DEFAULT_MIN_RX_SYMBOLS: u16 = 6;
 

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -33,6 +33,16 @@ pub enum IrqState {
 /// LoRa physical layer API
 #[allow(async_fn_in_trait)]
 pub trait RadioKind {
+    /// Minimum preamble-detection window, in symbols, for a single receive.
+    ///
+    /// The LoRaWAN receive-window timing shrinks the programmed timeout as the
+    /// data rate rises; this floor keeps it long enough for the chip to latch
+    /// an incoming preamble. The default of 6 matches LoRaMac-node. The
+    /// sx127x needs a longer floor to detect the 8-symbol LoRaWAN preamble, so
+    /// it raises this. Overridable at runtime via
+    /// [`LorawanRadio::set_min_rx_symbols`](crate::lorawan_radio::LorawanRadio::set_min_rx_symbols).
+    const DEFAULT_MIN_RX_SYMBOLS: u16 = 6;
+
     /// Initialize lora radio
     ///
     /// The sync word is given in the 16-bit sx126x register form; the legacy

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -43,6 +43,15 @@ pub trait RadioKind {
     /// [`LorawanRadio::set_min_rx_symbols`](crate::lorawan_radio::LorawanRadio::set_min_rx_symbols).
     const DEFAULT_MIN_RX_SYMBOLS: u16 = 6;
 
+    /// Whether the chip can wake from sleep with its configuration retained,
+    /// skipping the full re-initialization on the next receive setup.
+    ///
+    /// Only chips with a real retention sleep should set this. The sx127x has
+    /// no warm start (its `set_sleep` ignores the request) and must run a fresh
+    /// `init_lora` after every sleep, so it leaves this `false`; the sx126x
+    /// keeps its configuration across a warm-start sleep and sets it `true`.
+    const SUPPORTS_WARM_START: bool = false;
+
     /// Initialize lora radio
     ///
     /// The sync word is given in the 16-bit sx126x register form; the legacy

--- a/lora-phy/src/mod_traits.rs
+++ b/lora-phy/src/mod_traits.rs
@@ -52,6 +52,22 @@ pub trait RadioKind {
     /// keeps its configuration across a warm-start sleep and sets it `true`.
     const SUPPORTS_WARM_START: bool = false;
 
+    /// Largest symbol count the chip's single-RX preamble timeout can express;
+    /// [`RxMode::Single`](crate::RxMode::Single) requests above it are clamped
+    /// to it by the driver. The sx126x and lr11xx symbol timeout tops out at
+    /// 248 symbols, which at fast data rates is shorter than the wall-clock
+    /// span a LoRaWAN receive window needs (SF7/BW500 with the default lead
+    /// and error wants 280+); [`LorawanRadio`](crate::lorawan_radio::LorawanRadio)
+    /// switches to [`RxMode::SingleMs`](crate::RxMode::SingleMs) above this
+    /// ceiling on chips that support it.
+    const MAX_SINGLE_RX_SYMBOLS: u16 = u16::MAX;
+
+    /// Whether the chip can close a single receive with its wall-clock RX
+    /// timer ([`RxMode::SingleMs`](crate::RxMode::SingleMs)). The sx126x and
+    /// lr11xx stop that timer on preamble detection, giving it the same
+    /// semantics as the symbol timeout; the sx127x has no such timer.
+    const SUPPORTS_TIMED_SINGLE_RX: bool = false;
+
     /// Initialize lora radio
     ///
     /// The sync word is given in the 16-bit sx126x register form; the legacy

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -224,6 +224,12 @@ where
     // stack can use the low-current retention sleep between receive windows.
     const SUPPORTS_WARM_START: bool = true;
 
+    const MAX_SINGLE_RX_SYMBOLS: u16 = SX126X_MAX_LORA_SYMB_NUM_TIMEOUT as u16;
+
+    // SetStopRxTimerOnPreamble(1) gives the SetRx tick timeout the same
+    // stop-on-preamble semantics as the symbol timeout.
+    const SUPPORTS_TIMED_SINGLE_RX: bool = true;
+
     async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {
         // DC-DC regulator setup (default is LDO)
         if self.config.use_dcdc {
@@ -572,7 +578,7 @@ where
         self.intf.write(&op_code_and_true_flag, false).await?;
 
         let num_symbols = match rx_mode {
-            RxMode::DutyCycle(_) | RxMode::Continuous => 0,
+            RxMode::DutyCycle(_) | RxMode::Continuous | RxMode::SingleMs(_) => 0,
             RxMode::Single(n) => n,
         };
         self.set_lora_symbol_num_timeout(num_symbols).await?;
@@ -599,6 +605,18 @@ where
                     Self::timeout_1(0),
                     Self::timeout_2(0),
                     Self::timeout_3(0),
+                ];
+                self.intf.write(&op, false).await
+            }
+            RxMode::SingleMs(ms) => {
+                // SetRx ticks are 15.625 us, 64 per millisecond; 0xffffff is
+                // the continuous sentinel, so saturate below it.
+                let ticks = (ms as u64 * 64).min(RX_CONTINUOUS_TIMEOUT as u64 - 1) as u32;
+                let op = [
+                    OpCode::SetRx.value(),
+                    Self::timeout_1(ticks),
+                    Self::timeout_2(ticks),
+                    Self::timeout_3(ticks),
                 ];
                 self.intf.write(&op, false).await
             }

--- a/lora-phy/src/sx126x/mod.rs
+++ b/lora-phy/src/sx126x/mod.rs
@@ -220,6 +220,10 @@ where
     IV: InterfaceVariant,
     C: Sx126xVariant,
 {
+    // The sx126x keeps its configuration across a warm-start sleep, so the
+    // stack can use the low-current retention sleep between receive windows.
+    const SUPPORTS_WARM_START: bool = true;
+
     async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {
         // DC-DC regulator setup (default is LDO)
         if self.config.use_dcdc {

--- a/lora-phy/src/sx126x/test/mod.rs
+++ b/lora-phy/src/sx126x/test/mod.rs
@@ -222,6 +222,8 @@ async fn test_do_rx() {
     let cases = [
         ("continuous", RxMode::Continuous, 0u8, 0xFFFFFF_u32),
         ("single8", RxMode::Single(8), 8, 0),
+        // wall-clock close: no symbol timeout, SetRx at 64 ticks/ms
+        ("single_72ms", RxMode::SingleMs(72), 0, 72 * 64),
     ];
     for (label, mode, symbs, rtc_timeout) in cases {
         let mut reference = reference();

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -145,6 +145,10 @@ where
     // (the trait default) is too short and drops downlinks at higher rates.
     const DEFAULT_MIN_RX_SYMBOLS: u16 = 8;
 
+    // RegSymbTimeout is 10 bits and there is no wall-clock RX timer to fall
+    // back on, so longer windows clamp (SUPPORTS_TIMED_SINGLE_RX stays false).
+    const MAX_SINGLE_RX_SYMBOLS: u16 = SX127X_MAX_LORA_SYMB_NUM_TIMEOUT;
+
     async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {
         let sync_word = sync_word_to_legacy(sync_word)?;
         if self.config.tcxo_used {
@@ -377,6 +381,7 @@ where
         let (num_symbols, mode) = match rx_mode {
             RxMode::DutyCycle(_) => Err(RadioError::DutyCycleUnsupported),
             RxMode::Single(ns) => Ok((ns.max(SX127X_MIN_LORA_SYMB_NUM_TIMEOUT), LoRaMode::RxSingle)),
+            RxMode::SingleMs(_) => Err(RadioError::TimedSingleRxUnsupported),
             RxMode::Continuous => Ok((0, LoRaMode::RxContinuous)),
         }?;
 
@@ -557,7 +562,7 @@ where
                     return Ok(Some(IrqState::Done));
                 }
             }
-            RadioMode::Receive(RxMode::Continuous) | RadioMode::Receive(RxMode::Single(_)) => {
+            RadioMode::Receive(RxMode::Continuous | RxMode::Single(_) | RxMode::SingleMs(_)) => {
                 if (irq_flags & IrqMask::RxDone.value()) == IrqMask::RxDone.value() {
                     debug!("RxDone in radio mode {}", radio_mode);
                     return Ok(Some(IrqState::Done));

--- a/lora-phy/src/sx127x/mod.rs
+++ b/lora-phy/src/sx127x/mod.rs
@@ -140,6 +140,11 @@ where
     IV: InterfaceVariant,
     C: Sx127xVariant,
 {
+    // The sx127x drives its single-receive timeout off SymbTimeout, which
+    // needs headroom over the 8-symbol LoRaWAN preamble to latch reliably; 6
+    // (the trait default) is too short and drops downlinks at higher rates.
+    const DEFAULT_MIN_RX_SYMBOLS: u16 = 8;
+
     async fn init_lora(&mut self, sync_word: u16) -> Result<(), RadioError> {
         let sync_word = sync_word_to_legacy(sync_word)?;
         if self.config.tcxo_used {

--- a/lorawan-device/CHANGELOG.md
+++ b/lorawan-device/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## Unreleased
 
 - Move to Rust edition 2024 (requires Rust 1.85+)
+- Add per-datarate receive-window timing to the async radio interface
 - Deprecate NewSKey in favor of more commonly used NwkSKey
 - Rename the defmt feature to defmt-03
 - Add `class-c` feature flag

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -703,7 +703,8 @@ where
     }
 }
 
-/// Allows to fine-tune the beginning and end of the receive windows for a specific board and runtime.
+/// Timing for one receive window: when to start radio setup relative to the
+/// nominal window time, and the timeout to program into the radio.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RxWindowTiming {
     /// Offset from the nominal receive-window time at which radio setup starts.
@@ -712,6 +713,7 @@ pub struct RxWindowTiming {
     pub timeout_symbols: u16,
 }
 
+/// Allows to fine-tune the beginning and end of the receive windows for a specific board and runtime.
 pub trait Timings {
     /// How many milliseconds before the RX window should the SPI transaction start?
     /// This value needs to account for the time it takes to wake up the radio and start the SPI transaction, as
@@ -727,8 +729,7 @@ pub trait Timings {
 
     /// Calculate timing for a receive window's modulation parameters.
     ///
-    /// Implementations that do not override this retain the historical
-    /// behavior: start `lead_time` early and add `buffer` to a 13-symbol
+    /// The default starts `lead_time` early and adds `buffer` to a 13-symbol
     /// preamble timeout.
     fn get_rx_window_timing(&self, rf: &RfConfig) -> RxWindowTiming {
         const PREAMBLE_SYMBOLS: u16 = 13;

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -411,7 +411,7 @@ where
         &mut self,
         duration: u32,
     ) -> Result<Option<mac::Response>, Error<R::PhyError>> {
-        self.radio.low_power().await.map_err(Error::Radio)?;
+        self.radio.low_power_retain().await.map_err(Error::Radio)?;
         self.timer.at(duration.into()).await;
         Ok(None)
     }
@@ -425,7 +425,7 @@ where
         use futures::{future::Either, future::select, pin_mut};
 
         if !self.class_c {
-            self.radio.low_power().await.map_err(Error::Radio)?;
+            self.radio.low_power_retain().await.map_err(Error::Radio)?;
             self.timer.at(duration.into()).await;
             return Ok(None);
         }

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -411,7 +411,7 @@ where
         &mut self,
         duration: u32,
     ) -> Result<Option<mac::Response>, Error<R::PhyError>> {
-        self.radio.low_power_retain().await.map_err(Error::Radio)?;
+        self.radio.warm_sleep().await.map_err(Error::Radio)?;
         self.timer.at(duration.into()).await;
         Ok(None)
     }
@@ -425,7 +425,7 @@ where
         use futures::{future::Either, future::select, pin_mut};
 
         if !self.class_c {
-            self.radio.low_power_retain().await.map_err(Error::Radio)?;
+            self.radio.warm_sleep().await.map_err(Error::Radio)?;
             self.timer.at(duration.into()).await;
             return Ok(None);
         }

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -537,8 +537,12 @@ where
     ) -> Result<mac::Response, Error<R::PhyError>> {
         self.radio_buffer.clear();
 
-        let rx1_start_delay = self.mac.get_rx_delay(frame, &Window::_1) + window_delay
-            - self.radio.get_rx_window_lead_time_ms();
+        let rx1_rf = rx_windows.get(&Window::_1);
+        let rx1_timing = self.radio.get_rx_window_timing(&rx1_rf);
+        let rx1_start_delay = apply_window_offset(
+            self.mac.get_rx_delay(frame, &Window::_1).saturating_add(window_delay),
+            rx1_timing.offset_ms,
+        );
 
         debug!("Starting RX1 in {} ms.", rx1_start_delay);
         // sleep or RXC
@@ -547,15 +551,19 @@ where
         // RX1
         let rx_config = rx_windows.rx_config(self.radio.get_rx_window_buffer(), &Window::_1);
         debug!("Configuring RX1 window with config {}.", rx_config);
-        self.radio.setup_rx(rx_config).await.map_err(Error::Radio)?;
+        self.radio.setup_rx_window(rx_config, rx1_timing).await.map_err(Error::Radio)?;
 
         if let Some(response) = self.rx_listen(&rx_config.rf).await? {
             debug!("RX1 received {}", response);
             return Ok(response);
         }
 
-        let rx2_start_delay = self.mac.get_rx_delay(frame, &Window::_2) + window_delay
-            - self.radio.get_rx_window_lead_time_ms();
+        let rx2_rf = rx_windows.get(&Window::_2);
+        let rx2_timing = self.radio.get_rx_window_timing(&rx2_rf);
+        let rx2_start_delay = apply_window_offset(
+            self.mac.get_rx_delay(frame, &Window::_2).saturating_add(window_delay),
+            rx2_timing.offset_ms,
+        );
         debug!("RX1 did not receive anything. Awaiting RX2 for {} ms.", rx2_start_delay);
         // sleep or RXC
         let _ = self.between_windows(rx2_start_delay).await?;
@@ -563,7 +571,7 @@ where
         // RX2
         let rx_config = rx_windows.rx_config(self.radio.get_rx_window_buffer(), &Window::_2);
         debug!("Configuring RX2 window with config {}.", rx_config);
-        self.radio.setup_rx(rx_config).await.map_err(Error::Radio)?;
+        self.radio.setup_rx_window(rx_config, rx2_timing).await.map_err(Error::Radio)?;
 
         if let Some(response) = self.rx_listen(&rx_config.rf).await? {
             debug!("RX2 received {}", response);
@@ -687,6 +695,14 @@ where
 }
 
 /// Allows to fine-tune the beginning and end of the receive windows for a specific board and runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RxWindowTiming {
+    /// Offset from the nominal receive-window time at which radio setup starts.
+    pub offset_ms: i32,
+    /// Preamble-detection timeout programmed into the radio.
+    pub timeout_symbols: u16,
+}
+
 pub trait Timings {
     /// How many milliseconds before the RX window should the SPI transaction start?
     /// This value needs to account for the time it takes to wake up the radio and start the SPI transaction, as
@@ -698,5 +714,40 @@ pub trait Timings {
     /// < Self::get_rx_window_lead_time_ms`.
     fn get_rx_window_buffer(&self) -> u32 {
         self.get_rx_window_lead_time_ms()
+    }
+
+    /// Calculate timing for a receive window's modulation parameters.
+    ///
+    /// Implementations that do not override this retain the historical
+    /// behavior: start `lead_time` early and add `buffer` to a 13-symbol
+    /// preamble timeout.
+    fn get_rx_window_timing(&self, rf: &RfConfig) -> RxWindowTiming {
+        const PREAMBLE_SYMBOLS: u16 = 13;
+        RxWindowTiming {
+            offset_ms: -(self.get_rx_window_lead_time_ms().min(i32::MAX as u32) as i32),
+            timeout_symbols: PREAMBLE_SYMBOLS
+                .saturating_add(rf.bb.delay_in_symbols_ceil(self.get_rx_window_buffer())),
+        }
+    }
+}
+
+fn apply_window_offset(nominal_ms: u32, offset_ms: i32) -> u32 {
+    if offset_ms >= 0 {
+        nominal_ms.saturating_add(offset_ms as u32)
+    } else {
+        nominal_ms.saturating_sub(offset_ms.unsigned_abs())
+    }
+}
+
+#[cfg(test)]
+mod timing_tests {
+    use super::apply_window_offset;
+
+    #[test]
+    fn window_offset_is_applied_without_wrapping() {
+        assert_eq!(940, apply_window_offset(1_000, -60));
+        assert_eq!(1_060, apply_window_offset(1_000, 60));
+        assert_eq!(0, apply_window_offset(10, -60));
+        assert_eq!(u32::MAX, apply_window_offset(u32::MAX - 10, 60));
     }
 }

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -555,7 +555,15 @@ where
 
         if let Some(response) = self.rx_listen(&rx_config.rf).await? {
             debug!("RX1 received {}", response);
+            self.window_complete().await?;
             return Ok(response);
+        }
+        // No window_complete between RX1 and RX2: the radio keeps its
+        // retained configuration through the gap so RX2 gets the fast warm
+        // wake (class C instead returns to RXC listening right away).
+        #[cfg(feature = "class-c")]
+        if self.class_c {
+            self.window_complete().await?;
         }
 
         let rx2_rf = rx_windows.get(&Window::_2);
@@ -573,7 +581,9 @@ where
         debug!("Configuring RX2 window with config {}.", rx_config);
         self.radio.setup_rx_window(rx_config, rx2_timing).await.map_err(Error::Radio)?;
 
-        if let Some(response) = self.rx_listen(&rx_config.rf).await? {
+        let response = self.rx_listen(&rx_config.rf).await?;
+        self.window_complete().await?;
+        if let Some(response) = response {
             debug!("RX2 received {}", response);
             return Ok(response);
         }
@@ -659,7 +669,6 @@ where
                 }
                 RxStatus::RxTimeout => None,
             };
-        self.window_complete().await?;
         Ok(response)
     }
 

--- a/lorawan-device/src/async_device/radio.rs
+++ b/lorawan-device/src/async_device/radio.rs
@@ -71,8 +71,25 @@ pub trait PhyRxTx: Sized {
     /// future should complete when RX data has been received or when the timeout has expired.
     async fn rx_single(&mut self, buf: &mut [u8]) -> Result<RxStatus, Self::PhyError>;
 
-    /// Puts the radio into a low-power mode
+    /// Puts the radio into a low-power mode.
+    ///
+    /// Used at the end of a receive cycle, before the potentially long idle
+    /// until the next uplink. Radios should favor the lowest-current sleep here
+    /// even when that means a slower, more expensive wake-up next time.
     async fn low_power(&mut self) -> Result<(), Self::PhyError> {
         Ok(())
+    }
+
+    /// Puts the radio into a low-power mode that keeps its configuration, for a
+    /// short idle where a fast wake-up matters more than the sleep current.
+    ///
+    /// Called between the transmit and its receive windows, and between RX1 and
+    /// RX2: gaps of seconds where re-initializing the radio from a cold sleep
+    /// would both burn the setup time and force the receive window to open
+    /// earlier to hide it. Radios with a retention sleep (e.g. the sx126x warm
+    /// start) should use it here; the default keeps the old behavior by
+    /// deferring to [`low_power`](Self::low_power).
+    async fn low_power_retain(&mut self) -> Result<(), Self::PhyError> {
+        self.low_power().await
     }
 }

--- a/lorawan-device/src/async_device/radio.rs
+++ b/lorawan-device/src/async_device/radio.rs
@@ -84,11 +84,7 @@ pub trait PhyRxTx: Sized {
     /// short idle where a fast wake-up matters more than the sleep current.
     ///
     /// Called between the transmit and its receive windows, and between RX1 and
-    /// RX2: gaps of seconds where re-initializing the radio from a cold sleep
-    /// would both burn the setup time and force the receive window to open
-    /// earlier to hide it. Radios with a retention sleep (e.g. the sx126x warm
-    /// start) should use it here; the default defers to
-    /// [`low_power`](Self::low_power).
+    /// RX2.
     async fn warm_sleep(&mut self) -> Result<(), Self::PhyError> {
         self.low_power().await
     }

--- a/lorawan-device/src/async_device/radio.rs
+++ b/lorawan-device/src/async_device/radio.rs
@@ -87,8 +87,8 @@ pub trait PhyRxTx: Sized {
     /// RX2: gaps of seconds where re-initializing the radio from a cold sleep
     /// would both burn the setup time and force the receive window to open
     /// earlier to hide it. Radios with a retention sleep (e.g. the sx126x warm
-    /// start) should use it here; the default keeps the old behavior by
-    /// deferring to [`low_power`](Self::low_power).
+    /// start) should use it here; the default defers to
+    /// [`low_power`](Self::low_power).
     async fn low_power_retain(&mut self) -> Result<(), Self::PhyError> {
         self.low_power().await
     }

--- a/lorawan-device/src/async_device/radio.rs
+++ b/lorawan-device/src/async_device/radio.rs
@@ -89,7 +89,7 @@ pub trait PhyRxTx: Sized {
     /// earlier to hide it. Radios with a retention sleep (e.g. the sx126x warm
     /// start) should use it here; the default defers to
     /// [`low_power`](Self::low_power).
-    async fn low_power_retain(&mut self) -> Result<(), Self::PhyError> {
+    async fn warm_sleep(&mut self) -> Result<(), Self::PhyError> {
         self.low_power().await
     }
 }

--- a/lorawan-device/src/async_device/radio.rs
+++ b/lorawan-device/src/async_device/radio.rs
@@ -46,6 +46,19 @@ pub trait PhyRxTx: Sized {
     /// Configures the radio to receive data. This future should not actually await the data itself.
     async fn setup_rx(&mut self, config: RxConfig) -> Result<(), Self::PhyError>;
 
+    /// Configure a single receive window with its precomputed timing.
+    ///
+    /// The default preserves compatibility with radios that derive their
+    /// timeout from [`RxConfig`]. Radios that support symbol-precise timeouts
+    /// can override this method.
+    async fn setup_rx_window(
+        &mut self,
+        config: RxConfig,
+        _timing: super::RxWindowTiming,
+    ) -> Result<(), Self::PhyError> {
+        self.setup_rx(config).await
+    }
+
     /// Receive data into the provided buffer with the given transceiver configuration. The returned
     /// future should only complete when RX data has been received. Furthermore, it should be
     /// possible to await the future again without settings up the receive config again.


### PR DESCRIPTION
Fixes #473.
Alternative to #474.

## Background

The LoRaWAN adapter starts radio setup a fixed lead time (50 ms) before the nominal RX1/RX2 instant and converts that same millisecond buffer into a symbol timeout. At fast datarates the symbols are short, so that timeout leaves very little tolerance for a late downlink. A fixed 250 ms timeout (#474) helps that case, but costs RX time at every datarate and does not move the opening side of the window.

Iterating on this surfaced a second problem: radio setup latency varies widely per chip, so the window math cannot assume setup consumes the whole lead time. A window centered under that assumption (as in LoRaMac-node's equations, which this PR originally used) opens and closes early on a radio with fast setup, and the receiver times out before the packet arrives.

## Approach

Each receive window is computed from the symbol duration of its datarate:

```text
offset  = -(lead_time + max_error)
timeout = ceil((lead_time + 2 * max_error) / T_sym) + min_symbols
```

- Opening `lead + error` early puts the radio in RX before the earliest possible packet, even when setup is slow and the device clock runs fast.
- The timeout spans `lead + 2 * error`, so the window still covers the nominal instant when setup is instant.
- The extra `min_symbols` keeps preamble-detection margin for a packet at the late edge of the error bound; without it the timeout could expire just as the latest packet's preamble begins.

The timeout is a symbol count, so it stays datarate-aware: slow symbols get a small count, fast symbols a larger one, and the wall-clock window stays the same.

RX1 and RX2 are computed independently because their datarates may differ. `set_system_max_rx_error` lets applications with larger clock or scheduling error widen both sides of the window (default ±10 ms).

### Per-chip minimum RX symbols

The preamble-detection floor is now a per-chip `RadioKind::DEFAULT_MIN_RX_SYMBOLS` (default 6). The sx127x uses 8: its single-receive timeout is driven by SymbTimeout and needs more headroom over the 8-symbol preamble. The lr11xx uses 13: its LoRaSynchTimeout appears to require the full preamble-plus-sync sequence (12.25 symbols) on the air before it counts a packet as detected, so a smaller floor can expire the window while a real downlink is still in its preamble. Still overridable at runtime with `set_min_rx_symbols`.

### Warm start between windows

With the windows fixed, cold radio setup dominates the lead time (about 30 ms measured on the sx126x, under 1 ms warm). A new `PhyRxTx::low_power_retain` (defaults to `low_power`) lets the stack use a retention sleep between a transmit and its receive windows on chips that keep their configuration across sleep, gated per chip by `RadioKind::SUPPORTS_WARM_START`: only the sx126x sets it true for now. The sx127x must re-init after every sleep, and on the lr11xx a warm-started window turned out to be deaf in hardware testing, so it stays on the cold sleep until that is isolated on local hardware. The idle before the next transmit stays a cold sleep.

## Compatibility

A defaulted `PhyRxTx::setup_rx_window` carries the symbol-precise timeout to radios that support it; existing radio implementations fall back to `setup_rx` unchanged. `low_power_retain` defaults to `low_power`. The existing `RxMode::Single { ms }`, `Timings` methods, and direct `setup_rx` behavior remain available.

## Tests

Unit coverage for the window math across datarates and error configurations, millisecond-to-symbol conversion edge cases, and lr1110 command byte streams.

Hardware tested on the sx1262 (NUCLEO-WL55JC) and sx1276 (B-L072Z-LRWAN1), including SF12/BW500 and SF10/BW500 downlink windows. The lr11xx window math is being verified on real hardware (thanks @Kezii).

- `cargo test -p lora-modulation -p lorawan-device -p lora-phy --features lora-phy/lorawan-radio`
- `cargo clippy -p lora-modulation -p lorawan-device -p lora-phy --features lora-phy/lorawan-radio --all-targets`
- `cargo fmt --all`


