### PR TITLE
Implement NbTrans support (Number of Redundant Uplink Transmissions)

### DIFF
--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -371,7 +371,9 @@ where
     /// receives no downlink in RX1/RX2 is retransmitted automatically with the same FCntUp,
     /// up to NbTrans times (1..=15). Each retransmission is a full transmission with its
     /// own channel selection and RX1/RX2 windows, and a downlink in either window
-    /// stops the retransmission.
+    /// stops the retransmission. This also applies to uplinks the stack itself
+    /// transmits (such as certification answer frames on FPort 224), which open
+    /// their own RX windows after transmission.
     ///
     /// In Class C mode, it is possible to get one or more downlinks and `Reponse::DownlinkReceived`
     /// maybe not even be indicated. It is recommended to call `take_downlink` after `send` until
@@ -392,13 +394,17 @@ where
         self.retransmit_buffer.clear();
         self.retransmit_buffer.extend_from_slice(self.radio_buffer.as_ref_for_read()).unwrap();
 
+        let mut ms = 0u32;
+        let mut tx_pending = true;
         loop {
-            // Transmit our data packet
-            let ms = self
-                .radio
-                .tx(tx_config, self.retransmit_buffer.as_ref_for_read())
-                .await
-                .map_err(Error::Radio)?;
+            if tx_pending {
+                // Transmit our data packet
+                ms = self
+                    .radio
+                    .tx(tx_config, self.retransmit_buffer.as_ref_for_read())
+                    .await
+                    .map_err(Error::Radio)?;
+            }
 
             // Wait for received data within window
             self.timer.reset();
@@ -407,7 +413,15 @@ where
                 // re-select the channel (and its RX windows) as usual
                 mac::Response::Retransmit => {
                     (tx_config, rx_windows) = self.mac.retransmit_config::<G>(&mut self.rng);
-                    continue;
+                    tx_pending = true;
+                }
+                // A certification answer was transmitted inside the RX window;
+                // it is a regular uplink, so run its RX windows (and NbTrans
+                // retransmissions) without transmitting again.
+                #[cfg(feature = "certification")]
+                mac::Response::UplinkPrepared => {
+                    (ms, rx_windows) = self.mac.take_pending_cert_rx();
+                    tx_pending = false;
                 }
                 response => return Ok(response.into()),
             }
@@ -520,6 +534,7 @@ where
                     )?;
                     match Self::handle_mac_response(
                         &mut self.radio_buffer,
+                        &mut self.retransmit_buffer,
                         &mut self.mac,
                         &mut self.radio,
                         &mut self.rng,
@@ -571,6 +586,14 @@ where
 
         debug!("Starting RX1 in {} ms.", rx1_start_delay);
         // sleep or RXC
+        #[cfg(feature = "certification")]
+        if let Some(mac::Response::UplinkPrepared) = self.between_windows(rx1_start_delay).await? {
+            // Class C: a certification request was answered during the
+            // inter-window gap, where the send loop cannot run the answer's
+            // RX windows; complete it here instead.
+            let _ = self.mac.rx2_complete();
+        }
+        #[cfg(not(feature = "certification"))]
         let _ = self.between_windows(rx1_start_delay).await?;
 
         // RX1
@@ -620,6 +643,7 @@ where
     #[allow(unused_variables)]
     async fn handle_mac_response(
         radio_buffer: &mut RadioBuffer<N>,
+        retransmit_buffer: &mut RadioBuffer<N>,
         mac: &mut Mac,
         radio: &mut R,
         rng: &mut G,
@@ -636,10 +660,21 @@ where
             }
             #[cfg(feature = "certification")]
             mac::Response::UplinkPrepared => {
-                let (tx_config, _rx_windows, _fcnt_up) =
+                let (tx_config, rx_windows, _fcnt_up) =
                     mac.certification_setup_send::<G, N>(rng, radio_buffer)?;
-                radio.tx(tx_config, radio_buffer.as_ref_for_read()).await.map_err(Error::Radio)?;
-                Ok(Some(mac.rx2_complete()))
+                // The answer is a regular uplink: retain it so the send loop
+                // can retransmit it per NbTrans (the radio buffer is reused
+                // for reception).
+                retransmit_buffer.clear();
+                retransmit_buffer.extend_from_slice(radio_buffer.as_ref_for_read()).unwrap();
+                let tx_duration_ms = radio
+                    .tx(tx_config, retransmit_buffer.as_ref_for_read())
+                    .await
+                    .map_err(Error::Radio)?;
+                // The answer opens its own RX windows; the send loop runs
+                // them (and any NbTrans retransmissions) after this response.
+                mac.set_pending_cert_rx(tx_duration_ms, rx_windows);
+                Ok(Some(mac::Response::UplinkPrepared))
             }
             #[cfg(feature = "multicast")]
             mac::Response::Multicast(mut response) => {
@@ -684,6 +719,7 @@ where
                     );
                     Self::handle_mac_response(
                         &mut self.radio_buffer,
+                        &mut self.retransmit_buffer,
                         &mut self.mac,
                         &mut self.radio,
                         &mut self.rng,
@@ -714,6 +750,7 @@ where
             )?;
             if let Some(response) = Self::handle_mac_response(
                 &mut self.radio_buffer,
+                &mut self.retransmit_buffer,
                 &mut self.mac,
                 &mut self.radio,
                 &mut self.rng,

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -73,6 +73,10 @@ where
     timer: T,
     mac: Mac,
     radio_buffer: RadioBuffer<N>,
+    /// Copy of the frame built for the current uplink, retained so that NbTrans
+    /// retransmissions can resend the exact same bytes (same FCntUp, ADRACKReq
+    /// bit and MAC commands) after the radio buffer is reused for reception.
+    retransmit_buffer: RadioBuffer<N>,
     downlink: Vec<Downlink, D>,
     #[cfg(feature = "class-c")]
     class_c: bool,
@@ -198,6 +202,7 @@ where
             rng,
             mac,
             radio_buffer: RadioBuffer::new(),
+            retransmit_buffer: RadioBuffer::new(),
             timer,
             downlink: Vec::new(),
             #[cfg(feature = "class-c")]
@@ -362,6 +367,12 @@ where
     /// if any, is available by calling take_downlink. Response::DownlinkReceived indicates a
     /// downlink is available.
     ///
+    /// When the network has set NbTrans > 1 via LinkADRReq (LoRaWAN 1.0.4), a frame that
+    /// receives no downlink in RX1/RX2 is retransmitted automatically with the same FCntUp,
+    /// up to NbTrans times (1..=15). Each retransmission is a full transmission with its
+    /// own channel selection and RX1/RX2 windows, and a downlink in either window
+    /// stops the retransmission.
+    ///
     /// In Class C mode, it is possible to get one or more downlinks and `Reponse::DownlinkReceived`
     /// maybe not even be indicated. It is recommended to call `take_downlink` after `send` until
     /// it returns `None`.
@@ -372,21 +383,35 @@ where
         confirmed: bool,
     ) -> Result<SendResponse, Error<R::PhyError>> {
         // Prepare transmission buffer
-        let (tx_config, rx_windows, _fcnt_up) = self.mac.send::<G, N>(
+        let (mut tx_config, mut rx_windows, _fcnt_up) = self.mac.send::<G, N>(
             &mut self.rng,
             &mut self.radio_buffer,
             &SendData { data, fport, confirmed },
         )?;
-        // Transmit our data packet
-        let ms = self
-            .radio
-            .tx(tx_config, self.radio_buffer.as_ref_for_read())
-            .await
-            .map_err(Error::Radio)?;
+        // Retain a copy of the built frame for potential NbTrans retransmissions
+        self.retransmit_buffer.clear();
+        self.retransmit_buffer.extend_from_slice(self.radio_buffer.as_ref_for_read()).unwrap();
 
-        // Wait for received data within window
-        self.timer.reset();
-        Ok(self.rx_downlink(&Frame::Data, ms, &rx_windows).await?.into())
+        loop {
+            // Transmit our data packet
+            let ms = self
+                .radio
+                .tx(tx_config, self.retransmit_buffer.as_ref_for_read())
+                .await
+                .map_err(Error::Radio)?;
+
+            // Wait for received data within window
+            self.timer.reset();
+            match self.rx_downlink(&Frame::Data, ms, &rx_windows).await? {
+                // NbTrans: the MAC will resend this frame with the same FCntUp;
+                // re-select the channel (and its RX windows) as usual
+                mac::Response::Retransmit => {
+                    (tx_config, rx_windows) = self.mac.retransmit_config::<G>(&mut self.rng);
+                    continue;
+                }
+                response => return Ok(response.into()),
+            }
+        }
     }
 
     /// Take the downlink data from the device. This is typically called after a

--- a/lorawan-device/src/async_device/mod.rs
+++ b/lorawan-device/src/async_device/mod.rs
@@ -636,7 +636,7 @@ where
             }
             #[cfg(feature = "certification")]
             mac::Response::UplinkPrepared => {
-                let (tx_config, _fcnt_up) =
+                let (tx_config, _rx_windows, _fcnt_up) =
                     mac.certification_setup_send::<G, N>(rng, radio_buffer)?;
                 radio.tx(tx_config, radio_buffer.as_ref_for_read()).await.map_err(Error::Radio)?;
                 Ok(Some(mac.rx2_complete()))

--- a/lorawan-device/src/async_device/test/certification/linkadrreq_eu868.rs
+++ b/lorawan-device/src/async_device/test/certification/linkadrreq_eu868.rs
@@ -1,0 +1,592 @@
+//! LoRaWAN 1.0.4 Certification testcases
+//! Based on LoRaWAN 1.0.4 End Device Certification Test Specification v1.6.4
+//!
+//! EU868 LinkADRReq tests
+
+use super::{decrypt_uplink, util};
+use crate::async_device::SendResponse;
+use crate::radio::RfConfig;
+use crate::test_util::{Uplink, get_crypto, get_dev_addr};
+use core::num::NonZeroU8;
+use lorawan::creator::{DataFrame, Payload};
+use lorawan::parser::{self, DataFrameType, FrmPayload, PhyPayload};
+
+/// Build a downlink frame. `fport = 0` puts the payload in FRMPayload as MAC
+/// commands; any other value is an FPort data payload. A confirmed
+/// `frame_type` acknowledges the previous confirmed uplink.
+fn build_downlink(
+    buf: &mut [u8],
+    frame_type: DataFrameType,
+    ack: bool,
+    fport: u8,
+    payload_hex: &str,
+    fcnt: u16,
+) -> usize {
+    let payload = hex::decode(payload_hex).unwrap();
+    let frame = DataFrame {
+        frame_type,
+        dev_addr: get_dev_addr(),
+        ack,
+        fcnt: fcnt.into(),
+        payload: match fport {
+            0 => Payload::MacCommands(&payload),
+            p => Payload::Data { f_port: NonZeroU8::new(p).unwrap(), data: &payload },
+        },
+        ..Default::default()
+    };
+    let finished = frame.build_into(buf, &get_crypto(), Some(&get_crypto())).unwrap();
+    finished.len()
+}
+
+/// TCL helper: sanity-check the FCntUp of the uplink the downlink answers.
+fn expect_uplink_fcnt(uplink: Option<Uplink>, fcnt: u32) {
+    let Some(mut uplink) = uplink else {
+        panic!("expected an uplink");
+    };
+    match parser::parse(uplink.data_mut()) {
+        Ok(PhyPayload::Data(data)) => {
+            assert_eq!(data.fhdr().fcnt() as u32, fcnt, "answered the wrong uplink");
+        }
+        _ => panic!("expected a data uplink"),
+    }
+}
+
+/// DUT helper: parse, MIC-check and decrypt an uplink, then verify its
+/// header fields and (decrypted) FRMPayload.
+fn assert_uplink(
+    uplink: &Uplink,
+    fcnt: u32,
+    confirmed: bool,
+    ack: bool,
+    fopts: &[u8],
+    fport: Option<u8>,
+    payload: &[u8],
+) {
+    let mut uplink = uplink.clone();
+    let dl = decrypt_uplink(&mut uplink);
+    assert_eq!(dl.fhdr().fcnt() as u32, fcnt, "FCntUp");
+    assert_eq!(dl.is_confirmed(), confirmed, "frame type");
+    assert_eq!(dl.fhdr().fctrl().ack(), ack, "ACK bit");
+    assert_eq!(dl.fhdr().f_opts(), fopts, "FOpts");
+    assert_eq!(dl.f_port(), fport, "FPort");
+    match (dl.frm_payload(), payload) {
+        (FrmPayload::Data(data), _) => assert_eq!(data, payload, "FRMPayload"),
+        (FrmPayload::MacCommands(data), _) => assert_eq!(data, payload, "FRMPayload"),
+        (FrmPayload::None, _) => assert!(payload.is_empty(), "expected no FRMPayload"),
+    }
+}
+
+/// Check an uplink is a plain application data frame on port 3.
+fn assert_data_uplink(uplink: &Uplink, fcnt: u32, confirmed: bool, ack: bool, fopts: &[u8]) {
+    assert_uplink(uplink, fcnt, confirmed, ack, fopts, Some(3), &[1, 2, 3]);
+}
+
+#[tokio::test]
+/// EU868 LinkADRReq Redundancy test
+///
+/// This test validates the DUT's correct implementation of the NbTrans
+/// setting within the LinkADRReq command.
+///
+/// Like a regular uplink, a certification answer (FPort 224) opens its own
+/// RX windows and is retransmitted per NbTrans. One deviation from the
+/// paper procedure: the paper test sends some TCL downlinks in the answer's
+/// own RX windows; here those windows are kept silent and the downlinks are
+/// delivered in the next regular uplink's window instead.
+async fn eu868_linkadrreq_redundancy() {
+    let (radio, timer, mut device) =
+        util::session_with_region(crate::region::EU868::new_eu868().into());
+
+    // LinkADRReq used throughout: CID 0x03, DRTP 0x50 (DataRate = DR5 =
+    // Max125kHzDR, TXPower = 0 = maximum), ChMask [0x07, 0x00] (ChMaskCntl =
+    // 0 with only the default channels 0..2 enabled), Redundancy byte whose
+    // lower nibble is NbTrans (ChMaskCntl lives in the upper nibble in this
+    // implementation).
+    const LINKADR_REQ: &str = "03500700";
+    const LINKADR_ANS: &[u8] = &[0x03, 0x07]; // all three ACK bits set
+
+    /// LinkADRReq with the given NbTrans (0 = default of 1 transmission).
+    fn linkadr_req(buf: &mut [u8], nb_trans: u8, fcnt: u16) -> usize {
+        let payload = format!("{LINKADR_REQ}{nb_trans:02x}");
+        build_downlink(buf, DataFrameType::UnconfirmedDown, false, 0, &payload, fcnt)
+    }
+
+    /// CP-CMD RxAppCntReq (FPort 224, payload 0x09).
+    fn rxappcnt_req(buf: &mut [u8], fcnt: u16) -> usize {
+        build_downlink(buf, DataFrameType::UnconfirmedDown, false, 224, "09", fcnt)
+    }
+
+    // Step 1: DUT sends an unconfirmed frame (FCntUp = n = 0); the TCL
+    // responds on RX1 with CP-CMD RxAppCntReq.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn tcl_rxappcnt_req_1(uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        expect_uplink_fcnt(uplink, 0);
+        rxappcnt_req(buf, 0)
+    }
+    radio.handle_rxtx(tcl_rxappcnt_req_1).await;
+
+    // The answer (FCntUp = n + 1) opens its own RX windows.
+    // (fire_when_armed: the device arms this timer as a result of the
+    // downlink above, so the test must not race the device task.)
+    timer.fire_when_armed(2).await; // answer RX1 start
+    radio.handle_timeout().await; // answer RX1 end
+    timer.fire_most_recent().await; // answer RX2 start
+    radio.handle_timeout().await; // answer RX2 end
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::RxComplete) => {}
+        _ => panic!("expected RxComplete after RxAppCntReq, got {response:?}"),
+    }
+
+    // Step 2: DUT answers with an RxAppCntAns uplink (FCntUp = n + 1)
+    // reporting RxAppCnt = x. The device sends the answer immediately, so
+    // this uplink was transmitted inside the window of the step-1 uplink.
+    let uplink = radio.get_last_uplink().await;
+    assert_uplink(&uplink, 1, false, false, &[], Some(224), &[0x09, 0x01, 0x00]);
+
+    let x: u16 = 1;
+
+    // Step 3: DUT sends an unconfirmed frame (FCntUp = n + 2); the TCL
+    // responds with MAC-CMD LinkADRReq, NbTrans = 2.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn tcl_linkadr_req_nbtrans2(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        expect_uplink_fcnt(uplink, 2);
+        linkadr_req(buf, 2, 1)
+    }
+    radio.handle_rxtx(tcl_linkadr_req_nbtrans2).await;
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(1)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+    // The next uplink must carry LinkADRAns (all settings valid)
+    let session = device.mac.get_session().unwrap();
+    assert_eq!(session.uplink.mac_commands(), LINKADR_ANS);
+
+    // Steps 4-5: the uplink (FCntUp = n + 3) carries the LinkADRAns and, as
+    // it receives no downlink, is retransmitted once (NbTrans = 2) with the
+    // same FCntUp.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    // Transmission 1
+    timer.fire_most_recent().await; // RX1 start
+    let mut tx1 = radio.get_last_uplink().await;
+    radio.handle_timeout().await; // RX1 end
+    timer.fire_most_recent().await; // RX2 start
+    radio.handle_timeout().await; // RX2 end -> retransmit
+    // Transmission 2
+    timer.fire_most_recent().await; // RX1 start
+    let mut tx2 = radio.get_last_uplink().await;
+    radio.handle_timeout().await; // RX1 end
+    timer.fire_most_recent().await; // RX2 start
+    radio.handle_timeout().await; // RX2 end -> FCntUp consumed
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::RxComplete) => {}
+        _ => panic!("expected RxComplete, got {response:?}"),
+    }
+    assert_data_uplink(&tx1, 3, false, false, LINKADR_ANS);
+    // The retransmission resends the exact same frame (same FCntUp)
+    assert_eq!(tx1.data_mut(), tx2.data_mut());
+
+    // Steps 6-7: next uplink (FCntUp = n + 4) is also sent twice
+    // (NbTrans = 2 is still in effect).
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    let mut tx1 = radio.get_last_uplink().await;
+    radio.handle_timeout().await;
+    timer.fire_most_recent().await; // RX2 start
+    radio.handle_timeout().await; // -> retransmit
+    timer.fire_most_recent().await; // RX1 start
+    let mut tx2 = radio.get_last_uplink().await;
+    radio.handle_timeout().await;
+    timer.fire_most_recent().await; // RX2 start
+    radio.handle_timeout().await; // -> FCntUp consumed
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::RxComplete) => {}
+        _ => panic!("expected RxComplete, got {response:?}"),
+    }
+    assert_data_uplink(&tx1, 4, false, false, &[]);
+    assert_eq!(tx1.data_mut(), tx2.data_mut());
+
+    // Step 8: DUT uplink (FCntUp = n + 5); the TCL responds with
+    // RxAppCntReq on the RX1 window.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn tcl_rxappcnt_req_rx1(uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        expect_uplink_fcnt(uplink, 5);
+        rxappcnt_req(buf, 2)
+    }
+    radio.handle_rxtx(tcl_rxappcnt_req_rx1).await;
+
+    // Step 9: the RxAppCntAns uplink (FCntUp = n + 6) reports
+    // RxAppCnt = x + 1. The answer is a regular uplink: it opens its own
+    // RX windows and, as it receives no downlink, is retransmitted once
+    // (NbTrans = 2) with the same FCntUp.
+    // Transmission 1
+    timer.fire_when_armed(14).await; // answer RX1 start
+    let mut tx1 = radio.get_last_uplink().await;
+    radio.handle_timeout().await; // answer RX1 end
+    timer.fire_most_recent().await; // answer RX2 start
+    radio.handle_timeout().await; // answer RX2 end -> retransmit
+    // Transmission 2
+    timer.fire_most_recent().await; // answer RX1 start
+    let mut tx2 = radio.get_last_uplink().await;
+    radio.handle_timeout().await; // answer RX1 end
+    timer.fire_most_recent().await; // answer RX2 start
+    radio.handle_timeout().await; // answer RX2 end -> FCntUp consumed
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::RxComplete) => {}
+        _ => panic!("expected RxComplete, got {response:?}"),
+    }
+    assert_uplink(&tx1, 6, false, false, &[], Some(224), &[0x09, (x + 1) as u8, 0x00]);
+    // The retransmission resends the exact same frame (same FCntUp)
+    assert_eq!(tx1.data_mut(), tx2.data_mut());
+
+    // Step 11: DUT uplink (FCntUp = n + 7); the TCL responds with
+    // RxAppCntReq on the RX2 window.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    radio.handle_timeout().await; // RX1 end
+    timer.fire_most_recent().await; // RX2 start
+    fn tcl_rxappcnt_req_rx2(uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        expect_uplink_fcnt(uplink, 7);
+        rxappcnt_req(buf, 3)
+    }
+    radio.handle_rxtx(tcl_rxappcnt_req_rx2).await;
+
+    // Step 12: the RxAppCntAns uplink (FCntUp = n + 8) reports
+    // RxAppCnt = x + 2. The answer is a regular uplink: it opens its own
+    // RX windows and, as it receives no downlink, is retransmitted once
+    // (NbTrans = 2) with the same FCntUp.
+    // Transmission 1
+    timer.fire_when_armed(20).await; // answer RX1 start
+    let mut tx1 = radio.get_last_uplink().await;
+    radio.handle_timeout().await; // answer RX1 end
+    timer.fire_most_recent().await; // answer RX2 start
+    radio.handle_timeout().await; // answer RX2 end -> retransmit
+    // Transmission 2
+    timer.fire_most_recent().await; // answer RX1 start
+    let mut tx2 = radio.get_last_uplink().await;
+    radio.handle_timeout().await; // answer RX1 end
+    timer.fire_most_recent().await; // answer RX2 start
+    radio.handle_timeout().await; // answer RX2 end -> FCntUp consumed
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::RxComplete) => {}
+        _ => panic!("expected RxComplete, got {response:?}"),
+    }
+    assert_uplink(&tx1, 8, false, false, &[], Some(224), &[0x09, (x + 2) as u8, 0x00]);
+    // The retransmission resends the exact same frame (same FCntUp)
+    assert_eq!(tx1.data_mut(), tx2.data_mut());
+
+    // Step 12 (cont'd) / 13: the TCL sends a LinkADRReq with NbTrans = 1.
+    // The answer's RX windows above are kept silent, so the TCL delivers it
+    // in the next regular uplink's window (FCntUp = n + 9) instead.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn tcl_linkadr_req_nbtrans1(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        expect_uplink_fcnt(uplink, 9);
+        linkadr_req(buf, 1, 4)
+    }
+    radio.handle_rxtx(tcl_linkadr_req_nbtrans1).await;
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(4)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+
+    // Step 14: the next uplink (FCntUp = n + 10) carries the LinkADRAns
+    // ("uplink sent once", NbTrans = 1) and the TCL responds with
+    // CP-CMD TxFramesCtrlReq (frame type = Confirmed).
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn tcl_txframectrl_confirmed(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        expect_uplink_fcnt(uplink, 10);
+        build_downlink(buf, DataFrameType::UnconfirmedDown, true, 224, "0702", 5)
+    }
+    radio.handle_rxtx(tcl_txframectrl_confirmed).await;
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(5)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+    let uplink = radio.get_last_uplink().await;
+    assert_data_uplink(&uplink, 10, false, false, LINKADR_ANS);
+    // The session is now configured to send only confirmed frames
+    let session = device.mac.get_session().unwrap();
+    assert_eq!(session.override_confirmed, Some(true));
+
+    // Step 15: the DUT sends a confirmed frame (FCntUp = n + 11) although
+    // the application asked for unconfirmed; the TCL acknowledges it and
+    // responds (confirmed downlink) with a LinkADRReq, NbTrans = 3.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn tcl_linkadr_req_nbtrans3(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        expect_uplink_fcnt(uplink, 11);
+        let payload = format!("{LINKADR_REQ}03");
+        build_downlink(buf, DataFrameType::ConfirmedDown, true, 0, &payload, 6)
+    }
+    radio.handle_rxtx(tcl_linkadr_req_nbtrans3).await;
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(6)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+    let uplink = radio.get_last_uplink().await;
+    assert_data_uplink(&uplink, 11, true, false, &[]);
+
+    // Steps 16-18: the next confirmed uplink (FCntUp = n + 12) carries the
+    // LinkADRAns and, as it is never acknowledged, is sent three times
+    // (NbTrans = 3) with the same FCntUp.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    let mut transmissions = Vec::new();
+    for _ in 0..3 {
+        timer.fire_most_recent().await; // RX1 start
+        transmissions.push(radio.get_last_uplink().await);
+        radio.handle_timeout().await; // RX1 end
+        timer.fire_most_recent().await; // RX2 start
+        radio.handle_timeout().await; // RX2 end
+    }
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::NoAck) => {}
+        _ => panic!("expected NoAck after 3 unacknowledged confirmed uplinks, got {response:?}"),
+    }
+    for tx in &transmissions {
+        assert_data_uplink(tx, 12, true, true, LINKADR_ANS);
+    }
+    let bytes: Vec<Vec<u8>> = transmissions.iter_mut().map(|tx| tx.data_mut().to_vec()).collect();
+    assert_eq!(bytes[0], bytes[1]);
+    assert_eq!(bytes[1], bytes[2]);
+
+    // Step 19: the next uplink (FCntUp = n + 13) is still confirmed (the
+    // override is in effect until told otherwise); the TCL acknowledges the
+    // previous frame and responds with CP-CMD TxFramesCtrlReq (frame type =
+    // Unconfirmed) to revert.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn tcl_txframectrl_unconfirmed(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        expect_uplink_fcnt(uplink, 13);
+        build_downlink(buf, DataFrameType::UnconfirmedDown, true, 224, "0701", 7)
+    }
+    radio.handle_rxtx(tcl_txframectrl_unconfirmed).await;
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(7)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+    let uplink = radio.get_last_uplink().await;
+    assert_data_uplink(&uplink, 13, true, false, &[]);
+    let session = device.mac.get_session().unwrap();
+    assert_eq!(session.override_confirmed, Some(false));
+
+    // Step 20: the next uplink (FCntUp = n + 14) is unconfirmed again; the
+    // TCL responds with RxAppCntReq.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn tcl_rxappcnt_req_4(uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        expect_uplink_fcnt(uplink, 14);
+        rxappcnt_req(buf, 8)
+    }
+    radio.handle_rxtx(tcl_rxappcnt_req_4).await;
+
+    // Steps 21-23: the RxAppCntAns uplink (FCntUp = n + 15) reports the
+    // number of applicative downlinks the DUT has received: the three
+    // RxAppCntReqs, the two TxFramesCtrlReqs, plus the step-15 downlink,
+    // which carries no application data but acknowledges the previous
+    // confirmed uplink (an empty downlink frame with the ACK bit set is an
+    // applicative downlink per the certification spec), i.e. x + 6.
+    // No Ack bit: the step-19 TxFramesCtrlReq downlink is unconfirmed, so
+    // there is no confirmed downlink left to acknowledge. The answer is a
+    // regular uplink: it opens its own RX windows and, as it receives no
+    // downlink, is sent three times (NbTrans = 3) with the same FCntUp.
+    // (fire_when_armed(35): the armed count is monotonic, so this only
+    // blocks on the first iteration, for the first answer RX1 start.)
+    let mut transmissions = Vec::new();
+    for _ in 0..3 {
+        timer.fire_when_armed(35).await; // answer RX1 start
+        transmissions.push(radio.get_last_uplink().await);
+        radio.handle_timeout().await; // answer RX1 end
+        timer.fire_most_recent().await; // answer RX2 start
+        radio.handle_timeout().await; // answer RX2 end
+    }
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::RxComplete) => {}
+        _ => panic!("expected RxComplete, got {response:?}"),
+    }
+    for tx in &transmissions {
+        assert_uplink(tx, 15, false, false, &[], Some(224), &[0x09, (x + 6) as u8, 0x00]);
+    }
+
+    // Step 23 (cont'd) / 24: the TCL sends a LinkADRReq with NbTrans = 0,
+    // which means the default of 1 transmission. The answer's RX windows
+    // above are kept silent, so the TCL delivers it in the next regular
+    // uplink's window (FCntUp = n + 16) instead.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn tcl_linkadr_req_nbtrans0(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        expect_uplink_fcnt(uplink, 16);
+        linkadr_req(buf, 0, 9)
+    }
+    radio.handle_rxtx(tcl_linkadr_req_nbtrans0).await;
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(9)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+
+    // Step 24: the uplink carrying the LinkADRAns (FCntUp = n + 17) is sent
+    // only once.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    let tx = radio.get_last_uplink().await;
+    radio.handle_timeout().await; // RX1 end
+    timer.fire_most_recent().await; // RX2 start
+    radio.handle_timeout().await; // RX2 end
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::RxComplete) => {}
+        _ => panic!("expected RxComplete, got {response:?}"),
+    }
+    assert_data_uplink(&tx, 17, false, false, LINKADR_ANS);
+
+    // Step 25: DUT uplink (FCntUp = n + 18); the TCL responds with a
+    // LinkADRReq with NbTrans = 1.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn tcl_linkadr_req_nbtrans1_final(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        expect_uplink_fcnt(uplink, 18);
+        linkadr_req(buf, 1, 10)
+    }
+    radio.handle_rxtx(tcl_linkadr_req_nbtrans1_final).await;
+
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(10)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+
+    // Step 26: the uplink (FCntUp = n + 19) carries the LinkADRAns; the DUT
+    // has reverted to the default settings.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    let tx = radio.get_last_uplink().await;
+    radio.handle_timeout().await; // RX1 end
+    timer.fire_most_recent().await; // RX2 start
+    radio.handle_timeout().await; // RX2 end
+
+    let (device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::RxComplete) => {}
+        _ => panic!("expected RxComplete, got {response:?}"),
+    }
+    assert_data_uplink(&tx, 19, false, false, LINKADR_ANS);
+
+    // Final state: all 20 FCntUps (n .. n + 19) were consumed, the DUT
+    // received 7 applicative downlinks (six FPort > 0, plus the step-15
+    // downlink without application data carrying the ACK bit), the
+    // confirmed override is off and the LinkADR settings hold DR5 / maximum
+    // power / NbTrans = 1.
+    let session = device.mac.get_session().unwrap();
+    assert_eq!(session.fcnt_up, 20);
+    assert_eq!(session.rx_app_cnt, 7);
+    assert_eq!(session.override_confirmed, Some(false));
+    let config = &device.mac.configuration;
+    assert_eq!(config.data_rate, crate::region::DR::_5);
+    assert_eq!(config.tx_power, Some(16)); // EU868 maximum EIRP
+    assert_eq!(config.nb_trans, 1);
+}

--- a/lorawan-device/src/async_device/test/certification/mac_common.rs
+++ b/lorawan-device/src/async_device/test/certification/mac_common.rs
@@ -175,12 +175,24 @@ async fn rxtimingsetup_eu868() {
 
     timer.fire_most_recent().await;
     radio.handle_rxtx(fp_echopayloadreq).await;
+    // The EchoIncPayloadAns is a regular uplink: it opens its own RX
+    // windows.
+    timer.fire_when_armed(5).await; // answer RX1 start
+    radio.handle_timeout().await; // answer RX1 end
+    timer.fire_most_recent().await; // answer RX2 start
+    radio.handle_timeout().await; // answer RX2 end
     let (device, response) = task.await.unwrap();
 
     match response {
         Ok(SendResponse::RxComplete) => {}
         _ => panic!(),
     }
+
+    // The answer was transmitted inside the uplink's RX window
+    let mut uplink = radio.get_last_uplink().await;
+    let dl = decrypt_uplink(&mut uplink);
+    assert_eq!(dl.f_port(), Some(224));
+    assert_eq!(dl.frm_payload(), FrmPayload::Data(&[0x08, 0x02, 0x03, 0x04]));
 
     // Check that uplink has been cleared after receiving frame
     // Check whether uplink still contains required data
@@ -266,6 +278,12 @@ async fn eu868_linkcheckreq_test() {
     }
     timer.fire_most_recent().await;
     radio.handle_rxtx(fp_echopayloadreq).await;
+    // The EchoIncPayloadAns is a regular uplink: it opens its own RX
+    // windows.
+    timer.fire_when_armed(4).await; // answer RX1 start
+    radio.handle_timeout().await; // answer RX1 end
+    timer.fire_most_recent().await; // answer RX2 start
+    radio.handle_timeout().await; // answer RX2 end
     let (_device, response) = task.await.unwrap();
 
     match response {
@@ -424,6 +442,11 @@ async fn eu868_rxappcnt_test() {
         build_downlink(buf, 224, false, 7, &[0x09])
     }
     radio.handle_rxtx(dl_rxappcntreq).await;
+    // The answer is a regular uplink: it opens its own RX windows.
+    timer.fire_when_armed(8).await; // answer RX1 start
+    radio.handle_timeout().await; // answer RX1 end
+    timer.fire_most_recent().await; // answer RX2 start
+    radio.handle_timeout().await; // answer RX2 end
     let (device, response) = task.await.unwrap();
     match response {
         Ok(SendResponse::RxComplete) => {}

--- a/lorawan-device/src/async_device/test/certification/mac_common.rs
+++ b/lorawan-device/src/async_device/test/certification/mac_common.rs
@@ -5,6 +5,7 @@
 //! * DevStatusReq (2.5.1)
 //! * RXTimingSetupReq (2.5.5)
 //! * LinkCheckReq (2.5.7)
+//! * RxAppCnt (certification protocol)
 //!
 //! Region-specific tests (in separate files):
 //! * NewChannelReq (2.5.2)
@@ -19,10 +20,12 @@
 use super::util;
 use crate::async_device::SendResponse;
 use crate::radio::RfConfig;
-use crate::test_util::Uplink;
+use crate::test_util::{Uplink, get_crypto, get_dev_addr};
+use core::num::NonZeroU8;
 
+use lorawan::creator::{DataFrame, Payload};
 use lorawan::maccommands::parse_uplink_mac_commands;
-use lorawan::parser::FrmPayload;
+use lorawan::parser::{DataFrameType, FrmPayload};
 
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -277,4 +280,162 @@ async fn eu868_linkcheckreq_test() {
     let dl = decrypt_uplink(&mut uplink);
     assert_eq!(dl.f_port(), Some(224));
     assert_eq!(dl.frm_payload(), FrmPayload::Data(&[0x08, 0x02, 0x03, 0x04]));
+}
+
+#[tokio::test]
+/// RxAppCnt test (certification protocol): the DUT increments RxAppCnt for
+/// each applicative downlink, i.e. a frame with FPort > 0, plus an empty
+/// downlink frame with the FCtrl ACK bit set (whether or not it carries a
+/// FPort 0 MAC-command payload). Downlinks without application data and
+/// without the ACK bit are not counted. The final RxAppCntAns reports the
+/// number of counted downlinks, including the RxAppCntReq itself.
+async fn eu868_rxappcnt_test() {
+    let (radio, timer, mut device) =
+        util::session_with_region(crate::region::EU868::new_eu868().into());
+
+    /// Build a downlink of a given shape: `fport > 0` carries `data` on
+    /// that port; `fport == 0` is a FPort-0 frame with an empty
+    /// MAC-command payload; `fport == 0xFF` has neither a FPort nor a
+    /// FRMPayload.
+    fn build_downlink(buf: &mut [u8], fport: u8, ack: bool, fcnt: u16, data: &[u8]) -> usize {
+        let frame = DataFrame {
+            frame_type: DataFrameType::UnconfirmedDown,
+            dev_addr: get_dev_addr(),
+            ack,
+            fcnt: fcnt.into(),
+            payload: match fport {
+                0xFF => Payload::None,
+                0 => Payload::MacCommands(&[]),
+                p => Payload::Data { f_port: NonZeroU8::new(p).unwrap(), data },
+            },
+            ..Default::default()
+        };
+        frame.build_into(buf, &get_crypto(), Some(&get_crypto())).unwrap().len()
+    }
+
+    // Downlink 1: FPort 3 without the ACK bit: application data, counted.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn dl_fport3_noack(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_downlink(buf, 3, false, 1, &[1, 2, 3])
+    }
+    radio.handle_rxtx(dl_fport3_noack).await;
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(1)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+
+    // Downlink 2: FPort 3 with the ACK bit: application data, counted.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn dl_fport3_ack(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_downlink(buf, 3, true, 2, &[1, 2, 3])
+    }
+    radio.handle_rxtx(dl_fport3_ack).await;
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(2)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+
+    // Downlink 3: FPort 0, empty MAC-command payload, no ACK bit:
+    // not counted.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn dl_fport0_noack(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_downlink(buf, 0, false, 3, &[])
+    }
+    radio.handle_rxtx(dl_fport0_noack).await;
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(3)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+
+    // Downlink 4: FPort 0, empty MAC-command payload, ACK bit:
+    // counted as an applicative downlink.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn dl_fport0_ack(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_downlink(buf, 0, true, 4, &[])
+    }
+    radio.handle_rxtx(dl_fport0_ack).await;
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(4)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+
+    // Downlink 5: no FPort and no FRMPayload, no ACK bit: not counted.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn dl_bare_noack(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_downlink(buf, 0xFF, false, 5, &[])
+    }
+    radio.handle_rxtx(dl_bare_noack).await;
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(5)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+
+    // Downlink 6: no FPort and no FRMPayload, ACK bit: counted as an
+    // applicative downlink.
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn dl_bare_ack(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_downlink(buf, 0xFF, true, 6, &[])
+    }
+    radio.handle_rxtx(dl_bare_ack).await;
+    let (mut device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(6)) => {}
+        _ => panic!("expected DownlinkReceived, got {response:?}"),
+    }
+
+    // Downlink 7: CP-CMD RxAppCntReq (FPort 224): counted. The answer
+    // reports the number of counted downlinks so far, i.e. 5 (downlinks 1,
+    // 2, 4, 6 and 7).
+    let task = tokio::spawn(async move {
+        let response = device.send(&[1, 2, 3], 3, false).await;
+        (device, response)
+    });
+    timer.fire_most_recent().await; // RX1 start
+    fn dl_rxappcntreq(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_downlink(buf, 224, false, 7, &[0x09])
+    }
+    radio.handle_rxtx(dl_rxappcntreq).await;
+    let (device, response) = task.await.unwrap();
+    match response {
+        Ok(SendResponse::RxComplete) => {}
+        _ => panic!("expected RxComplete, got {response:?}"),
+    }
+
+    let mut uplink = radio.get_last_uplink().await;
+    let dl = decrypt_uplink(&mut uplink);
+    assert_eq!(dl.f_port(), Some(224));
+    assert_eq!(dl.frm_payload(), FrmPayload::Data(&[0x09, 0x05, 0x00]));
+
+    // Final state: 5 applicative downlinks were counted.
+    let session = device.mac.get_session().unwrap();
+    assert_eq!(session.rx_app_cnt, 5);
 }

--- a/lorawan-device/src/async_device/test/certification/mod.rs
+++ b/lorawan-device/src/async_device/test/certification/mod.rs
@@ -14,6 +14,7 @@ use tokio::sync::Mutex;
 mod mac_common;
 
 mod dlchannelreq_eu868;
+mod linkadrreq_eu868;
 mod mac_priority;
 mod newchannelreq_eu868;
 mod oversized_payload_eu868;

--- a/lorawan-device/src/async_device/test/certification/oversized_payload_eu868.rs
+++ b/lorawan-device/src/async_device/test/certification/oversized_payload_eu868.rs
@@ -27,9 +27,9 @@ async fn oversized_payload_sf12_bw_125_eu868() {
     });
 
     fn cfg_rx(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
-        // LinkADRReq: DR=0 (SF12BW125), MAX, 0700, 01
+        // LinkADRReq: DR=0 (SF12BW125), MAX, 0700, 02
         // RXParamSetupReq: Rx1DROffset=0, RX2DataRate=DR0 (SF12BW125), Frequency=869525000
-        build_mac(buf, "03000700010500d2ad84", 1)
+        build_mac(buf, "03000700020500d2ad84", 1)
     }
 
     timer.fire_most_recent().await;
@@ -66,8 +66,14 @@ async fn oversized_payload_sf12_bw_125_eu868() {
             2,
         )
     }
-    timer.fire_most_recent().await;
-    radio.handle_rxtx(oversized_payload).await;
+    // The LinkADRReq in step 1 set NbTrans to 2, so the oversized (invalid,
+    // therefore not acknowledging) downlink triggers a retransmission.
+    timer.fire_when_armed(2).await; // RX1 start, attempt 1
+    radio.handle_rxtx(oversized_payload).await; // oversized, dropped -> retransmit
+    timer.fire_when_armed(3).await; // RX1 start, attempt 2
+    radio.handle_timeout().await; // RX1 end
+    timer.fire_when_armed(4).await; // RX2 start
+    radio.handle_timeout().await; // RX2 end
 
     // We should skip this packet as it's oversized...
     let (mut device, response) = task.await.unwrap();
@@ -92,20 +98,26 @@ async fn oversized_payload_sf12_bw_125_eu868() {
     });
 
     // Skip RX1
-    timer.fire_most_recent().await;
-    radio.handle_timeout().await;
+    timer.fire_when_armed(5).await; // RX1 start, attempt 1
+    radio.handle_timeout().await; // RX1 end
 
     // Check that we are not using RX2 frequency
     let rx_conf = radio.get_rxconfig().await.unwrap();
     assert_ne!(rx_conf.rf.frequency, 869525000);
 
-    timer.fire_most_recent().await;
-    radio.handle_rxtx(oversized_payload).await;
+    timer.fire_when_armed(6).await; // RX2 start, attempt 1
+    radio.handle_rxtx(oversized_payload).await; // oversized, dropped -> retransmit
 
     let rx_conf = radio.get_rxconfig().await.unwrap();
     assert_eq!(rx_conf.rf.frequency, 869525000);
 
-    // RX2
+    // NbTrans is still 2, so the retransmission's windows time out and the
+    // FCntUp is consumed
+    timer.fire_when_armed(7).await; // RX1 start, attempt 2
+    radio.handle_timeout().await; // RX1 end
+    timer.fire_when_armed(8).await; // RX2 start
+    radio.handle_timeout().await; // RX2 end
+
     // We should skip this packet as it's oversized...
     let (_device, response) = task.await.unwrap();
     match response {

--- a/lorawan-device/src/async_device/test/mod.rs
+++ b/lorawan-device/src/async_device/test/mod.rs
@@ -201,6 +201,93 @@ async fn test_unconfirmed_uplink_no_downlink() {
 }
 
 #[tokio::test]
+async fn test_unconfirmed_uplink_retransmission() {
+    let (radio, timer, mut async_device) = setup_with_session();
+    async_device.mac.configuration.nb_trans = 2;
+
+    let async_device = tokio::spawn(async move {
+        let response = async_device.send(&[1, 2, 3], 3, false).await;
+        (async_device, response)
+    });
+
+    // First transmission: RX1 and RX2 both time out
+    timer.fire_when_armed(1).await; // RX1 start
+    let first = radio.get_last_uplink().await;
+    radio.handle_timeout().await; // RX1 end
+    timer.fire_when_armed(2).await; // RX2 start
+    radio.handle_timeout().await; // RX2 end -> retransmit
+
+    // Retransmission: RX1 and RX2 both time out
+    timer.fire_when_armed(3).await; // RX1 start
+    let second = radio.get_last_uplink().await;
+    radio.handle_timeout().await; // RX1 end
+    timer.fire_when_armed(4).await; // RX2 start
+    radio.handle_timeout().await; // RX2 end -> FCntUp consumed
+
+    let (mut device, response) = async_device.await.unwrap();
+    match response {
+        Ok(SendResponse::RxComplete) => (),
+        _ => panic!(),
+    }
+
+    // The retransmission resends the exact same frame (same FCntUp)
+    assert_eq!(first.data(), second.data());
+    // The FCntUp was consumed only once for the two attempts
+    assert_eq!(device.get_session().unwrap().fcnt_up, 1);
+}
+
+#[tokio::test]
+async fn test_unconfirmed_uplink_downlink_stops_retransmission() {
+    let (radio, timer, mut async_device) = setup_with_session();
+    async_device.mac.configuration.nb_trans = 3;
+
+    let async_device = tokio::spawn(async move {
+        let response = async_device.send(&[1, 2, 3], 3, false).await;
+        (async_device, response)
+    });
+
+    // First transmission: RX1 times out, a downlink arrives in RX2
+    timer.fire_when_armed(1).await; // RX1 start
+    radio.handle_timeout().await; // RX1 end
+    timer.fire_when_armed(2).await; // RX2 start
+    radio.handle_rxtx(handle_data_uplink_with_link_adr_req::<0, 0>).await;
+
+    let (mut device, response) = async_device.await.unwrap();
+    match response {
+        Ok(SendResponse::DownlinkReceived(_)) => (),
+        _ => panic!(),
+    }
+    // A single transmission was made
+    assert_eq!(device.get_session().unwrap().fcnt_up, 1);
+}
+
+#[tokio::test]
+async fn test_confirmed_uplink_no_ack_retransmission() {
+    let (radio, timer, mut async_device) = setup_with_session();
+    async_device.mac.configuration.nb_trans = 3;
+
+    let async_device = tokio::spawn(async move {
+        let response = async_device.send(&[1, 2, 3], 3, true).await;
+        (async_device, response)
+    });
+
+    for (rx1, rx2) in [(1, 2), (3, 4), (5, 6)] {
+        timer.fire_when_armed(rx1).await; // RX1 start
+        radio.handle_timeout().await; // RX1 end
+        timer.fire_when_armed(rx2).await; // RX2 start
+        radio.handle_timeout().await; // RX2 end
+    }
+
+    // No confirmation after all NbTrans attempts
+    let (mut device, response) = async_device.await.unwrap();
+    match response {
+        Ok(SendResponse::NoAck) => (),
+        _ => panic!(),
+    }
+    assert_eq!(device.get_session().unwrap().fcnt_up, 1);
+}
+
+#[tokio::test]
 async fn test_confirmed_uplink_no_ack() {
     let (radio, timer, mut async_device) = setup_with_session();
     let send_await_complete = Arc::new(Mutex::new(false));

--- a/lorawan-device/src/async_device/test/timer.rs
+++ b/lorawan-device/src/async_device/test/timer.rs
@@ -57,6 +57,17 @@ impl TimerChannel {
         tx.send(()).await.unwrap();
     }
 
+    /// Fire the most recent timer, first waiting until `count` timers have
+    /// been armed. Use this when the device arms the timer as a result of an
+    /// earlier test event (eg: a retransmission after an RX window) so the
+    /// test does not race the device task.
+    pub async fn fire_when_armed(&self, count: usize) {
+        while self.get_armed_count().await < count {
+            tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+        }
+        self.fire_most_recent().await;
+    }
+
     #[allow(unused)]
     pub async fn confirm_dropped_timer(&self, index: usize) {
         tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;

--- a/lorawan-device/src/mac/certification.rs
+++ b/lorawan-device/src/mac/certification.rs
@@ -1,5 +1,3 @@
-use crate::mac;
-use crate::radio::RadioBuffer;
 use lorawan::certification::parse_downlink_dut_commands;
 
 /// Certification protocol uses `fport = 224`
@@ -94,24 +92,8 @@ impl Certification {
         CERTIFICATION_PORT == fport
     }
 
-    pub(crate) fn setup_send<const N: usize>(
-        &mut self,
-        mut state: &mut mac::State,
-        buf: &mut RadioBuffer<N>,
-        configuration: &mac::Configuration,
-        region: &crate::region::Configuration,
-    ) -> mac::Result<mac::FcntUp> {
-        let send_data = mac::SendData {
-            fport: CERTIFICATION_PORT,
-            data: self.pending_uplink.as_ref().unwrap(),
-            confirmed: false,
-        };
-        match &mut state {
-            mac::State::Joined(session) => {
-                Ok(session.prepare_buffer::<N>(&send_data, buf, configuration, region))
-            }
-            mac::State::Otaa(_) => Err(mac::Error::NotJoined),
-            mac::State::Unjoined => Err(mac::Error::NotJoined),
-        }
+    /// Consume the pending certification uplink, if any.
+    pub(crate) fn take_pending_uplink(&mut self) -> Option<heapless::Vec<u8, 256>> {
+        self.pending_uplink.take()
     }
 }

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -86,6 +86,10 @@ pub struct Configuration {
     /// When true, uplinks set the FCtrl ADR bit so the network may manage
     /// data rate and TX power via LinkADRReq.
     pub(crate) adr_enabled: bool,
+    /// Number of transmissions of each uplink (LoRaWAN 1.0.4 NbTrans), set by
+    /// the network via LinkADRReq: 1..=15 transmissions per FCntUp. Defaults
+    /// to 1 (no retransmission).
+    pub(crate) nb_trans: u8,
 }
 
 pub(crate) struct Mac {
@@ -144,6 +148,7 @@ impl Mac {
                 rx2_frequency: None,
                 tx_power: None,
                 adr_enabled: true,
+                nb_trans: 1,
             },
             #[cfg(feature = "certification")]
             certification: certification::Certification::new(),
@@ -189,18 +194,45 @@ impl Mac {
     ) -> Result<(radio::TxConfig, RxWindows, FcntUp)> {
         let fcnt = match &mut self.state {
             State::Joined(session) => {
-                Ok(session.prepare_buffer::<N>(send_data, buf, &self.configuration, &self.region))
+                let fcnt =
+                    session.prepare_buffer::<N>(send_data, buf, &self.configuration, &self.region);
+                // Data uplinks participate in NbTrans retransmission; the other
+                // senders (multicast setup, certification) do not.
+                session.retransmissions = 1;
+                Ok(fcnt)
             }
             State::Otaa(_) => Err(Error::NotJoined),
             State::Unjoined => Err(Error::NotJoined),
         }?;
+        let (tx_config, rx_windows) = self.tx_config_and_windows(rng);
+        Ok((tx_config, rx_windows, fcnt))
+    }
+
+    /// Prepare the radio configuration and RX windows for a NbTrans
+    /// retransmission of the current uplink. The frame itself (and its
+    /// FCntUp) is unchanged; the region's normal channel selection is run
+    /// again so that retransmissions hop frequencies as usual.
+    pub(crate) fn retransmit_config<RNG: RngCore>(
+        &mut self,
+        rng: &mut RNG,
+    ) -> (radio::TxConfig, RxWindows) {
+        self.tx_config_and_windows(rng)
+    }
+
+    /// Channel selection, TX power, and RX windows for the next data
+    /// transmission, derived together so the windows match the channel
+    /// actually used.
+    fn tx_config_and_windows<RNG: RngCore>(
+        &mut self,
+        rng: &mut RNG,
+    ) -> (radio::TxConfig, RxWindows) {
         let (mut tx_config, tx_channel) =
             self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Data);
         tx_config.adjust_power(
             self.configuration.tx_power.unwrap_or(self.board_eirp.max_power),
             self.board_eirp.antenna_gain,
         );
-        Ok((tx_config, self.rx_windows(&tx_channel), fcnt))
+        (tx_config, self.rx_windows(&tx_channel))
     }
 
     pub(crate) fn add_uplink<M: SerializableMacCommand>(&mut self, cmd: M) -> Result<()> {
@@ -450,6 +482,9 @@ pub(crate) enum Response {
     JoinSuccess,
     NoUpdate,
     RxComplete,
+    /// Both RX windows expired without a downlink and NbTrans permits another
+    /// transmission of the same frame (same FCntUp).
+    Retransmit,
     LinkCheckReq,
     #[cfg(feature = "certification")]
     UplinkPrepared,
@@ -478,6 +513,8 @@ impl From<Response> for nb_device::Response {
             Response::JoinSuccess => nb_device::Response::JoinSuccess,
             Response::NoUpdate => nb_device::Response::NoUpdate,
             Response::RxComplete => nb_device::Response::RxComplete,
+            // Handled internally by the nb_device state machine.
+            Response::Retransmit => unimplemented!(),
             Response::LinkCheckReq => unimplemented!(),
             #[cfg(feature = "certification")]
             Response::UplinkPrepared => unimplemented!(),

--- a/lorawan-device/src/mac/mod.rs
+++ b/lorawan-device/src/mac/mod.rs
@@ -99,6 +99,11 @@ pub(crate) struct Mac {
     state: State,
     #[cfg(feature = "certification")]
     certification: certification::Certification,
+    /// Actual TX duration and RX windows of the prepared certification answer
+    /// uplink, stashed by the device after transmitting it, for the send loop
+    /// which runs its RX windows and any NbTrans retransmissions.
+    #[cfg(feature = "certification")]
+    pending_cert_rx: Option<(u32, RxWindows)>,
     #[cfg(feature = "multicast")]
     pub multicast: multicast::Multicast,
 }
@@ -152,6 +157,8 @@ impl Mac {
             },
             #[cfg(feature = "certification")]
             certification: certification::Certification::new(),
+            #[cfg(feature = "certification")]
+            pending_cert_rx: None,
             #[cfg(feature = "multicast")]
             multicast: multicast::Multicast::new(),
         }
@@ -196,8 +203,9 @@ impl Mac {
             State::Joined(session) => {
                 let fcnt =
                     session.prepare_buffer::<N>(send_data, buf, &self.configuration, &self.region);
-                // Data uplinks participate in NbTrans retransmission; the other
-                // senders (multicast setup, certification) do not.
+                // Uplinks prepared here (data uplinks and certification answers)
+                // participate in NbTrans retransmission; multicast setup uplinks
+                // do not.
                 session.retransmissions = 1;
                 Ok(fcnt)
             }
@@ -267,21 +275,35 @@ impl Mac {
         )
     }
 
+    /// Prepare the pending certification uplink for transmission. A certification answer is a
+    /// regular Class A uplink, so it is prepared exactly like a data uplink: NbTrans
+    /// retransmission is armed and the RX windows are derived from the selected channel.
+    /// Returns the TX configuration, the RX windows and the frame counter of the answer.
     #[cfg(feature = "certification")]
     pub(crate) fn certification_setup_send<RNG: RngCore, const N: usize>(
         &mut self,
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
-    ) -> Result<(radio::TxConfig, FcntUp)> {
-        self.certification
-            .setup_send::<N>(&mut self.state, buf, &self.configuration, &self.region)
-            .map(|fcnt_up| {
-                // No RX windows follow this uplink; the caller completes with rx2_complete().
-                let (mut tx_config, _) =
-                    self.region.create_tx_config(rng, self.configuration.data_rate, &Frame::Data);
-                tx_config.adjust_power(self.board_eirp.max_power, self.board_eirp.antenna_gain);
-                (tx_config, fcnt_up)
-            })
+    ) -> Result<(radio::TxConfig, RxWindows, FcntUp)> {
+        let data = self.certification.take_pending_uplink().unwrap();
+        let send_data =
+            SendData { fport: certification::CERTIFICATION_PORT, data: &data, confirmed: false };
+        self.send::<RNG, N>(rng, buf, &send_data)
+    }
+
+    /// Stash the actual TX duration and RX windows of the transmitted
+    /// certification answer; see [`take_pending_cert_rx`](Self::take_pending_cert_rx).
+    #[cfg(feature = "certification")]
+    pub(crate) fn set_pending_cert_rx(&mut self, tx_duration_ms: u32, rx_windows: RxWindows) {
+        self.pending_cert_rx = Some((tx_duration_ms, rx_windows));
+    }
+
+    /// Take the TX duration and RX windows stashed by
+    /// [`set_pending_cert_rx`](Self::set_pending_cert_rx). Only valid immediately
+    /// after an `UplinkPrepared` response.
+    #[cfg(feature = "certification")]
+    pub(crate) fn take_pending_cert_rx(&mut self) -> (u32, RxWindows) {
+        self.pending_cert_rx.take().unwrap()
     }
 
     pub(crate) fn get_rx_delay(&self, frame: &Frame, window: &Window) -> u32 {

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -44,6 +44,10 @@ pub struct Session {
     fcnt_down: Option<u32>,
     /// Uplinks since the last accepted downlink; used for ADRACKReq / ADR backoff.
     pub(crate) adr_ack_cnt: u32,
+    /// Transmissions already made at the current FCntUp. Set by `Mac::send`
+    /// and consumed by `rx2_complete` to implement NbTrans retransmission.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub(crate) retransmissions: u8,
     #[cfg(feature = "certification")]
     /// Whether to override confirmation bit for sent frames
     pub override_confirmed: Option<bool>,
@@ -88,6 +92,7 @@ impl Session {
             fcnt_down: None,
             fcnt_up: 0,
             adr_ack_cnt: 0,
+            retransmissions: 0,
             uplink: uplink::Uplink::default(),
 
             #[cfg(feature = "certification")]
@@ -214,8 +219,10 @@ impl Session {
                     // if the FCnt is used up, the session has expired
                     Response::SessionExpired
                 } else {
-                    // we can always increment fcnt_up when we receive a downlink
+                    // we can always increment fcnt_up when we receive a downlink;
+                    // the accepted downlink also ends any retransmission cycle
                     self.fcnt_up += 1;
+                    self.retransmissions = 0;
                     if let (Some(fport), FrmPayload::Data(data)) =
                         (decrypted.f_port(), decrypted.frm_payload())
                     {
@@ -273,11 +280,22 @@ impl Session {
         configuration: &mut super::Configuration,
         region: &region::Configuration,
     ) -> Response {
-        // Until we handle NbTrans, there is no case where we should not increment FCntUp.
-        if self.fcnt_up == 0xFFFF_FFFF {
-            // if the FCnt is used up, the session has expired
-            return Response::SessionExpired;
+        // With NbTrans > 1, a missed downlink does not consume the FCntUp: the
+        // same frame is retransmitted (same FCntUp) until NbTrans is reached
+        // or a downlink is accepted. A used-up FCntUp can never be
+        // retransmitted, so the session expires.
+        let retransmit = self.retransmissions > 0
+            && self.fcnt_up != 0xFFFF_FFFF
+            && self.retransmissions < configuration.nb_trans;
+
+        if retransmit {
+            self.retransmissions += 1;
         } else {
+            self.retransmissions = 0;
+            if self.fcnt_up == 0xFFFF_FFFF {
+                // if the FCnt is used up, the session has expired
+                return Response::SessionExpired;
+            }
             self.fcnt_up += 1;
         }
 
@@ -295,7 +313,9 @@ impl Session {
             }
         }
 
-        if self.confirmed {
+        if retransmit {
+            Response::Retransmit
+        } else if self.confirmed {
             Response::NoAck
         } else {
             Response::RxComplete
@@ -586,7 +606,7 @@ fn next_fcnt_down(last: Option<u32>, wire: u16) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::next_fcnt_down;
-    use super::{SendData, Session};
+    use super::{Response, SendData, Session};
     use crate::mac::Mac;
     use crate::radio::RadioBuffer;
     use crate::region;
@@ -595,6 +615,7 @@ mod tests {
     use lorawan::maccommandcreator::LinkADRAnsCreator;
     use lorawan::parser::{DecryptedDataPayload, DevAddr, EncryptedDataPayload, FrmPayload};
     use lorawan::types::DR;
+    use rand_core::RngCore;
 
     fn uplink_fctrl(session: &mut Session, mac: &Mac) -> lorawan::parser::FCtrl {
         let mut tx: RadioBuffer<256> = RadioBuffer::new();
@@ -662,6 +683,152 @@ mod tests {
         let fctrl = uplink_fctrl(&mut session, &mac);
         assert!(fctrl.adr());
         assert!(!fctrl.adr_ack_req());
+    }
+
+    /// A deterministic RNG returning consecutive u32 values so tests can
+    /// rely on distinct channel-selection draws.
+    struct SeqRng(u32);
+
+    impl RngCore for SeqRng {
+        fn next_u32(&mut self) -> u32 {
+            let v = self.0;
+            self.0 = self.0.wrapping_add(1);
+            v
+        }
+        fn next_u64(&mut self) -> u64 {
+            let v = self.0 as u64;
+            self.0 = self.0.wrapping_add(1);
+            v
+        }
+        fn fill_bytes(&mut self, bytes: &mut [u8]) {
+            for b in bytes.iter_mut() {
+                *b = (self.0 & 0xFF) as u8;
+                self.0 = self.0.wrapping_add(1);
+            }
+        }
+        fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> Result<(), rand_core::Error> {
+            self.fill_bytes(bytes);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn retransmission_reselects_channel() {
+        let mut mac = eu868_mac();
+        mac.set_session(session());
+        let mut rng = SeqRng(0);
+        let mut tx: RadioBuffer<256> = RadioBuffer::new();
+
+        let (first, first_windows, _) = mac
+            .send::<SeqRng, 256>(
+                &mut rng,
+                &mut tx,
+                &SendData { data: &[1, 2, 3], fport: 1, confirmed: false },
+            )
+            .unwrap();
+        let (second, second_windows) = mac.retransmit_config::<SeqRng>(&mut rng);
+
+        // Each attempt goes through the normal channel selection, so the
+        // retransmission hops to another channel at the same data rate, and
+        // its RX1 window follows the new channel
+        assert_ne!(first.rf.frequency, second.rf.frequency);
+        assert_eq!(first.rf.bb, second.rf.bb);
+        assert_ne!(first_windows.rx1.frequency, second_windows.rx1.frequency);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn session_serde_roundtrip_and_missing_retransmissions() {
+        let session = session();
+        let json = serde_json::to_string(&session).unwrap();
+        let back: Session = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.fcnt_up, session.fcnt_up);
+
+        // Sessions serialized before retransmissions existed still
+        // deserialize, defaulting to no retransmission in flight.
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        value.as_object_mut().unwrap().remove("retransmissions");
+        let back: Session = serde_json::from_value(value).unwrap();
+        assert_eq!(back.retransmissions, 0);
+    }
+
+    #[test]
+    fn rx2_complete_without_retransmission_consumes_fcnt() {
+        let mut mac = eu868_mac();
+        let mut session = session();
+        session.retransmissions = 1;
+
+        let response = session.rx2_complete(&mut mac.configuration, &mac.region);
+        assert!(matches!(response, Response::RxComplete));
+        assert_eq!(session.fcnt_up, 1);
+        assert_eq!(session.retransmissions, 0);
+    }
+
+    #[test]
+    fn rx2_complete_retransmits_up_to_nb_trans() {
+        let mut mac = eu868_mac();
+        mac.configuration.nb_trans = 3;
+        let mut session = session();
+        session.retransmissions = 1;
+
+        let response = session.rx2_complete(&mut mac.configuration, &mac.region);
+        assert!(matches!(response, Response::Retransmit));
+        assert_eq!(session.fcnt_up, 0);
+        assert_eq!(session.retransmissions, 2);
+
+        let response = session.rx2_complete(&mut mac.configuration, &mac.region);
+        assert!(matches!(response, Response::Retransmit));
+        assert_eq!(session.retransmissions, 3);
+
+        // Third transmission done: the FCntUp is consumed.
+        let response = session.rx2_complete(&mut mac.configuration, &mac.region);
+        assert!(matches!(response, Response::RxComplete));
+        assert_eq!(session.fcnt_up, 1);
+        assert_eq!(session.retransmissions, 0);
+    }
+
+    #[test]
+    fn rx2_complete_retransmits_up_to_high_nb_trans() {
+        let mut mac = eu868_mac();
+        mac.configuration.nb_trans = 15;
+        let mut session = session();
+        session.retransmissions = 1;
+
+        for expected in 2..=15 {
+            let response = session.rx2_complete(&mut mac.configuration, &mac.region);
+            assert!(matches!(response, Response::Retransmit));
+            assert_eq!(session.retransmissions, expected);
+            assert_eq!(session.fcnt_up, 0);
+        }
+        // 15th transmission done: the FCntUp is consumed
+        let response = session.rx2_complete(&mut mac.configuration, &mac.region);
+        assert!(matches!(response, Response::RxComplete));
+        assert_eq!(session.fcnt_up, 1);
+    }
+
+    #[test]
+    fn rx2_complete_exhausted_fcnt_expires_instead_of_retransmitting() {
+        let mut mac = eu868_mac();
+        mac.configuration.nb_trans = 4;
+        let mut session = session();
+        session.fcnt_up = 0xFFFF_FFFF;
+        session.retransmissions = 1;
+
+        let response = session.rx2_complete(&mut mac.configuration, &mac.region);
+        assert!(matches!(response, Response::SessionExpired));
+    }
+
+    #[test]
+    fn rx2_complete_without_uplink_in_flight_consumes_fcnt() {
+        // retransmissions == 0 (join, multicast setup, certification): the
+        // FCntUp is consumed even when NbTrans > 1.
+        let mut mac = eu868_mac();
+        mac.configuration.nb_trans = 4;
+        let mut session = session();
+
+        let response = session.rx2_complete(&mut mac.configuration, &mac.region);
+        assert!(matches!(response, Response::RxComplete));
+        assert_eq!(session.fcnt_up, 1);
     }
 
     /// FPort 0 sends the queued MAC commands as the FRMPayload (encrypted

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -163,10 +163,19 @@ impl Session {
             }
 
             #[cfg(feature = "certification")]
-            if let Some(port) = encrypted_data.f_port()
-                && port > 0
             {
-                self.rx_app_cnt += 1;
+                // RxAppCnt counts applicative downlinks:
+                // - frames with FPort > 0
+                // - empty frames (no FPort, or FPort 0) with the FCtrl ACK bit set,
+                //   which the certification spec considers an applicative downlink
+                let ack = encrypted_data.fhdr().fctrl().ack();
+                let is_app_downlink = match encrypted_data.f_port() {
+                    Some(port) => port > 0 || (port == 0 && ack),
+                    None => ack,
+                };
+                if is_app_downlink {
+                    self.rx_app_cnt += 1;
+                }
             }
             #[cfg(feature = "multicast")]
             if let Some(port) = encrypted_data.f_port()
@@ -229,7 +238,7 @@ impl Session {
                         #[cfg(feature = "certification")]
                         if certification.fport(fport) {
                             use crate::mac::certification::Response::*;
-                            match certification.handle_message(data, fcnt as u16) {
+                            match certification.handle_message(data, self.rx_app_cnt) {
                                 AdrBitChange(adr) => {
                                     configuration.adr_enabled = adr;
                                 }

--- a/lorawan-device/src/mac/session.rs
+++ b/lorawan-device/src/mac/session.rs
@@ -471,12 +471,16 @@ impl Session {
                         DR::_15 => Some(configuration.tx_power),
                         p => region.check_tx_power(p as u8),
                     };
+                    // Handle NbTrans: a redundancy nibble of 0 means the
+                    // default of 1 transmission; 1..=15 is the number of
+                    // transmissions as-is.
+                    let nb_trans = payload.redundancy().number_of_transmissions().max(1);
 
                     let cm_ack = region.channel_mask_validate(&channel_mask, dr);
                     if cm_ack && let (Some(dr), Some(pw)) = (dr, pw) {
-                        // TODO: handle nbtrans
                         configuration.data_rate = dr;
                         configuration.tx_power = pw;
+                        configuration.nb_trans = nb_trans;
                         region.channel_mask_set(channel_mask.clone());
                     }
                     // Add matching number of LinkADRAns responses
@@ -608,12 +612,17 @@ mod tests {
     use super::next_fcnt_down;
     use super::{Response, SendData, Session};
     use crate::mac::Mac;
-    use crate::radio::RadioBuffer;
+    use crate::radio::{RadioBuffer, RfConfig};
     use crate::region;
-    use crate::{AppSKey, NwkSKey};
+    use crate::{AppSKey, Downlink, NwkSKey};
+    use core::num::NonZeroU8;
+    use lora_modulation::BaseBandModulationParams;
+    use lorawan::creator::{DataFrame, Payload};
     use lorawan::default_crypto::DefaultCrypto;
     use lorawan::maccommandcreator::LinkADRAnsCreator;
-    use lorawan::parser::{DecryptedDataPayload, DevAddr, EncryptedDataPayload, FrmPayload};
+    use lorawan::parser::{
+        DataFrameType, DecryptedDataPayload, DevAddr, EncryptedDataPayload, FrmPayload,
+    };
     use lorawan::types::DR;
     use rand_core::RngCore;
 
@@ -634,6 +643,65 @@ mod tests {
 
     fn session() -> Session {
         Session::new(NwkSKey::from([2; 16]), AppSKey::from([1; 16]), DevAddr::from_value(1))
+    }
+
+    /// Feed an encrypted downlink with the given FOpts (and a data payload on
+    /// port 1) into a Mac with the standard test session, returning the
+    /// Mac's response.
+    fn handle_downlink_with_fopts(mac: &mut Mac, f_opts: &[u8]) -> Response {
+        let mut rx: RadioBuffer<256> = RadioBuffer::new();
+        let mut buf = [0u8; 256];
+        let nwk_crypto = DefaultCrypto::new(NwkSKey::from([2; 16]).inner());
+        let app_crypto = DefaultCrypto::new(AppSKey::from([1; 16]).inner());
+        let frame = DataFrame {
+            frame_type: DataFrameType::UnconfirmedDown,
+            dev_addr: DevAddr::from_value(1),
+            fcnt: 0,
+            f_opts,
+            payload: Payload::Data { f_port: NonZeroU8::new(1).unwrap(), data: &[3, 2, 1] },
+            ..Default::default()
+        };
+        let packet = frame.build_into(&mut buf, &nwk_crypto, Some(&app_crypto)).unwrap();
+        rx.extend_from_slice(packet).unwrap();
+
+        let dr = mac.region.get_datarate(5).unwrap();
+        let rf_config = RfConfig {
+            frequency: 868_100_000,
+            bb: BaseBandModulationParams::new(
+                dr.spreading_factor,
+                dr.bandwidth,
+                mac.region.get_coding_rate(),
+            ),
+            max_payload_len: 255,
+        };
+        let mut dl: heapless::Vec<Downlink, 1> = heapless::Vec::new();
+        mac.handle_rx::<256, 1>(&mut rx, &mut dl, 10, &rf_config)
+    }
+
+    #[test]
+    fn link_adr_req_sets_nb_trans() {
+        let mut mac = eu868_mac();
+        mac.set_session(session());
+        // LinkADRReq: DR 5, TxPower 0, CMControl 5 (per-bank) with bank 0
+        // enabled, NbTrans 2 (=> 2 transmissions)
+        let f_opts = [0x03, 0x50, 0x01, 0x00, 0x52];
+
+        let response = handle_downlink_with_fopts(&mut mac, &f_opts);
+        assert!(matches!(response, Response::DownlinkReceived(0)));
+        assert_eq!(mac.configuration.nb_trans, 2);
+    }
+
+    #[test]
+    fn link_adr_req_zero_nb_trans_restores_default() {
+        let mut mac = eu868_mac();
+        mac.set_session(session());
+        mac.configuration.nb_trans = 3;
+        // Same command as above but with NbTrans 0: use the default of 1
+        let f_opts = [0x03, 0x50, 0x01, 0x00, 0x50];
+
+        let response = handle_downlink_with_fopts(&mut mac, &f_opts);
+        assert!(matches!(response, Response::DownlinkReceived(0)));
+        assert_eq!(mac.configuration.nb_trans, 1);
     }
 
     #[test]

--- a/lorawan-device/src/nb_device/mod.rs
+++ b/lorawan-device/src/nb_device/mod.rs
@@ -35,6 +35,7 @@ where
                 radio,
                 rng,
                 tx_buffer: RadioBuffer::new(),
+                retransmit_buffer: RadioBuffer::new(),
                 mac: Mac::new(region, R::MAX_RADIO_POWER, R::ANTENNA_GAIN),
                 downlink: Vec::new(),
             },
@@ -112,6 +113,7 @@ where
             &mut self.shared.radio,
             &mut self.shared.rng,
             &mut self.shared.tx_buffer,
+            &mut self.shared.retransmit_buffer,
             &mut self.shared.downlink,
             event,
         );
@@ -124,6 +126,10 @@ pub(crate) struct Shared<R: PhyRxTx + Timings, RNG: RngCore, const N: usize, con
     pub(crate) radio: R,
     pub(crate) rng: RNG,
     pub(crate) tx_buffer: RadioBuffer<N>,
+    /// Copy of the frame built for the current uplink, retained so that NbTrans
+    /// retransmissions can resend the exact same bytes (same FCntUp, ADRACKReq
+    /// bit and MAC commands) after the radio buffer is reused for reception.
+    pub(crate) retransmit_buffer: RadioBuffer<N>,
     pub(crate) mac: Mac,
     pub(crate) downlink: Vec<Downlink, D>,
 }

--- a/lorawan-device/src/nb_device/state.rs
+++ b/lorawan-device/src/nb_device/state.rs
@@ -102,6 +102,7 @@ impl<R: radio::PhyRxTx> From<Error> for super::Error<R> {
 }
 
 impl State {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn handle_event<
         R: radio::PhyRxTx + Timings,
         RNG: RngCore,
@@ -113,14 +114,19 @@ impl State {
         radio: &mut R,
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
+        retransmit_buf: &mut RadioBuffer<N>,
         dl: &mut Vec<Downlink, D>,
         event: Event<'_, R>,
     ) -> (Self, Result<Response, super::Error<R>>) {
         match self {
-            State::Idle(s) => s.handle_event::<R, RNG, N>(mac, radio, rng, buf, event),
+            State::Idle(s) => {
+                s.handle_event::<R, RNG, N>(mac, radio, rng, buf, retransmit_buf, event)
+            }
             State::SendingData(s) => s.handle_event::<R, N>(mac, radio, event),
             State::WaitingForRxWindow(s) => s.handle_event::<R, N>(mac, radio, event),
-            State::WaitingForRx(s) => s.handle_event::<R, N, D>(mac, radio, buf, event, dl),
+            State::WaitingForRx(s) => {
+                s.handle_event::<R, RNG, N, D>(mac, radio, rng, buf, retransmit_buf, event, dl)
+            }
         }
     }
 }
@@ -135,6 +141,7 @@ impl Idle {
         radio: &mut R,
         rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
+        retransmit_buf: &mut RadioBuffer<N>,
         event: Event<'_, R>,
     ) -> (State, Result<Response, super::Error<R>>) {
         enum IntermediateResponse<R: radio::PhyRxTx> {
@@ -162,6 +169,11 @@ impl Idle {
                 match tx_config {
                     Err(e) => IntermediateResponse::EarlyReturn(Err(e.into())),
                     Ok((tx_config, rx_windows, fcnt_up)) => {
+                        // Retain a copy of the built frame for NbTrans
+                        // retransmissions; the radio buffer is reused for
+                        // received packets.
+                        retransmit_buf.clear();
+                        retransmit_buf.extend_from_slice(buf.as_ref_for_read()).unwrap();
                         IntermediateResponse::RadioTx((Frame::Data, tx_config, rx_windows, fcnt_up))
                     }
                 }
@@ -317,11 +329,19 @@ pub struct WaitingForRx {
 }
 
 impl WaitingForRx {
-    pub(crate) fn handle_event<R: radio::PhyRxTx + Timings, const N: usize, const D: usize>(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn handle_event<
+        R: radio::PhyRxTx + Timings,
+        RNG: RngCore,
+        const N: usize,
+        const D: usize,
+    >(
         self,
         mac: &mut Mac,
         radio: &mut R,
+        rng: &mut RNG,
         buf: &mut RadioBuffer<N>,
+        retransmit_buf: &mut RadioBuffer<N>,
         event: Event<'_, R>,
         dl: &mut Vec<Downlink, D>,
     ) -> (State, Result<Response, super::Error<R>>) {
@@ -342,14 +362,9 @@ impl WaitingForRx {
                                     Err(Error::BufferTooSmall.into()),
                                 );
                             }
-                            match mac.handle_rx::<N, D>(buf, dl, quality.snr(), &self.rf_config) {
-                                // NoUpdate can occur when a stray radio packet is received. Maintain state
-                                mac::Response::NoUpdate => {
-                                    (State::WaitingForRx(self), Ok(Response::NoUpdate))
-                                }
-                                // Any other type of update indicates we are done receiving. Change to Idle
-                                r => (State::Idle(Idle), Ok(r.into())),
-                            }
+                            let response =
+                                mac.handle_rx::<N, D>(buf, dl, quality.snr(), &self.rf_config);
+                            self.complete_or_retransmit(response, mac, radio, rng, retransmit_buf)
                         }
                         _ => (State::WaitingForRx(self), Ok(Response::NoUpdate)),
                     },
@@ -376,10 +391,11 @@ impl WaitingForRx {
                             Ok(Response::TimeoutRequest(t2)),
                         )
                     }
-                    // Timeout during second RxWindow leads to giving up
+                    // Timeout during second RxWindow: give up, or retransmit
+                    // the frame while NbTrans allows it
                     Rx::_2(_) => {
                         let response = mac.rx2_complete();
-                        (State::Idle(Idle), Ok(response.into()))
+                        self.complete_or_retransmit(response, mac, radio, rng, retransmit_buf)
                     }
                 }
             }
@@ -389,6 +405,42 @@ impl WaitingForRx {
             Event::SendDataRequest(_) => {
                 (State::WaitingForRx(self), Err(Error::SendDataWhileWaitingForRx.into()))
             }
+        }
+    }
+
+    /// Handle the outcome of a completed RX window (or an early exit, eg: an
+    /// oversized downlink): if the MAC wants to retransmit the current frame
+    /// (NbTrans), re-arm the radio with the retained copy; otherwise complete
+    /// the uplink cycle.
+    fn complete_or_retransmit<R: radio::PhyRxTx + Timings, RNG: RngCore, const N: usize>(
+        self,
+        response: mac::Response,
+        mac: &mut Mac,
+        radio: &mut R,
+        rng: &mut RNG,
+        retransmit_buf: &mut RadioBuffer<N>,
+    ) -> (State, Result<Response, super::Error<R>>) {
+        match response {
+            mac::Response::Retransmit => {
+                // Re-run the normal channel selection so retransmissions hop
+                // frequencies as usual; the frame itself (and its FCntUp) is
+                // unchanged.
+                let (tx, rx_windows) = mac.retransmit_config::<RNG>(rng);
+                let event = radio::Event::TxRequest(tx, retransmit_buf.as_ref_for_read());
+                match radio.handle_event(event) {
+                    Ok(radio::Response::Txing) => (
+                        State::SendingData(SendingData { frame: self.frame, rx_windows }),
+                        Ok(Response::UplinkSending(mac.get_fcnt_up().unwrap())),
+                    ),
+                    Ok(radio::Response::TxDone(ms)) => {
+                        data_rxwindow1_timeout::<R, N>(self.frame, rx_windows, mac, radio, ms)
+                    }
+                    _ => (State::WaitingForRx(self), Err(Error::UnexpectedRadioResponse.into())),
+                }
+            }
+            // Any other type of update indicates we are done receiving.
+            // Change to Idle
+            r => (State::Idle(Idle), Ok(r.into())),
         }
     }
 }

--- a/lorawan-device/src/nb_device/state.rs
+++ b/lorawan-device/src/nb_device/state.rs
@@ -364,6 +364,18 @@ impl WaitingForRx {
                             }
                             let response =
                                 mac.handle_rx::<N, D>(buf, dl, quality.snr(), &self.rf_config);
+                            #[cfg(feature = "certification")]
+                            if let mac::Response::UplinkPrepared = response {
+                                // Transmit the certification answer in place,
+                                // like a regular uplink.
+                                return self.answer_certification_uplink(
+                                    buf,
+                                    mac,
+                                    radio,
+                                    rng,
+                                    retransmit_buf,
+                                );
+                            }
                             self.complete_or_retransmit(response, mac, radio, rng, retransmit_buf)
                         }
                         _ => (State::WaitingForRx(self), Ok(Response::NoUpdate)),
@@ -441,6 +453,39 @@ impl WaitingForRx {
             // Any other type of update indicates we are done receiving.
             // Change to Idle
             r => (State::Idle(Idle), Ok(r.into())),
+        }
+    }
+
+    /// Handle a certification request received in an RX window: the answer is a regular
+    /// uplink, so prepare it exactly like a data uplink (arming NbTrans retransmission)
+    /// and transmit it in place; it opens its own RX windows.
+    #[cfg(feature = "certification")]
+    fn answer_certification_uplink<R: radio::PhyRxTx + Timings, RNG: RngCore, const N: usize>(
+        self,
+        buf: &mut RadioBuffer<N>,
+        mac: &mut Mac,
+        radio: &mut R,
+        rng: &mut RNG,
+        retransmit_buf: &mut RadioBuffer<N>,
+    ) -> (State, Result<Response, super::Error<R>>) {
+        let (tx, rx_windows) = match mac.certification_setup_send::<RNG, N>(rng, buf) {
+            Ok((tx, rx_windows, _)) => (tx, rx_windows),
+            Err(e) => return (State::WaitingForRx(self), Err(e.into())),
+        };
+        // Retain the answer so it can be retransmitted per NbTrans (the radio
+        // buffer is reused for reception).
+        retransmit_buf.clear();
+        retransmit_buf.extend_from_slice(buf.as_ref_for_read()).unwrap();
+        let event = radio::Event::TxRequest(tx, retransmit_buf.as_ref_for_read());
+        match radio.handle_event(event) {
+            Ok(radio::Response::Txing) => (
+                State::SendingData(SendingData { frame: self.frame, rx_windows }),
+                Ok(Response::UplinkSending(mac.get_fcnt_up().unwrap())),
+            ),
+            Ok(radio::Response::TxDone(ms)) => {
+                data_rxwindow1_timeout::<R, N>(self.frame, rx_windows, mac, radio, ms)
+            }
+            _ => (State::WaitingForRx(self), Err(Error::UnexpectedRadioResponse.into())),
         }
     }
 }

--- a/lorawan-device/src/nb_device/test/linkadrreq_eu868.rs
+++ b/lorawan-device/src/nb_device/test/linkadrreq_eu868.rs
@@ -1,0 +1,453 @@
+//! LoRaWAN 1.0.4 Certification testcases
+//! Based on LoRaWAN 1.0.4 End Device Certification Test Specification v1.6.4
+//!
+//! EU868 LinkADRReq tests
+
+use super::util::TestRadio;
+use crate::nb_device::radio::Event as RadioEvent;
+use crate::nb_device::{Device, Event, Response};
+use crate::radio::RfConfig;
+use crate::region::{Configuration, Region};
+use crate::test_util::{RxTxHandler, Uplink, get_abp_credentials, get_crypto, get_dev_addr};
+use core::num::NonZeroU8;
+use lorawan::creator::{DataFrame, Payload};
+use lorawan::parser::{self, DataFrameType, DecryptedDataPayload, FrmPayload, PhyPayload};
+
+type TestDevice = Device<TestRadio, rand::rngs::OsRng, 255>;
+
+/// New EU868 device with the shared test ABP credentials.
+fn eu868_device() -> TestDevice {
+    let mut device =
+        Device::new(Configuration::new(Region::EU868), TestRadio::default(), rand::rngs::OsRng);
+    device.join(get_abp_credentials()).unwrap();
+    device
+}
+
+/// Build a downlink frame. `fport = 0` puts the payload in FRMPayload as MAC
+/// commands; any other value is an FPort data payload. A confirmed
+/// `frame_type` acknowledges the previous confirmed uplink.
+fn build_downlink(
+    buf: &mut [u8],
+    frame_type: DataFrameType,
+    ack: bool,
+    fport: u8,
+    payload_hex: &str,
+    fcnt: u16,
+) -> usize {
+    let payload = hex::decode(payload_hex).unwrap();
+    let frame = DataFrame {
+        frame_type,
+        dev_addr: get_dev_addr(),
+        ack,
+        fcnt: fcnt.into(),
+        payload: match fport {
+            0 => Payload::MacCommands(&payload),
+            p => Payload::Data { f_port: NonZeroU8::new(p).unwrap(), data: &payload },
+        },
+        ..Default::default()
+    };
+    let finished = frame.build_into(buf, &get_crypto(), Some(&get_crypto())).unwrap();
+    finished.len()
+}
+
+/// TCL helper: sanity-check the FCntUp of the uplink the downlink answers.
+fn expect_uplink_fcnt(uplink: Option<Uplink>, fcnt: u32) {
+    let Some(mut uplink) = uplink else {
+        panic!("expected an uplink");
+    };
+    match parser::parse(uplink.data_mut()) {
+        Ok(PhyPayload::Data(data)) => {
+            assert_eq!(data.fhdr().fcnt() as u32, fcnt, "answered the wrong uplink");
+        }
+        _ => panic!("expected a data uplink"),
+    }
+}
+
+/// Parses the uplink, checks the MIC, and decrypts it in place, allowing
+/// access to payload contents
+fn decrypt_uplink(uplink: &mut Uplink) -> DecryptedDataPayload<'_> {
+    let bytes = uplink.data_mut();
+    let fcnt = match parser::parse(&*bytes) {
+        Ok(PhyPayload::Data(data)) => {
+            let fcnt = data.fhdr().fcnt() as u32;
+            assert!(data.validate_mic(&get_crypto(), fcnt));
+            fcnt
+        }
+        _ => panic!("expected a data frame"),
+    };
+    DecryptedDataPayload::decrypt_in_place(bytes, Some(&get_crypto()), Some(&get_crypto()), fcnt)
+        .unwrap()
+}
+
+/// DUT helper: parse, MIC-check and decrypt an uplink, then verify its
+/// header fields and (decrypted) FRMPayload.
+fn assert_uplink(
+    uplink: &Uplink,
+    fcnt: u32,
+    confirmed: bool,
+    ack: bool,
+    fopts: &[u8],
+    fport: Option<u8>,
+    payload: &[u8],
+) {
+    let mut uplink = uplink.clone();
+    let dl = decrypt_uplink(&mut uplink);
+    assert_eq!(dl.fhdr().fcnt() as u32, fcnt, "FCntUp");
+    assert_eq!(dl.is_confirmed(), confirmed, "frame type");
+    assert_eq!(dl.fhdr().fctrl().ack(), ack, "ACK bit");
+    assert_eq!(dl.fhdr().f_opts(), fopts, "FOpts");
+    assert_eq!(dl.f_port(), fport, "FPort");
+    match (dl.frm_payload(), payload) {
+        (FrmPayload::Data(data), _) => assert_eq!(data, payload, "FRMPayload"),
+        (FrmPayload::MacCommands(data), _) => assert_eq!(data, payload, "FRMPayload"),
+        (FrmPayload::None, _) => assert!(payload.is_empty(), "expected no FRMPayload"),
+    }
+}
+
+/// Check an uplink is a plain application data frame on port 3.
+fn assert_data_uplink(uplink: &Uplink, fcnt: u32, confirmed: bool, ack: bool, fopts: &[u8]) {
+    assert_uplink(uplink, fcnt, confirmed, ack, fopts, Some(3), &[1, 2, 3]);
+}
+
+/// Fire the RX1/RX2 window timeouts of the current transmission and return
+/// the response to the last timeout (RX2 end): a completion response
+/// (RxComplete, NoAck, ...), or a TimeoutRequest when the frame is
+/// retransmitted.
+fn expire_rx_windows(device: &mut TestDevice) -> Response {
+    let mut response = device.handle_event(Event::TimeoutFired).unwrap();
+    for _ in 0..3 {
+        if !matches!(response, Response::TimeoutRequest(_)) {
+            return response;
+        }
+        response = device.handle_event(Event::TimeoutFired).unwrap();
+    }
+    response
+}
+
+/// Fire the RX1 start timeout, then deliver a downlink in RX1 via the
+/// handler; returns the response to the downlink.
+fn deliver_downlink_rx1(device: &mut TestDevice, handler: RxTxHandler) -> Response {
+    let _ = device.handle_event(Event::TimeoutFired).unwrap();
+    device.get_radio().set_rxtx_handler(handler);
+    device.handle_event(Event::RadioEvent(RadioEvent::Phy(()))).unwrap()
+}
+
+/// Fire timeouts until RX2 is active, then deliver a downlink in RX2 via the
+/// handler; returns the response to the downlink.
+fn deliver_downlink_rx2(device: &mut TestDevice, handler: RxTxHandler) -> Response {
+    let _ = device.handle_event(Event::TimeoutFired).unwrap();
+    let _ = device.handle_event(Event::TimeoutFired).unwrap();
+    let _ = device.handle_event(Event::TimeoutFired).unwrap();
+    device.get_radio().set_rxtx_handler(handler);
+    device.handle_event(Event::RadioEvent(RadioEvent::Phy(()))).unwrap()
+}
+
+#[test]
+/// EU868 LinkADRReq Redundancy test
+///
+/// This test validates the DUT's correct implementation of the NbTrans
+/// setting within the LinkADRReq command.
+///
+/// Like a regular uplink, a certification answer (FPort 224) opens its own
+/// RX windows and is retransmitted per NbTrans. One deviation from the
+/// paper procedure: the paper test sends some TCL downlinks in the answer's
+/// own RX windows; here those windows are kept silent and the downlinks are
+/// delivered in the next regular uplink's window instead.
+fn eu868_linkadrreq_redundancy() {
+    let mut device = eu868_device();
+
+    // LinkADRReq used throughout: CID 0x03, DRTP 0x50 (DataRate = DR5 =
+    // Max125kHzDR, TXPower = 0 = maximum), ChMask [0x07, 0x00] (ChMaskCntl =
+    // 0 with only the default channels 0..2 enabled), Redundancy byte whose
+    // lower nibble is NbTrans (ChMaskCntl lives in the upper nibble in this
+    // implementation).
+    const LINKADR_REQ: &str = "03500700";
+    const LINKADR_ANS: &[u8] = &[0x03, 0x07]; // all three ACK bits set
+
+    /// LinkADRReq with the given NbTrans (0 = default of 1 transmission).
+    fn linkadr_req(buf: &mut [u8], nb_trans: u8, fcnt: u16) -> usize {
+        let payload = format!("{LINKADR_REQ}{nb_trans:02x}");
+        build_downlink(buf, DataFrameType::UnconfirmedDown, false, 0, &payload, fcnt)
+    }
+
+    /// CP-CMD RxAppCntReq (FPort 224, payload 0x09).
+    fn rxappcnt_req(buf: &mut [u8], fcnt: u16) -> usize {
+        build_downlink(buf, DataFrameType::UnconfirmedDown, false, 224, "09", fcnt)
+    }
+
+    // Step 1: DUT sends an unconfirmed frame (FCntUp = 0); the TCL responds
+    // on RX1 with CP-CMD RxAppCntReq. The answer (FCntUp = 1) opens its own
+    // RX windows.
+    let response = device.send(&[1, 2, 3], 3, false).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    fn tcl_rxappcnt_req_1(uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        expect_uplink_fcnt(uplink, 0);
+        rxappcnt_req(buf, 0)
+    }
+    let response = deliver_downlink_rx1(&mut device, tcl_rxappcnt_req_1);
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let response = expire_rx_windows(&mut device);
+    assert!(matches!(response, Response::RxComplete));
+    let uplink = device.get_radio().take_last_uplink().unwrap();
+    assert_uplink(&uplink, 1, false, false, &[], Some(224), &[0x09, 0x01, 0x00]);
+
+    let x: u16 = 1;
+
+    // Step 3: DUT sends an unconfirmed frame (FCntUp = 2); the TCL responds
+    // with MAC-CMD LinkADRReq, NbTrans = 2.
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    fn tcl_linkadr_req_nbtrans2(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        expect_uplink_fcnt(uplink, 2);
+        linkadr_req(buf, 2, 1)
+    }
+    let response = deliver_downlink_rx1(&mut device, tcl_linkadr_req_nbtrans2);
+    assert!(matches!(response, Response::DownlinkReceived(1)));
+    // The next uplink must carry LinkADRAns (all settings valid)
+    let session = device.shared.mac.get_session().unwrap();
+    assert_eq!(session.uplink.mac_commands(), LINKADR_ANS);
+
+    // Steps 4-5: the uplink (FCntUp = 3) carries the LinkADRAns and, as it
+    // receives no downlink, is retransmitted once (NbTrans = 2) with the
+    // same FCntUp.
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    let tx1 = device.get_radio().take_last_uplink().unwrap();
+    let response = expire_rx_windows(&mut device); // RX2 end -> retransmit
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let tx2 = device.get_radio().take_last_uplink().unwrap();
+    let response = expire_rx_windows(&mut device); // FCntUp consumed
+    assert!(matches!(response, Response::RxComplete));
+    assert_data_uplink(&tx1, 3, false, false, LINKADR_ANS);
+    // The retransmission resends the exact same frame (same FCntUp)
+    assert_eq!(tx1.data(), tx2.data());
+
+    // Steps 6-7: next uplink (FCntUp = 4) is also sent twice (NbTrans = 2 is
+    // still in effect).
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    let tx1 = device.get_radio().take_last_uplink().unwrap();
+    let response = expire_rx_windows(&mut device); // -> retransmit
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let tx2 = device.get_radio().take_last_uplink().unwrap();
+    let response = expire_rx_windows(&mut device); // -> FCntUp consumed
+    assert!(matches!(response, Response::RxComplete));
+    assert_data_uplink(&tx1, 4, false, false, &[]);
+    assert_eq!(tx1.data(), tx2.data());
+
+    // Step 8: DUT uplink (FCntUp = 5); the TCL responds with RxAppCntReq on
+    // the RX1 window. Step 9: the RxAppCntAns uplink (FCntUp = 6) reports
+    // RxAppCnt = x + 1; it is retransmitted once (NbTrans = 2).
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    fn tcl_rxappcnt_req_rx1(uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        expect_uplink_fcnt(uplink, 5);
+        rxappcnt_req(buf, 2)
+    }
+    let response = deliver_downlink_rx1(&mut device, tcl_rxappcnt_req_rx1);
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let tx1 = device.get_radio().take_last_uplink().unwrap();
+    let response = expire_rx_windows(&mut device); // -> retransmit
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let tx2 = device.get_radio().take_last_uplink().unwrap();
+    let response = expire_rx_windows(&mut device); // -> FCntUp consumed
+    assert!(matches!(response, Response::RxComplete));
+    assert_uplink(&tx1, 6, false, false, &[], Some(224), &[0x09, (x + 1) as u8, 0x00]);
+    assert_eq!(tx1.data(), tx2.data());
+
+    // Step 11: DUT uplink (FCntUp = 7); the TCL responds with RxAppCntReq on
+    // the RX2 window. Step 12: the RxAppCntAns uplink (FCntUp = 8) reports
+    // RxAppCnt = x + 2; it is retransmitted once (NbTrans = 2).
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    fn tcl_rxappcnt_req_rx2(uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        expect_uplink_fcnt(uplink, 7);
+        rxappcnt_req(buf, 3)
+    }
+    let response = deliver_downlink_rx2(&mut device, tcl_rxappcnt_req_rx2);
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let tx1 = device.get_radio().take_last_uplink().unwrap();
+    let response = expire_rx_windows(&mut device); // -> retransmit
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let tx2 = device.get_radio().take_last_uplink().unwrap();
+    let response = expire_rx_windows(&mut device); // -> FCntUp consumed
+    assert!(matches!(response, Response::RxComplete));
+    assert_uplink(&tx1, 8, false, false, &[], Some(224), &[0x09, (x + 2) as u8, 0x00]);
+    assert_eq!(tx1.data(), tx2.data());
+
+    // Step 12 (cont'd) / 13: the TCL sends a LinkADRReq with NbTrans = 1.
+    // The answer's RX windows above are kept silent, so the TCL delivers it
+    // in the next regular uplink's window (FCntUp = 9) instead.
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    fn tcl_linkadr_req_nbtrans1(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        expect_uplink_fcnt(uplink, 9);
+        linkadr_req(buf, 1, 4)
+    }
+    let response = deliver_downlink_rx1(&mut device, tcl_linkadr_req_nbtrans1);
+    assert!(matches!(response, Response::DownlinkReceived(4)));
+
+    // Step 14: the next uplink (FCntUp = 10) carries the LinkADRAns ("uplink
+    // sent once", NbTrans = 1) and the TCL responds with CP-CMD
+    // TxFramesCtrlReq (frame type = Confirmed).
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    fn tcl_txframectrl_confirmed(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        let uplink = uplink.expect("expected an uplink");
+        assert_data_uplink(&uplink, 10, false, false, LINKADR_ANS);
+        build_downlink(buf, DataFrameType::UnconfirmedDown, true, 224, "0702", 5)
+    }
+    let response = deliver_downlink_rx1(&mut device, tcl_txframectrl_confirmed);
+    assert!(matches!(response, Response::DownlinkReceived(5)));
+    // The session is now configured to send only confirmed frames
+    let session = device.shared.mac.get_session().unwrap();
+    assert_eq!(session.override_confirmed, Some(true));
+
+    // Step 15: the DUT sends a confirmed frame (FCntUp = 11) although the
+    // application asked for unconfirmed; the TCL acknowledges it and responds
+    // (confirmed downlink) with a LinkADRReq, NbTrans = 3.
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    fn tcl_linkadr_req_nbtrans3(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        let uplink = uplink.expect("expected an uplink");
+        assert_data_uplink(&uplink, 11, true, false, &[]);
+        let payload = format!("{LINKADR_REQ}03");
+        build_downlink(buf, DataFrameType::ConfirmedDown, true, 0, &payload, 6)
+    }
+    let response = deliver_downlink_rx1(&mut device, tcl_linkadr_req_nbtrans3);
+    assert!(matches!(response, Response::DownlinkReceived(6)));
+
+    // Steps 16-18: the next confirmed uplink (FCntUp = 12) carries the
+    // LinkADRAns and, as it is never acknowledged, is sent three times
+    // (NbTrans = 3) with the same FCntUp.
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    let mut transmissions = vec![device.get_radio().take_last_uplink().unwrap()];
+    let response = expire_rx_windows(&mut device); // -> retransmit
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    transmissions.push(device.get_radio().take_last_uplink().unwrap());
+    let response = expire_rx_windows(&mut device); // -> retransmit
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    transmissions.push(device.get_radio().take_last_uplink().unwrap());
+    let response = expire_rx_windows(&mut device); // -> FCntUp consumed
+    assert!(matches!(response, Response::NoAck));
+    for tx in &transmissions {
+        assert_data_uplink(tx, 12, true, true, LINKADR_ANS);
+    }
+    let bytes: Vec<Vec<u8>> = transmissions.iter().map(|tx| tx.data().to_vec()).collect();
+    assert_eq!(bytes[0], bytes[1]);
+    assert_eq!(bytes[1], bytes[2]);
+
+    // Step 19: the next uplink (FCntUp = 13) is still confirmed (the override
+    // is in effect until told otherwise); the TCL acknowledges the previous
+    // frame and responds with CP-CMD TxFramesCtrlReq (frame type =
+    // Unconfirmed) to revert.
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    fn tcl_txframectrl_unconfirmed(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        let uplink = uplink.expect("expected an uplink");
+        assert_data_uplink(&uplink, 13, true, false, &[]);
+        build_downlink(buf, DataFrameType::UnconfirmedDown, true, 224, "0701", 7)
+    }
+    let response = deliver_downlink_rx1(&mut device, tcl_txframectrl_unconfirmed);
+    assert!(matches!(response, Response::DownlinkReceived(7)));
+    let session = device.shared.mac.get_session().unwrap();
+    assert_eq!(session.override_confirmed, Some(false));
+
+    // Step 20: the next uplink (FCntUp = 14) is unconfirmed again; the TCL
+    // responds with RxAppCntReq. Steps 21-23: the RxAppCntAns uplink
+    // (FCntUp = 15) reports the number of applicative downlinks the DUT has
+    // received: the three RxAppCntReqs, the two TxFramesCtrlReqs, plus the
+    // step-15 downlink, which carries no application data but acknowledges
+    // the previous confirmed uplink (an empty downlink frame with the ACK
+    // bit set is an applicative downlink per the certification spec), i.e.
+    // x + 6. The answer is sent three times (NbTrans = 3) with the same
+    // FCntUp.
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    fn tcl_rxappcnt_req_4(uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        expect_uplink_fcnt(uplink, 14);
+        rxappcnt_req(buf, 8)
+    }
+    let response = deliver_downlink_rx1(&mut device, tcl_rxappcnt_req_4);
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let mut transmissions = vec![device.get_radio().take_last_uplink().unwrap()];
+    let response = expire_rx_windows(&mut device); // -> retransmit
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    transmissions.push(device.get_radio().take_last_uplink().unwrap());
+    let response = expire_rx_windows(&mut device); // -> retransmit
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    transmissions.push(device.get_radio().take_last_uplink().unwrap());
+    let response = expire_rx_windows(&mut device); // -> FCntUp consumed
+    assert!(matches!(response, Response::RxComplete));
+    for tx in &transmissions {
+        assert_uplink(tx, 15, false, false, &[], Some(224), &[0x09, (x + 6) as u8, 0x00]);
+    }
+
+    // Step 23 (cont'd) / 24: the TCL sends a LinkADRReq with NbTrans = 0,
+    // which means the default of 1 transmission, in the next regular
+    // uplink's window (FCntUp = 16).
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    fn tcl_linkadr_req_nbtrans0(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        expect_uplink_fcnt(uplink, 16);
+        linkadr_req(buf, 0, 9)
+    }
+    let response = deliver_downlink_rx1(&mut device, tcl_linkadr_req_nbtrans0);
+    assert!(matches!(response, Response::DownlinkReceived(9)));
+
+    // Step 24: the uplink carrying the LinkADRAns (FCntUp = 17) is sent only
+    // once.
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    let tx = device.get_radio().take_last_uplink().unwrap();
+    let response = expire_rx_windows(&mut device);
+    assert!(matches!(response, Response::RxComplete));
+    assert_data_uplink(&tx, 17, false, false, LINKADR_ANS);
+
+    // Step 25: DUT uplink (FCntUp = 18); the TCL responds with a LinkADRReq
+    // with NbTrans = 1.
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    fn tcl_linkadr_req_nbtrans1_final(
+        uplink: Option<Uplink>,
+        _config: RfConfig,
+        buf: &mut [u8],
+    ) -> usize {
+        expect_uplink_fcnt(uplink, 18);
+        linkadr_req(buf, 1, 10)
+    }
+    let response = deliver_downlink_rx1(&mut device, tcl_linkadr_req_nbtrans1_final);
+    assert!(matches!(response, Response::DownlinkReceived(10)));
+
+    // Step 26: the uplink (FCntUp = 19) carries the LinkADRAns; the DUT has
+    // reverted to the default settings.
+    device.send(&[1, 2, 3], 3, false).unwrap();
+    let tx = device.get_radio().take_last_uplink().unwrap();
+    let response = expire_rx_windows(&mut device);
+    assert!(matches!(response, Response::RxComplete));
+    assert_data_uplink(&tx, 19, false, false, LINKADR_ANS);
+
+    // Final state: all 20 FCntUps (0 .. 19) were consumed, the DUT received
+    // 7 applicative downlinks (six FPort > 0, plus the step-15 downlink
+    // without application data carrying the ACK bit), the confirmed override
+    // is off and the LinkADR settings hold DR5 / maximum power / NbTrans = 1.
+    let session = device.shared.mac.get_session().unwrap();
+    assert_eq!(session.fcnt_up, 20);
+    assert_eq!(session.rx_app_cnt, 7);
+    assert_eq!(session.override_confirmed, Some(false));
+    let config = &device.shared.mac.configuration;
+    assert_eq!(config.data_rate, crate::region::DR::_5);
+    assert_eq!(config.tx_power, Some(16)); // EU868 maximum EIRP
+    assert_eq!(config.nb_trans, 1);
+}

--- a/lorawan-device/src/nb_device/test/mod.rs
+++ b/lorawan-device/src/nb_device/test/mod.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(feature = "certification")]
+mod linkadrreq_eu868;
 mod util;
 use crate::test_util::*;
 use util::*;

--- a/lorawan-device/src/nb_device/test/mod.rs
+++ b/lorawan-device/src/nb_device/test/mod.rs
@@ -55,6 +55,90 @@ fn test_unconfirmed_uplink_no_downlink() {
     assert!(matches!(response, Response::RxComplete));
 }
 #[test]
+fn test_unconfirmed_uplink_retransmission() {
+    let mut device = test_device();
+    device.join(get_abp_credentials()).unwrap();
+    device.shared.mac.configuration.nb_trans = 2;
+    let response = device.send(&[0; 1], 1, false).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let first = device.get_radio().take_last_uplink().unwrap();
+
+    // RX windows of the first transmission time out
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx1
+    assert!(matches!(response, Response::TimeoutRequest(2000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx2
+    assert!(matches!(response, Response::TimeoutRequest(2100)));
+    // End Rx2: NbTrans allows another transmission, so the radio is re-armed
+    let response = device.handle_event(Event::TimeoutFired).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+
+    // The retransmission resends the exact same frame (same FCntUp)
+    let second = device.get_radio().take_last_uplink().unwrap();
+    assert_eq!(first.data(), second.data());
+
+    // RX windows of the retransmission time out; the FCntUp is consumed
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx1
+    assert!(matches!(response, Response::TimeoutRequest(2000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx2
+    assert!(matches!(response, Response::TimeoutRequest(2100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx2
+    assert!(matches!(response, Response::RxComplete));
+    assert_eq!(device.get_fcnt_up(), Some(1));
+}
+
+#[test]
+fn test_unconfirmed_uplink_downlink_stops_retransmission() {
+    let mut device = test_device();
+    device.join(get_abp_credentials()).unwrap();
+    device.shared.mac.configuration.nb_trans = 4;
+    let response = device.send(&[0; 1], 1, false).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx1
+    assert!(matches!(response, Response::TimeoutRequest(2000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx2
+    assert!(matches!(response, Response::TimeoutRequest(2100)));
+    device.get_radio().set_rxtx_handler(handle_data_uplink_with_link_adr_req::<0, 0>);
+    // A downlink in RX2 acknowledges the uplink: no retransmission
+    let response = device.handle_event(Event::RadioEvent(radio::Event::Phy(()))).unwrap();
+    assert!(matches!(response, Response::DownlinkReceived(0)));
+    assert_eq!(device.get_fcnt_up(), Some(1));
+}
+
+#[test]
+fn test_confirmed_uplink_no_ack_retransmission() {
+    let mut device = test_device();
+    device.join(get_abp_credentials()).unwrap();
+    device.shared.mac.configuration.nb_trans = 2;
+    let response = device.send(&[0; 1], 1, true).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let _first = device.get_radio().take_last_uplink().unwrap();
+    for attempt in 0..2 {
+        let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+        assert!(matches!(response, Response::TimeoutRequest(1100)));
+        let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx1
+        assert!(matches!(response, Response::TimeoutRequest(2000)));
+        let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx2
+        assert!(matches!(response, Response::TimeoutRequest(2100)));
+        let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx2
+        if attempt == 0 {
+            // NbTrans allows one more transmission
+            assert!(matches!(response, Response::TimeoutRequest(1000)));
+            let _second = device.get_radio().take_last_uplink().unwrap();
+        } else {
+            // No confirmation after all NbTrans attempts
+            assert!(matches!(response, Response::NoAck));
+        }
+    }
+    assert_eq!(device.get_fcnt_up(), Some(1));
+}
+
+#[test]
 fn test_confirmed_uplink_no_ack() {
     let mut device = test_device();
     let response = device.join(get_abp_credentials());

--- a/lorawan-device/src/nb_device/test/mod.rs
+++ b/lorawan-device/src/nb_device/test/mod.rs
@@ -4,6 +4,26 @@ use crate::test_util::*;
 use util::*;
 
 use crate::nb_device::Event;
+use crate::radio::RfConfig;
+use core::num::NonZeroU8;
+use lorawan::creator::{DataFrame, Payload};
+use lorawan::parser::{self, DataFrameType, DecryptedDataPayload, PhyPayload};
+
+/// Build an FPort 224 certification downlink with the given payload bytes.
+#[cfg(feature = "certification")]
+fn build_cert_downlink(buf: &mut [u8], payload_in_hex: &str, fcnt: u16) -> usize {
+    let payload = hex::decode(payload_in_hex).unwrap();
+    let frame = DataFrame {
+        frame_type: DataFrameType::UnconfirmedDown,
+        dev_addr: get_dev_addr(),
+        ack: true,
+        fcnt: fcnt.into(),
+        payload: Payload::Data { f_port: NonZeroU8::new(224).unwrap(), data: &payload },
+        ..Default::default()
+    };
+    let finished = frame.build_into(buf, &get_crypto(), Some(&get_crypto())).unwrap();
+    finished.len()
+}
 #[test]
 fn test_join_rx1() {
     let mut device = test_device();
@@ -187,6 +207,117 @@ fn test_confirmed_uplink_with_ack_rx2() {
     // send a radio event to let the radio device indicate a packet was received
     let response = device.handle_event(Event::RadioEvent(radio::Event::Phy(()))).unwrap();
     assert!(matches!(response, Response::DownlinkReceived(0)));
+}
+
+#[cfg(feature = "certification")]
+#[test]
+fn test_certification_answer_uplink() {
+    // An RxAppCntReq received in an RX window is answered with a regular
+    // uplink: it opens its own RX windows.
+    fn fp_rxappcnt_req(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_cert_downlink(buf, "09", 1) // RxAppCntReq
+    }
+
+    let mut device = test_device();
+    device.join(get_abp_credentials()).unwrap();
+    let response = device.send(&[0; 1], 1, false).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx1
+    assert!(matches!(response, Response::TimeoutRequest(2000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx2
+    assert!(matches!(response, Response::TimeoutRequest(2100)));
+    device.get_radio().set_rxtx_handler(fp_rxappcnt_req);
+    // The RxAppCntReq is answered in place; the answer opens its own RX1
+    let response = device.handle_event(Event::RadioEvent(radio::Event::Phy(()))).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+
+    // The answer is a data frame on FPort 224 carrying the RxAppCntAns;
+    // the request downlink itself is counted, so the answer reports 1
+    let mut answer = device.get_radio().take_last_uplink().unwrap();
+    let uplink = match parser::parse(answer.data_mut()) {
+        Ok(PhyPayload::Data(data)) => {
+            let fcnt = data.fhdr().fcnt() as u32;
+            assert!(data.validate_mic(&get_crypto(), fcnt));
+            DecryptedDataPayload::decrypt_in_place(
+                answer.data_mut(),
+                Some(&get_crypto()),
+                Some(&get_crypto()),
+                fcnt,
+            )
+            .unwrap()
+        }
+        _ => panic!("expected a data frame"),
+    };
+    // The user uplink was FCntUp 0; the accepted downlink incremented the
+    // counter, so the answer is FCntUp 1
+    assert_eq!(uplink.fhdr().fcnt(), 1);
+    assert_eq!(uplink.f_port(), Some(224));
+    assert_eq!(uplink.frm_payload(), lorawan::parser::FrmPayload::Data(&[0x09, 0x01, 0x00]));
+
+    // The answer's RX windows time out; the uplink cycle completes
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin answer Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end answer Rx1
+    assert!(matches!(response, Response::TimeoutRequest(2000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin answer Rx2
+    assert!(matches!(response, Response::TimeoutRequest(2100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end answer Rx2
+    assert!(matches!(response, Response::RxComplete));
+    assert_eq!(device.get_fcnt_up(), Some(2));
+}
+
+#[cfg(feature = "certification")]
+#[test]
+fn test_certification_answer_retransmission() {
+    // A certification answer is retransmitted per NbTrans when its own RX
+    // windows time out without a downlink.
+    fn fp_rxappcnt_req(_uplink: Option<Uplink>, _config: RfConfig, buf: &mut [u8]) -> usize {
+        build_cert_downlink(buf, "09", 1) // RxAppCntReq
+    }
+
+    let mut device = test_device();
+    device.join(get_abp_credentials()).unwrap();
+    device.shared.mac.configuration.nb_trans = 2;
+    let response = device.send(&[0; 1], 1, false).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx1
+    assert!(matches!(response, Response::TimeoutRequest(2000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx2
+    assert!(matches!(response, Response::TimeoutRequest(2100)));
+    device.get_radio().set_rxtx_handler(fp_rxappcnt_req);
+    // The RxAppCntReq is answered in place; the answer opens its own RX1
+    let response = device.handle_event(Event::RadioEvent(radio::Event::Phy(()))).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let first = device.get_radio().take_last_uplink().unwrap();
+
+    // The answer's RX windows time out; NbTrans allows one more transmission
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin answer Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end answer Rx1
+    assert!(matches!(response, Response::TimeoutRequest(2000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin answer Rx2
+    assert!(matches!(response, Response::TimeoutRequest(2100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end answer Rx2
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+
+    // The retransmission resends the exact same answer frame (same FCntUp)
+    let second = device.get_radio().take_last_uplink().unwrap();
+    assert_eq!(first.data(), second.data());
+
+    // No downlink after all NbTrans attempts: the uplink cycle completes
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin answer Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end answer Rx1
+    assert!(matches!(response, Response::TimeoutRequest(2000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin answer Rx2
+    assert!(matches!(response, Response::TimeoutRequest(2100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end answer Rx2
+    assert!(matches!(response, Response::RxComplete));
+    assert_eq!(device.get_fcnt_up(), Some(2));
 }
 
 #[test]

--- a/lorawan-device/src/nb_device/test/util.rs
+++ b/lorawan-device/src/nb_device/test/util.rs
@@ -25,6 +25,11 @@ impl TestRadio {
     pub fn set_rxtx_handler(&mut self, handler: RxTxHandler) {
         self.rxtx_handler = Some(handler);
     }
+
+    /// Take the most recently transmitted uplink, if any.
+    pub fn take_last_uplink(&mut self) -> Option<Uplink> {
+        self.last_uplink.take()
+    }
 }
 
 impl Default for TestRadio {

--- a/lorawan-device/src/test_util.rs
+++ b/lorawan-device/src/test_util.rs
@@ -43,6 +43,11 @@ impl Uplink {
     pub fn data_mut(&mut self) -> &mut [u8] {
         &mut self.data
     }
+
+    /// The raw frame bytes.
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
 }
 
 /// Test functions shared by async_device and no_async_device tests


### PR DESCRIPTION
Tested against LCTT for EU868 and US915 using virtual-lorawan-device.

Now `TP_A_EU868_ED_MAC_104_BV_012_A.Redundancy` and `TP_A_US915_ED_MAC_104_BV_012_A.Redundancy` tests pass.

