### PR TITLE
lorawan-encoding: use as_chunks for constant-size chunking

### DIFF
--- a/lorawan-encoding/src/creator.rs
+++ b/lorawan-encoding/src/creator.rs
@@ -123,7 +123,8 @@ impl JoinAccept {
         // The server encrypts by running AES in *decrypt* mode so that the
         // device can decrypt with the cheaper encrypt mode. MHDR stays clear;
         // the MIC is inside the encrypted region.
-        for block in out[MHDR_LEN..].chunks_exact_mut(16) {
+        let (blocks, _) = out[MHDR_LEN..].as_chunks_mut::<16>();
+        for block in blocks {
             crypto.decrypt_block(block);
         }
         Ok(out)

--- a/lorawan-encoding/src/parser.rs
+++ b/lorawan-encoding/src/parser.rs
@@ -588,7 +588,8 @@ impl<'a> DecryptedJoinAcceptPayload<'a> {
         validate_join_accept_structure(buf)?;
         // The device side runs AES *encryption* to invert the server's
         // decrypt-mode transformation, per the spec.
-        for block in buf[1..].chunks_exact_mut(16) {
+        let (blocks, _) = buf[1..].as_chunks_mut::<16>();
+        for block in blocks {
             crypto.encrypt_block(block);
         }
         Ok(Self { bytes: buf })
@@ -663,8 +664,9 @@ impl<'a> DecryptedJoinAcceptPayload<'a> {
         match cflist[15] {
             0 => {
                 let mut freqs = [Frequency::default(); 5];
-                for (freq, chunk) in freqs.iter_mut().zip(cflist.chunks_exact(3)) {
-                    *freq = Frequency::from_wire_bytes(arr(chunk));
+                let (chunks, _) = cflist.as_chunks::<3>();
+                for (freq, chunk) in freqs.iter_mut().zip(chunks) {
+                    *freq = Frequency::from_wire_bytes(*chunk);
                 }
                 Some(CfList::DynamicChannel(freqs))
             }


### PR DESCRIPTION
The newest stable clippy flags `chunks_exact` with a constant chunk size. The lint job runs unpinned stable with `-Dclippy::all`, so every PR now fails on these three pre-existing sites in lorawan-encoding.

This switches them to `as_chunks`/`as_chunks_mut` (stable since 1.88, well under our 1.97 pin). In the CFList path this also drops a slice-to-array conversion, since the chunks come out as `[u8; 3]` directly.

No behavior change; all lorawan-encoding tests pass.