### PR TITLE
lorawan-device: update rand_core to 0.10

### DIFF
--- a/lorawan-device/CHANGELOG.md
+++ b/lorawan-device/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Enable Adaptive Data Rate (ADR) by default: uplink FCtrl ADR bit, ADRACKReq
   after `ADR_ACK_LIMIT` missed downlinks, and data-rate backoff after
   `ADR_ACK_DELAY`. Controllable via `Device::set_adr` / `get_adr`.
+- Update `rand_core` to 0.10: the device RNG bound and public re-export
+  change from `RngCore` to `Rng`
 
 ## [v0.12.1]
 

--- a/lorawan-device/Cargo.toml
+++ b/lorawan-device/Cargo.toml
@@ -23,7 +23,7 @@ heapless = "0.9"
 defmt = { version = "0.3", optional = true }
 fastrand = { version = "2", default-features = false }
 futures = { version = "0.3", default-features = false }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 serde = { version = "1", default-features = false, features = [
     "derive",
 ], optional = true }
@@ -32,7 +32,7 @@ embassy-time = { version = ">=0.3, <0.6", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }
-rand = { version = "0", features = ["getrandom"] }
+rand = "0.10"
 serde_json = "1"
 hex = "0.4.3"
 

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -7,7 +7,7 @@ pub use super::{
     region::{self, Region},
 };
 use heapless::Vec;
-use rand_core::RngCore;
+use rand_core::Rng;
 
 pub use crate::region::DR;
 use crate::{
@@ -65,7 +65,7 @@ pub struct Device<R, T, G, const N: usize = 256, const D: usize = 1>
 where
     R: radio::PhyRxTx + Timings,
     T: radio::Timer,
-    G: RngCore,
+    G: Rng,
 {
     radio: R,
     /// Access to provided (pseudo)-random number generator.
@@ -170,10 +170,10 @@ impl<R, T, G, const N: usize, const D: usize> Device<R, T, G, N, D>
 where
     R: radio::PhyRxTx + Timings,
     T: radio::Timer,
-    G: RngCore,
+    G: Rng,
 {
     /// Create a new instance of [`Device`] with a RNG external to the LoRa chip. You must provide your own RNG
-    /// implementing [`RngCore`].
+    /// implementing [`Rng`].
     ///
     /// See also [`new_with_seed`](Device::new_with_seed) to let [`Device`] use a builtin PRNG by providing a random
     /// seed.

--- a/lorawan-device/src/async_device/test/mod.rs
+++ b/lorawan-device/src/async_device/test/mod.rs
@@ -27,7 +27,7 @@ mod class_c;
 #[cfg(feature = "multicast")]
 mod multicast;
 
-type Device = crate::async_device::Device<TestRadio, TestTimer, rand_core::OsRng, 512, 4>;
+type Device = crate::async_device::Device<TestRadio, TestTimer, rand::rngs::StdRng, 512, 4>;
 
 #[tokio::test]
 async fn test_join_rx1() {

--- a/lorawan-device/src/async_device/test/util.rs
+++ b/lorawan-device/src/async_device/test/util.rs
@@ -18,7 +18,7 @@ pub fn session_with_region(region: region::Configuration) -> (RadioChannel, Time
         region,
         mock_radio,
         mock_timer,
-        rand::rngs::OsRng,
+        rand::make_rng(),
         Some(default_session()),
     );
     (radio_channel, timer_channel, async_device)
@@ -32,7 +32,7 @@ fn setup_internal(session_data: Option<Session>) -> (RadioChannel, TimerChannel,
         region.into(),
         mock_radio,
         mock_timer,
-        rand::rngs::OsRng,
+        rand::make_rng(),
         session_data,
     );
     (radio_channel, timer_channel, async_device)

--- a/lorawan-device/src/lib.rs
+++ b/lorawan-device/src/lib.rs
@@ -36,7 +36,7 @@ pub use lorawan::{
 #[deprecated(since = "0.12.2", note = "Please use `NwkSKey` instead")]
 pub use lorawan::keys::NwkSKey as NewSKey;
 
-pub use rand_core::RngCore;
+pub use rand_core::Rng;
 mod rng;
 pub use rng::Prng;
 

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -17,7 +17,7 @@ pub type FcntDown = u32;
 pub type FcntUp = u32;
 
 mod session;
-use rand_core::RngCore;
+use rand_core::Rng;
 pub use session::{Session, SessionKeys};
 
 mod otaa;
@@ -154,7 +154,7 @@ impl Mac {
 
     /// Prepare the radio buffer with transmitting a join request frame and provides the radio
     /// configuration for the transmission along with the RX window configurations bound to it.
-    pub(crate) fn join_otaa<RNG: RngCore, const N: usize>(
+    pub(crate) fn join_otaa<RNG: Rng, const N: usize>(
         &mut self,
         rng: &mut RNG,
         credentials: NetworkCredentials,
@@ -181,7 +181,7 @@ impl Mac {
 
     /// Prepare the radio buffer for transmitting a data frame and provide the radio configuration
     /// for the transmission. Returns an error if the device is not joined.
-    pub(crate) fn send<RNG: RngCore, const N: usize>(
+    pub(crate) fn send<RNG: Rng, const N: usize>(
         &mut self,
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
@@ -216,7 +216,7 @@ impl Mac {
     }
 
     #[cfg(feature = "multicast")]
-    pub(crate) fn multicast_setup_send<RNG: RngCore, const N: usize>(
+    pub(crate) fn multicast_setup_send<RNG: Rng, const N: usize>(
         &mut self,
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
@@ -236,7 +236,7 @@ impl Mac {
     }
 
     #[cfg(feature = "certification")]
-    pub(crate) fn certification_setup_send<RNG: RngCore, const N: usize>(
+    pub(crate) fn certification_setup_send<RNG: Rng, const N: usize>(
         &mut self,
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,

--- a/lorawan-device/src/mac/otaa.rs
+++ b/lorawan-device/src/mac/otaa.rs
@@ -5,7 +5,7 @@ use crate::{AppEui, AppKey, DevEui};
 use lorawan::creator::JoinRequest;
 use lorawan::default_crypto::DefaultCrypto;
 use lorawan::parser::DecryptedJoinAcceptPayload;
-use rand_core::RngCore;
+use rand_core::Rng;
 
 pub(crate) type DevNonce = lorawan::parser::DevNonce;
 
@@ -28,7 +28,7 @@ impl Otaa {
 
     /// Prepare a join request to be sent. This populates the radio buffer with the request to be
     /// sent, and returns the radio config to use for transmitting.
-    pub(crate) fn prepare_buffer<G: RngCore, const N: usize>(
+    pub(crate) fn prepare_buffer<G: Rng, const N: usize>(
         &mut self,
         rng: &mut G,
         buf: &mut RadioBuffer<N>,

--- a/lorawan-device/src/nb_device/mod.rs
+++ b/lorawan-device/src/nb_device/mod.rs
@@ -17,7 +17,7 @@ type TimestampMs = u32;
 pub struct Device<R, RNG, const N: usize, const D: usize = 1>
 where
     R: PhyRxTx + Timings,
-    RNG: RngCore,
+    RNG: Rng,
 {
     state: State,
     shared: Shared<R, RNG, N, D>,
@@ -26,7 +26,7 @@ where
 impl<R, RNG, const N: usize, const D: usize> Device<R, RNG, N, D>
 where
     R: PhyRxTx + Timings,
-    RNG: RngCore,
+    RNG: Rng,
 {
     pub fn new(region: region::Configuration, radio: R, rng: RNG) -> Device<R, RNG, N, D> {
         Device {
@@ -120,7 +120,7 @@ where
     }
 }
 
-pub(crate) struct Shared<R: PhyRxTx + Timings, RNG: RngCore, const N: usize, const D: usize> {
+pub(crate) struct Shared<R: PhyRxTx + Timings, RNG: Rng, const N: usize, const D: usize> {
     pub(crate) radio: R,
     pub(crate) rng: RNG,
     pub(crate) tx_buffer: RadioBuffer<N>,

--- a/lorawan-device/src/nb_device/state.rs
+++ b/lorawan-device/src/nb_device/state.rs
@@ -104,7 +104,7 @@ impl<R: radio::PhyRxTx> From<Error> for super::Error<R> {
 impl State {
     pub(crate) fn handle_event<
         R: radio::PhyRxTx + Timings,
-        RNG: RngCore,
+        RNG: Rng,
         const N: usize,
         const D: usize,
     >(
@@ -129,7 +129,7 @@ impl State {
 pub struct Idle;
 
 impl Idle {
-    pub(crate) fn handle_event<R: radio::PhyRxTx + Timings, RNG: RngCore, const N: usize>(
+    pub(crate) fn handle_event<R: radio::PhyRxTx + Timings, RNG: Rng, const N: usize>(
         self,
         mac: &mut Mac,
         radio: &mut R,

--- a/lorawan-device/src/nb_device/test/util.rs
+++ b/lorawan-device/src/nb_device/test/util.rs
@@ -8,8 +8,8 @@ use crate::nb_device::{
 use crate::test_util::*;
 use region::{Configuration, Region};
 
-pub fn test_device() -> Device<TestRadio, rand_core::OsRng, 255> {
-    Device::new(Configuration::new(Region::US915), TestRadio::default(), rand::rngs::OsRng)
+pub fn test_device() -> Device<TestRadio, rand::rngs::StdRng, 255> {
+    Device::new(Configuration::new(Region::US915), TestRadio::default(), rand::make_rng())
 }
 
 #[derive(Debug)]

--- a/lorawan-device/src/region/dynamic_channel_plans/mod.rs
+++ b/lorawan-device/src/region/dynamic_channel_plans/mod.rs
@@ -80,7 +80,7 @@ impl<R: DynamicChannelRegion> DynamicChannelPlan<R> {
         }
     }
 
-    fn get_random_in_range<RNG: RngCore>(&self, rng: &mut RNG) -> usize {
+    fn get_random_in_range<RNG: Rng>(&self, rng: &mut RNG) -> usize {
         // SAFETY: We will always have at least number of join channels, therefore
         // unwrap is safe to use.
         let range = self.channels.iter().rposition(|&x| x.is_some()).unwrap() + 1;
@@ -195,7 +195,7 @@ impl<R: DynamicChannelRegion> RegionHandler for DynamicChannelPlan<R> {
         R::datarates()[dr as usize].as_ref()
     }
 
-    fn select_tx_channel<RNG: RngCore>(
+    fn select_tx_channel<RNG: Rng>(
         &mut self,
         rng: &mut RNG,
         datarate: DR,

--- a/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/join_channels.rs
@@ -26,7 +26,7 @@ impl JoinChannels {
 
     /// The first data channel will always be some random channel (possibly the same as previous)
     /// of the preferred subband. Returns None if there is no preferred subband.
-    pub(crate) fn first_data_channel(&mut self, rng: &mut impl RngCore) -> Option<u8> {
+    pub(crate) fn first_data_channel(&mut self, rng: &mut impl Rng) -> Option<u8> {
         if self.preferred_subband.is_some() && self.num_retries != 0 {
             self.clear_join_bias();
             // determine which subband the successful join was sent on
@@ -58,7 +58,7 @@ impl JoinChannels {
         self.available_channels = AvailableChannels::default();
     }
 
-    pub(crate) fn get_next_channel(&mut self, rng: &mut impl RngCore) -> u8 {
+    pub(crate) fn get_next_channel(&mut self, rng: &mut impl Rng) -> u8 {
         match (self.preferred_subband, self.num_retries.cmp(&self.max_retries)) {
             (Some(sb), Ordering::Less) => {
                 self.num_retries += 1;
@@ -101,7 +101,7 @@ impl AvailableChannels {
         true
     }
 
-    fn get_next(&mut self, rng: &mut impl RngCore) -> u8 {
+    fn get_next(&mut self, rng: &mut impl Rng) -> u8 {
         // this guarantees that there will be _some_ open channel available
         if self.is_exhausted() {
             self.reset();
@@ -114,7 +114,7 @@ impl AvailableChannels {
         channel
     }
 
-    fn get_next_channel_inner(&mut self, rng: &mut impl RngCore) -> u8 {
+    fn get_next_channel_inner(&mut self, rng: &mut impl Rng) -> u8 {
         if let Some(previous) = self.previous {
             // choose the next one by possibly wrapping around
             let next = (previous + 8) % 72;
@@ -223,7 +223,7 @@ mod test {
 
     #[test]
     fn test_join_channels_standard() {
-        let mut rng = rand_core::OsRng;
+        let mut rng = rand::rng();
         // run the test a bunch of times due to the rng
         for _ in 0..100 {
             let mut join_channels = JoinChannels::default();
@@ -248,7 +248,7 @@ mod test {
 
     #[test]
     fn test_join_channels_standard_exhausted() {
-        let mut rng = rand_core::OsRng;
+        let mut rng = rand::rng();
 
         let mut join_channels = JoinChannels::default();
         let first_channel = join_channels.get_next_channel(&mut rng);
@@ -267,7 +267,7 @@ mod test {
 
     #[test]
     fn test_join_channels_biased() {
-        let mut rng = rand_core::OsRng;
+        let mut rng = rand::rng();
         // run the test a bunch of times due to the rng
         for _ in 0..100 {
             let mut join_channels = JoinChannels::default();
@@ -299,7 +299,7 @@ mod test {
     fn test_join_rx1_datarate_follows_forced_join_dr() {
         use lora_modulation::{Bandwidth, SpreadingFactor};
 
-        let mut rng = rand_core::OsRng;
+        let mut rng = rand::rng();
         let mut mac = Mac::new(US915::new().into(), 21, 2);
         let mut buf: RadioBuffer<255> = RadioBuffer::new();
         let credentials = NetworkCredentials::new(
@@ -342,7 +342,7 @@ mod test {
 
         let mut buf: RadioBuffer<255> = RadioBuffer::new();
         let (tx_config, rx_windows, _dev_nonce) = mac.join_otaa::<_, 255>(
-            &mut rand::rngs::OsRng,
+            &mut rand::rng(),
             NetworkCredentials::new(
                 AppEui::from([0x0; 8]),
                 DevEui::from([0x0; 8]),
@@ -378,7 +378,7 @@ mod test {
         }
         let (tx_config, _rx_windows, _fcnt) = mac
             .send::<_, 255>(
-                &mut rand::rngs::OsRng,
+                &mut rand::rng(),
                 &mut buf,
                 &SendData { fport: 1, data: &[0x0; 1], confirmed: false },
             )
@@ -404,7 +404,7 @@ mod test {
 
         let mut buf: RadioBuffer<255> = RadioBuffer::new();
         let (tx_config, rx_windows, _dev_nonce) = mac.join_otaa::<_, 255>(
-            &mut rand::rngs::OsRng,
+            &mut rand::rng(),
             NetworkCredentials::new(
                 AppEui::from([0x0; 8]),
                 DevEui::from([0x0; 8]),
@@ -440,7 +440,7 @@ mod test {
         for _ in 0..8 {
             let (tx_config, _rx_windows, _fcnt) = mac
                 .send::<_, 255>(
-                    &mut rand::rngs::OsRng,
+                    &mut rand::rng(),
                     &mut buf,
                     &SendData { fport: 1, data: &[0x0; 1], confirmed: false },
                 )

--- a/lorawan-device/src/region/fixed_channel_plans/mod.rs
+++ b/lorawan-device/src/region/fixed_channel_plans/mod.rs
@@ -171,7 +171,7 @@ impl<F: FixedChannelRegion> RegionHandler for FixedChannelPlan<F> {
         F::datarates()[dr as usize].as_ref()
     }
 
-    fn select_tx_channel<RNG: RngCore>(
+    fn select_tx_channel<RNG: Rng>(
         &mut self,
         rng: &mut RNG,
         datarate: DR,

--- a/lorawan-device/src/region/mod.rs
+++ b/lorawan-device/src/region/mod.rs
@@ -4,7 +4,7 @@ use lorawan::{
     parser::CfList,
     types::{ChannelMask, DataRateRange},
 };
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use crate::mac::{Frame, Window};
 pub(crate) mod constants;
@@ -377,7 +377,7 @@ impl Configuration {
         )
     }
 
-    pub(crate) fn create_tx_config<RNG: RngCore>(
+    pub(crate) fn create_tx_config<RNG: Rng>(
         &mut self,
         rng: &mut RNG,
         datarate: DR,
@@ -408,7 +408,7 @@ impl Configuration {
         region_dispatch!(self, check_tx_power, tx_power).map(Some)
     }
 
-    fn select_tx_channel<RNG: RngCore>(
+    fn select_tx_channel<RNG: Rng>(
         &mut self,
         rng: &mut RNG,
         datarate: DR,
@@ -553,7 +553,7 @@ pub(crate) trait RegionHandler {
         DR::_0
     }
 
-    fn select_tx_channel<RNG: RngCore>(
+    fn select_tx_channel<RNG: Rng>(
         &mut self,
         rng: &mut RNG,
         datarate: DR,

--- a/lorawan-device/src/rng.rs
+++ b/lorawan-device/src/rng.rs
@@ -16,12 +16,12 @@
 //! * No one cares if the channel selected for the next uplink is predictable,
 //!   as long as the channel selection yields an uniform distribution.
 //!
-//! By providing a PRNG `RngCore` implementation, we enable the crate users the
+//! By providing a PRNG `Rng` implementation, we enable the crate users the
 //! flexibility of choosing whether they want to provide their own RNG, or just
 //! a seed to instantiate this PRNG to generate the random numbers for them.
 
 use fastrand::Rng;
-use rand_core::RngCore;
+use rand_core::TryRng;
 
 #[derive(Clone)]
 /// A pseudorandom number generator utilizing Wyrand algorithm via
@@ -34,21 +34,25 @@ impl Prng {
     }
 }
 
-impl RngCore for Prng {
-    fn next_u32(&mut self) -> u32 {
-        self.0.u32(..)
+impl TryRng for Prng {
+    type Error = core::convert::Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, core::convert::Infallible> {
+        Ok(self.0.u32(..))
     }
 
-    fn next_u64(&mut self) -> u64 {
-        self.0.u64(..)
+    fn try_next_u64(&mut self) -> Result<u64, core::convert::Infallible> {
+        Ok(self.0.u64(..))
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        rand_core::impls::fill_bytes_via_next(self, dest)
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), core::convert::Infallible> {
+        let mut offset = 0;
+        while offset < dest.len() {
+            let word = self.try_next_u64()?.to_le_bytes();
+            let n = word.len().min(dest.len() - offset);
+            dest[offset..offset + n].copy_from_slice(&word[..n]);
+            offset += n;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Ok, apparently this has to wait as most HALs (rp and stm32) have not been released with rand_core 0.10 support.

RngCore is gone in 0.10: the device RNG bound and public re-export now use Rng, and Prng implements TryRng with an Infallible error type. Test RNGs are seeded via rand::make_rng.